### PR TITLE
feat: CODEF 금융기관 계정 연동 기능 구현 (Asset 도메인)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ REDIS_PORT=6379
 # 외부 API 키 (담당자가 발급 후 채울 것)
 CODEF_CLIENT_ID=
 CODEF_CLIENT_SECRET=
+CODEF_PUBLIC_KEY=
+CODEF_OAUTH_DOMAIN=https://oauth.codef.io
+CODEF_API_DOMAIN=https://development.codef.io
+# Connected ID AES-256 암호화 키 (openssl rand -base64 32 로 생성)
+CODEF_ENCRYPT_KEY=
 KAKAO_REST_API_KEY=
 MOLIT_SERVICE_KEY=
 POLICY_API_KEY=

--- a/src/main/java/com/team/independence/asset/controller/AssetController.java
+++ b/src/main/java/com/team/independence/asset/controller/AssetController.java
@@ -1,0 +1,23 @@
+package com.team.independence.asset.controller;
+
+import com.team.independence.asset.dto.AssetLinkRequest;
+import com.team.independence.asset.dto.AssetLinkResponse;
+import com.team.independence.asset.service.AssetService;
+import com.team.independence.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/assets")
+@RequiredArgsConstructor
+public class AssetController {
+
+    private final AssetService assetService;
+
+    @PostMapping("/link")
+    public ApiResponse<AssetLinkResponse> linkAccount(
+            @RequestParam Long memberId,
+            @RequestBody AssetLinkRequest request) {
+        return ApiResponse.ok(assetService.linkAccount(memberId, request));
+    }
+}

--- a/src/main/java/com/team/independence/asset/domain/ConnectedAccount.java
+++ b/src/main/java/com/team/independence/asset/domain/ConnectedAccount.java
@@ -1,0 +1,21 @@
+package com.team.independence.asset.domain;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConnectedAccount {
+    private Long id;
+    private Long memberId;
+    private String connectedId;  // AES 암호화된 Connected ID
+    private String connectedStatus;  // ACTIVE / EXPIRED / REVOKED
+    private LocalDateTime lastSyncedAt;
+    private String syncStatus;  // SUCCESS / FAILED / IN_PROGRESS
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/team/independence/asset/domain/ConnectedInstitution.java
+++ b/src/main/java/com/team/independence/asset/domain/ConnectedInstitution.java
@@ -1,0 +1,23 @@
+package com.team.independence.asset.domain;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConnectedInstitution {
+    private Long id;
+    private Long connectedAccountId;
+    private String institutionCode;  // institution.code FK (= CODEF organization 코드)
+    private String status;  // ACTIVE / AUTH_EXPIRED / ERROR
+    private LocalDateTime lastSyncedAt;
+    private String lastErrorCode;
+    private String lastErrorMessage;
+    private LocalDateTime lastAttemptedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/team/independence/asset/dto/AssetLinkRequest.java
+++ b/src/main/java/com/team/independence/asset/dto/AssetLinkRequest.java
@@ -1,0 +1,23 @@
+package com.team.independence.asset.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@ToString(exclude = "password")
+public class AssetLinkRequest {
+    private String organization;
+    private String businessType;
+    private String countryCode;
+    private String loginType;
+    private String clientType;
+    private String id;
+    private String password;  // 서버에서 RSA 암호화 (평문으로 수신)
+    private String birthDate;  // 형식: YYMMDD
+    private String loginTypeLevel;
+    private String clientTypeLevel;
+    private String cardNo;
+    private String cardPassword;
+}

--- a/src/main/java/com/team/independence/asset/dto/AssetLinkResponse.java
+++ b/src/main/java/com/team/independence/asset/dto/AssetLinkResponse.java
@@ -1,0 +1,12 @@
+package com.team.independence.asset.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AssetLinkResponse {
+    private String connectedId;
+    private String organization;
+    private String action;  // "CREATED" | "ADDED"
+}

--- a/src/main/java/com/team/independence/asset/mapper/ConnectedAccountMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/ConnectedAccountMapper.java
@@ -1,0 +1,10 @@
+package com.team.independence.asset.mapper;
+
+import com.team.independence.asset.domain.ConnectedAccount;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ConnectedAccountMapper {
+    ConnectedAccount findByMemberId(Long memberId);
+    void insert(ConnectedAccount connectedAccount);
+}

--- a/src/main/java/com/team/independence/asset/mapper/ConnectedInstitutionMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/ConnectedInstitutionMapper.java
@@ -1,0 +1,9 @@
+package com.team.independence.asset.mapper;
+
+import com.team.independence.asset.domain.ConnectedInstitution;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ConnectedInstitutionMapper {
+    void insert(ConnectedInstitution connectedInstitution);
+}

--- a/src/main/java/com/team/independence/asset/service/AssetService.java
+++ b/src/main/java/com/team/independence/asset/service/AssetService.java
@@ -1,0 +1,8 @@
+package com.team.independence.asset.service;
+
+import com.team.independence.asset.dto.AssetLinkRequest;
+import com.team.independence.asset.dto.AssetLinkResponse;
+
+public interface AssetService {
+    AssetLinkResponse linkAccount(Long memberId, AssetLinkRequest request);
+}

--- a/src/main/java/com/team/independence/asset/service/AssetServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetServiceImpl.java
@@ -1,0 +1,129 @@
+package com.team.independence.asset.service;
+
+import com.team.independence.asset.domain.ConnectedAccount;
+import com.team.independence.asset.domain.ConnectedInstitution;
+import com.team.independence.asset.dto.AssetLinkRequest;
+import com.team.independence.asset.dto.AssetLinkResponse;
+import com.team.independence.asset.mapper.ConnectedAccountMapper;
+import com.team.independence.asset.mapper.ConnectedInstitutionMapper;
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.common.security.AesEncryptor;
+import com.team.independence.external.codef.CodefClient;
+import com.team.independence.external.codef.CodefProperties;
+import com.team.independence.external.codef.CodefRsaEncryptor;
+import com.team.independence.external.codef.CodefTokenManager;
+import com.team.independence.external.codef.dto.CodefAccountRequest;
+import com.team.independence.external.codef.dto.CodefApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AssetServiceImpl implements AssetService {
+
+    private static final String LOCK_KEY_PREFIX = "asset:link:lock:";
+    private static final long LOCK_TTL_SECONDS = 30L;
+
+    private final ConnectedAccountMapper connectedAccountMapper;
+    private final ConnectedInstitutionMapper connectedInstitutionMapper;
+    private final CodefClient codefClient;
+    private final CodefTokenManager codefTokenManager;
+    private final CodefProperties codefProperties;
+    private final CodefRsaEncryptor rsaEncryptor;
+    private final AesEncryptor aesEncryptor;
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    @Transactional
+    public AssetLinkResponse linkAccount(Long memberId, AssetLinkRequest request) {
+        String lockKey = LOCK_KEY_PREFIX + memberId;
+        boolean locked = Boolean.TRUE.equals(
+                redisTemplate.opsForValue().setIfAbsent(lockKey, "1", LOCK_TTL_SECONDS, TimeUnit.SECONDS)
+        );
+        if (!locked) {
+            throw new BusinessException(ErrorCode.ASSET_SYNC_IN_PROGRESS);
+        }
+
+        try {
+            String accessToken = codefTokenManager.getAccessToken();
+            String encryptedPassword = rsaEncryptor.encrypt(codefProperties.getPublicKey(), request.getPassword());
+            String birthDate = request.getBirthDate();
+
+            CodefAccountRequest.CodefAccountItem item = CodefAccountRequest.CodefAccountItem.builder()
+                    .countryCode(request.getCountryCode() != null ? request.getCountryCode() : "KR")
+                    .businessType(request.getBusinessType())
+                    .clientType(request.getClientType() != null ? request.getClientType() : "P")
+                    .organization(request.getOrganization())
+                    .loginType(request.getLoginType())
+                    .id(request.getId())
+                    .password(encryptedPassword)
+                    .birthDate(birthDate)
+                    .loginTypeLevel(request.getLoginTypeLevel())
+                    .clientTypeLevel(request.getClientTypeLevel())
+                    .cardNo(request.getCardNo())
+                    .cardPassword(request.getCardPassword())
+                    .build();
+
+            ConnectedAccount existing = connectedAccountMapper.findByMemberId(memberId);
+
+            if (existing == null) {
+                return create(memberId, accessToken, item, request);
+            } else {
+                return add(existing, accessToken, item, request);
+            }
+        } finally {
+            redisTemplate.delete(lockKey);
+        }
+    }
+
+    private AssetLinkResponse create(Long memberId, String accessToken,
+                                     CodefAccountRequest.CodefAccountItem item,
+                                     AssetLinkRequest request) {
+        CodefApiResponse response = codefClient.createAccount(accessToken, item);
+        String connectedId = response.getData().getConnectedId();
+
+        ConnectedAccount account = ConnectedAccount.builder()
+                .memberId(memberId)
+                .connectedId(aesEncryptor.encrypt(connectedId))
+                .build();
+        connectedAccountMapper.insert(account);
+
+        saveInstitution(account.getId(), request);
+
+        return AssetLinkResponse.builder()
+                .connectedId(connectedId)
+                .organization(request.getOrganization())
+                .action("CREATED")
+                .build();
+    }
+
+    private AssetLinkResponse add(ConnectedAccount existing, String accessToken,
+                                  CodefAccountRequest.CodefAccountItem item,
+                                  AssetLinkRequest request) {
+        String connectedId = aesEncryptor.decrypt(existing.getConnectedId());
+        codefClient.addAccount(accessToken, connectedId, item);
+
+        saveInstitution(existing.getId(), request);
+
+        return AssetLinkResponse.builder()
+                .connectedId(connectedId)
+                .organization(request.getOrganization())
+                .action("ADDED")
+                .build();
+    }
+
+    private void saveInstitution(Long connectedAccountId, AssetLinkRequest request) {
+        ConnectedInstitution institution = ConnectedInstitution.builder()
+                .connectedAccountId(connectedAccountId)
+                .institutionCode(request.getOrganization())
+                .build();
+        connectedInstitutionMapper.insert(institution);
+    }
+}

--- a/src/main/java/com/team/independence/common/exception/ErrorCode.java
+++ b/src/main/java/com/team/independence/common/exception/ErrorCode.java
@@ -22,6 +22,8 @@ public enum ErrorCode {
     // ===== 자산 ASSET_xxx =====
     ASSET_NOT_LINKED("ASSET_001", "자산 연동이 필요합니다.", HttpStatus.BAD_REQUEST),
     ASSET_SYNC_IN_PROGRESS("ASSET_002", "동기화가 이미 진행 중입니다.", HttpStatus.CONFLICT),
+    ASSET_RSA_ENCRYPT_FAILED("ASSET_003", "비밀번호 암호화에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ASSET_CODEF_API_ERROR("ASSET_004", "금융 연동 서버 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY),
 
     // ===== 목표 GOAL_xxx =====
     GOAL_NOT_FOUND("GOAL_001", "목표를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/team/independence/common/security/AesEncryptor.java
+++ b/src/main/java/com/team/independence/common/security/AesEncryptor.java
@@ -1,0 +1,74 @@
+package com.team.independence.common.security;
+
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * AES-256-GCM 대칭 암호화 클래스
+ * Connected ID 등 민감 식별자를 DB에 저장할 때 사용합니다.
+ * 출력 포맷: Base64(12-byte nonce || ciphertext+tag)
+ */
+@Component
+public class AesEncryptor {
+
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final int NONCE_LENGTH = 12;
+    private static final int TAG_LENGTH_BIT = 128;
+
+    private final SecretKeySpec secretKey;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public AesEncryptor(@Value("${CODEF_ENCRYPT_KEY}") String keyBase64) {
+        byte[] keyBytes = Base64.getDecoder().decode(keyBase64);
+        if (keyBytes.length != 32) {
+            throw new IllegalArgumentException("CODEF_ENCRYPT_KEY must be 32 bytes (Base64-encoded 256-bit key)");
+        }
+        this.secretKey = new SecretKeySpec(keyBytes, "AES");
+    }
+
+    public String encrypt(String plaintext) {
+        try {
+            byte[] nonce = new byte[NONCE_LENGTH];
+            secureRandom.nextBytes(nonce);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey, new GCMParameterSpec(TAG_LENGTH_BIT, nonce));
+
+            byte[] ciphertext = cipher.doFinal(plaintext.getBytes("UTF-8"));
+
+            byte[] combined = new byte[NONCE_LENGTH + ciphertext.length];
+            System.arraycopy(nonce, 0, combined, 0, NONCE_LENGTH);
+            System.arraycopy(ciphertext, 0, combined, NONCE_LENGTH, ciphertext.length);
+
+            return Base64.getEncoder().encodeToString(combined);
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INTERNAL_ERROR, "Connected ID 암호화에 실패했습니다.");
+        }
+    }
+
+    public String decrypt(String encryptedBase64) {
+        try {
+            byte[] combined = Base64.getDecoder().decode(encryptedBase64);
+
+            byte[] nonce = new byte[NONCE_LENGTH];
+            byte[] ciphertext = new byte[combined.length - NONCE_LENGTH];
+            System.arraycopy(combined, 0, nonce, 0, NONCE_LENGTH);
+            System.arraycopy(combined, NONCE_LENGTH, ciphertext, 0, ciphertext.length);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(TAG_LENGTH_BIT, nonce));
+
+            return new String(cipher.doFinal(ciphertext), "UTF-8");
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INTERNAL_ERROR, "Connected ID 복호화에 실패했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/team/independence/config/RootConfig.java
+++ b/src/main/java/com/team/independence/config/RootConfig.java
@@ -13,11 +13,16 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.client.RestTemplate;
 
 import javax.sql.DataSource;
 
@@ -102,6 +107,23 @@ public class RootConfig {
     @Bean
     public PlatformTransactionManager transactionManager(DataSource dataSource) {
         return new DataSourceTransactionManager(dataSource);
+    }
+
+    // ===== Jackson =====
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    // ===== HTTP Client =====
+    @Bean
+    public RestTemplate restTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5_000);
+        factory.setReadTimeout(30_000);
+        return new RestTemplate(factory);
     }
 
     // ===== Redis =====

--- a/src/main/java/com/team/independence/config/WebAppInitializer.java
+++ b/src/main/java/com/team/independence/config/WebAppInitializer.java
@@ -4,6 +4,12 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
 
 import javax.servlet.Filter;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * web.xml 대체 (자바 Config 방식).
@@ -38,5 +44,63 @@ public class WebAppInitializer extends AbstractAnnotationConfigDispatcherServlet
         encodingFilter.setEncoding("UTF-8");
         encodingFilter.setForceEncoding(true);
         return new Filter[]{ encodingFilter };
+    }
+
+    /**
+     * Spring 컨텍스트 초기화 전에 .env 파일을 읽어 시스템 프로퍼티로 주입합니다.
+     * VM options(-D)나 이미 설정된 시스템 프로퍼티가 있으면 .env 값을 덮어쓰지 않습니다.
+     */
+    @Override
+    public void onStartup(ServletContext servletContext) throws ServletException {
+        loadDotEnv(servletContext);
+        super.onStartup(servletContext);
+    }
+
+    private void loadDotEnv(ServletContext servletContext) {
+        Path envFile = findEnvFile(servletContext);
+        if (envFile == null) return;
+
+        try {
+            Files.lines(envFile)
+                    .map(String::trim)
+                    .filter(line -> !line.isEmpty() && !line.startsWith("#") && line.contains("="))
+                    .forEach(line -> {
+                        int eq = line.indexOf('=');
+                        String key   = line.substring(0, eq).trim();
+                        String value = line.substring(eq + 1).trim();
+                        if (System.getProperty(key) == null) {
+                            System.setProperty(key, value);
+                        }
+                    });
+        } catch (IOException ignored) {
+        }
+    }
+
+    /**
+     * <.env 탐색 순서>
+     * 1) 배포된 WAR 실제 경로에서 상위로 탐색
+     * 2) user.dir 에서 상위로 탐색
+     */
+    private Path findEnvFile(ServletContext servletContext) {
+        String realPath = servletContext.getRealPath("/");
+        if (realPath != null) {
+            Path dir = Paths.get(realPath);
+            for (int i = 0; i < 4; i++) {
+                Path candidate = dir.resolve(".env");
+                if (Files.exists(candidate)) return candidate;
+                Path parent = dir.getParent();
+                if (parent == null) break;
+                dir = parent;
+            }
+        }
+        Path dir = Paths.get(System.getProperty("user.dir", "."));
+        for (int i = 0; i < 4; i++) {
+            Path candidate = dir.resolve(".env");
+            if (Files.exists(candidate)) return candidate;
+            Path parent = dir.getParent();
+            if (parent == null) break;
+            dir = parent;
+        }
+        return null;
     }
 }

--- a/src/main/java/com/team/independence/external/codef/CodefClient.java
+++ b/src/main/java/com/team/independence/external/codef/CodefClient.java
@@ -1,0 +1,88 @@
+package com.team.independence.external.codef;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.external.codef.dto.CodefAccountRequest;
+import com.team.independence.external.codef.dto.CodefApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * CODEF 계정 등록 API 클라이언트 클래스
+ * CODEF 응답은 application/x-www-form-urlencoded → URL 디코딩 후 JSON 파싱이 필요합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CodefClient {
+
+    // 계정 등록 데모 버전 Endpoint
+    private static final String CREATE_PATH = "/v1/account/create";
+    private static final String ADD_PATH = "/v1/account/add";
+
+    private final CodefProperties properties;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public CodefApiResponse createAccount(String accessToken, CodefAccountRequest.CodefAccountItem item) {
+        CodefAccountRequest body = CodefAccountRequest.builder()
+                .accountList(List.of(item))
+                .build();
+        return call(accessToken, CREATE_PATH, body);
+    }
+
+    public CodefApiResponse addAccount(String accessToken, String connectedId, CodefAccountRequest.CodefAccountItem item) {
+        CodefAccountRequest body = CodefAccountRequest.builder()
+                .connectedId(connectedId)
+                .accountList(List.of(item))
+                .build();
+        return call(accessToken, ADD_PATH, body);
+    }
+
+    private CodefApiResponse call(String accessToken, String path, CodefAccountRequest body) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(accessToken);
+
+            HttpEntity<CodefAccountRequest> request = new HttpEntity<>(body, headers);
+
+            log.debug("CODEF 요청 URL : {}{}", properties.getApiDomain(), path);
+            log.debug("CODEF 요청 토큰: {}...", accessToken.substring(0, Math.min(20, accessToken.length())));
+            log.debug("CODEF 요청 Body: {}", objectMapper.writeValueAsString(body));
+
+            ResponseEntity<String> response = restTemplate.exchange(
+                    properties.getApiDomain() + path,
+                    HttpMethod.POST,
+                    request,
+                    String.class
+            );
+
+            log.debug("CODEF 원본 응답: {}", response.getBody());
+            String decoded = URLDecoder.decode(response.getBody(), StandardCharsets.UTF_8);
+            log.debug("CODEF 디코딩 응답: {}", decoded);
+            CodefApiResponse result = objectMapper.readValue(decoded, CodefApiResponse.class);
+
+            if (!result.isSuccess()) {
+                log.error("CODEF API 오류: code={}, message={}", result.getResult().getCode(), result.getResult().getMessage());
+                throw new BusinessException(ErrorCode.ASSET_CODEF_API_ERROR, result.getResult().getMessage());
+            }
+
+            return result;
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("CODEF API 호출 실패: path={}", path, e);
+            throw new BusinessException(ErrorCode.ASSET_CODEF_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/team/independence/external/codef/CodefProperties.java
+++ b/src/main/java/com/team/independence/external/codef/CodefProperties.java
@@ -1,0 +1,28 @@
+package com.team.independence.external.codef;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * CODEF 연동에 필요한 5개의 환경변수(.env 파일에 존재)
+ */
+@Getter
+@Component
+public class CodefProperties {
+
+    @Value("${CODEF_CLIENT_ID}")
+    private String clientId;
+
+    @Value("${CODEF_CLIENT_SECRET}")
+    private String clientSecret;
+
+    @Value("${CODEF_PUBLIC_KEY}")
+    private String publicKey;
+
+    @Value("${CODEF_OAUTH_DOMAIN}")
+    private String oauthDomain;
+
+    @Value("${CODEF_API_DOMAIN}")
+    private String apiDomain;
+}

--- a/src/main/java/com/team/independence/external/codef/CodefRsaEncryptor.java
+++ b/src/main/java/com/team/independence/external/codef/CodefRsaEncryptor.java
@@ -1,0 +1,47 @@
+package com.team.independence.external.codef;
+
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+
+/**
+ * CODEF RSA 암호화 유틸리티 클래스
+ * CODEF가 발급한 public_key(Base64)로 비밀번호 평문을 RSA/ECB/PKCS1Padding 방식으로 암호화합니다.
+ * 암호화된 값을 그대로 CODEF 계정 등록 요청의 password 필드에 사용합니다.
+ */
+@Slf4j
+@Component
+public class CodefRsaEncryptor {
+
+    private static final String ALGORITHM = "RSA/ECB/PKCS1Padding";
+
+    /**
+     * @param publicKeyBase64 CODEF가 제공한 Base64 인코딩된 RSA 공개키
+     * @param plainPassword   암호화할 비밀번호 평문
+     * @return Base64 인코딩된 RSA 암호문
+     */
+    public String encrypt(String publicKeyBase64, String plainPassword) {
+        try {
+            byte[] keyBytes = Base64.getDecoder().decode(publicKeyBase64);
+            PublicKey publicKey = KeyFactory.getInstance("RSA")
+                    .generatePublic(new X509EncodedKeySpec(keyBytes));
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, publicKey);
+
+            byte[] encrypted = cipher.doFinal(plainPassword.getBytes("UTF-8"));
+            return Base64.getEncoder().encodeToString(encrypted);
+
+        } catch (Exception e) {
+            log.error("RSA 암호화 실패: {}", e.getMessage(), e);
+            throw new BusinessException(ErrorCode.ASSET_RSA_ENCRYPT_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/team/independence/external/codef/CodefTokenManager.java
+++ b/src/main/java/com/team/independence/external/codef/CodefTokenManager.java
@@ -1,0 +1,71 @@
+package com.team.independence.external.codef;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.external.codef.dto.CodefTokenResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * CODEF OAuth2 토큰을 발급하고 Redis에 캐시합니다.
+ * CODEF 토큰 유효기간: 7일 → Redis TTL: 6일 (만료 전 갱신 보장)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CodefTokenManager {
+
+    private static final String REDIS_KEY = "codef:oauth:token";
+    private static final long TTL_DAYS = 6L;
+
+    private final CodefProperties properties;
+    private final StringRedisTemplate redisTemplate;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public String getAccessToken() {
+        String cached = redisTemplate.opsForValue().get(REDIS_KEY);
+        if (cached != null) {
+            return cached;
+        }
+        return issueAndCache();
+    }
+
+    private String issueAndCache() {
+        try {
+            String credentials = properties.getClientId() + ":" + properties.getClientSecret();
+            String encoded = Base64.getEncoder().encodeToString(credentials.getBytes("UTF-8"));
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+            headers.set(HttpHeaders.AUTHORIZATION, "Basic " + encoded);
+
+            HttpEntity<String> request = new HttpEntity<>("grant_type=client_credentials&scope=read", headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(
+                    properties.getOauthDomain() + "/oauth/token",
+                    HttpMethod.POST,
+                    request,
+                    String.class
+            );
+
+            CodefTokenResponse tokenResponse = objectMapper.readValue(response.getBody(), CodefTokenResponse.class);
+            String token = tokenResponse.getAccessToken();
+
+            redisTemplate.opsForValue().set(REDIS_KEY, token, TTL_DAYS, TimeUnit.DAYS);
+            return token;
+
+        } catch (Exception e) {
+            log.error("CODEF 토큰 발급 실패", e);
+            throw new BusinessException(ErrorCode.ASSET_CODEF_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/team/independence/external/codef/dto/CodefAccountRequest.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefAccountRequest.java
@@ -1,0 +1,34 @@
+package com.team.independence.external.codef.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CodefAccountRequest {
+
+    private String connectedId;
+    private List<CodefAccountItem> accountList;
+
+    @Getter
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class CodefAccountItem {
+        private String countryCode;
+        private String businessType;
+        private String clientType;
+        private String organization;
+        private String loginType;
+        private String id;
+        private String password;
+        private String birthDate;
+        private String loginTypeLevel;
+        private String clientTypeLevel;
+        private String cardNo;
+        private String cardPassword;
+    }
+}

--- a/src/main/java/com/team/independence/external/codef/dto/CodefApiResponse.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefApiResponse.java
@@ -1,0 +1,45 @@
+package com.team.independence.external.codef.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CodefApiResponse {
+
+    private CodefResult result;
+    private CodefData data;
+
+    public boolean isSuccess() {
+        // 결과 코드가 CF-00000인 경우, 계정 등록 성공
+        return result != null && "CF-00000".equals(result.getCode());
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class CodefResult {
+        private String code;
+        private String message;
+        private String extraMessage;
+        private String transactionId;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class CodefData {
+        private List<CodefAccountResult> successList;
+        private List<CodefAccountResult> errorList;
+        private String connectedId;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class CodefAccountResult {
+        private String code;
+        private String message;
+        private String organization;
+        private String businessType;
+    }
+}

--- a/src/main/java/com/team/independence/external/codef/dto/CodefTokenResponse.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefTokenResponse.java
@@ -1,0 +1,19 @@
+package com.team.independence.external.codef.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CodefTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private long expiresIn;
+}

--- a/src/main/resources/mybatis/mapper/asset/ConnectedAccountMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/ConnectedAccountMapper.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.team.independence.asset.mapper.ConnectedAccountMapper">
+
+    <resultMap id="connectedAccountMap" type="com.team.independence.asset.domain.ConnectedAccount">
+        <id     property="id"              column="id"/>
+        <result property="memberId"        column="member_id"/>
+        <result property="connectedId"     column="connected_id"/>
+        <result property="connectedStatus" column="connected_status"/>
+        <result property="lastSyncedAt"    column="last_synced_at"/>
+        <result property="syncStatus"      column="sync_status"/>
+        <result property="createdAt"       column="created_at"/>
+        <result property="updatedAt"       column="updated_at"/>
+    </resultMap>
+
+    <select id="findByMemberId" parameterType="long" resultMap="connectedAccountMap">
+        SELECT id, member_id, connected_id, connected_status,
+               last_synced_at, sync_status, created_at, updated_at
+          FROM connected_account
+         WHERE member_id = #{memberId}
+    </select>
+
+    <insert id="insert" parameterType="com.team.independence.asset.domain.ConnectedAccount"
+            useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO connected_account (member_id, connected_id, connected_status)
+        VALUES (#{memberId}, #{connectedId}, 'ACTIVE')
+    </insert>
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/asset/ConnectedInstitutionMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/ConnectedInstitutionMapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.team.independence.asset.mapper.ConnectedInstitutionMapper">
+
+    <insert id="insert" parameterType="com.team.independence.asset.domain.ConnectedInstitution">
+        INSERT INTO connected_institution (connected_account_id, institution_code, status)
+        VALUES (#{connectedAccountId}, #{institutionCode}, 'ACTIVE')
+    </insert>
+
+</mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #1 

## 📝작업 내용

사용자가 자신의 은행 계정 정보를 입력하면, 서버가 CODEF(금융 데이터 중계 플랫폼)에 계정을 등록하고 그 결과를 DB에 저장하는 자산 연동 기능입니다.

엔드포인트: POST `/api/v1/assets/link?memberId={id}`

### ❗️주요 설계 결정 및 이유

  #### 1. create / add 분기를 서버가 결정합니다
  CODEF는 첫 기관 등록(create)과 기관 추가(add)의 API가 다릅니다. 어느 API를 써야 하는지는 DB에서 이 회원의 `connected_account` 행이 있는지로 판단합니다. 프론트엔드는 항상 같은 요청을 보내면 됩니다.

  #### 2. 비밀번호는 서버에서 암호화합니다
  CODEF는 비밀번호를 RSA 공개키로 암호화해서 전송해야 합니다. 클라이언트가 직접 암호화하면 공개키가 노출되므로, 서버에서 처리합니다. 로그에 평문이 남지 않도록 `@ToString(exclude="password")`도 적용했습니다.

  #### 3. Connected ID를 AES-256-GCM으로 암호화해 저장합니다
  Connected ID는 CODEF에서 이 회원의 금융 데이터에 접근할 수 있는 키입니다. DB가 유출되더라도 바로 악용되지 않도록 저장 시 암호화하고, 사용 시 복호화합니다. AES-GCM 방식은 암호화와 위변조 감지를 동시에 제공합니다.

  #### 4. Redis 분산 락으로 동시 요청을 차단합니다
  같은 회원이 동시에 두 요청을 보내면 CODEF가 Connected ID를 2개 발급할 수 있습니다. Redis의 `setIfAbsent`로 첫 번째 요청만 통과시키고, 처리가 끝나면 락을 해제합니다. (키: `asset:link:lock:{memberId}`, TTL: 30초)

  #### 5. CODEF OAuth 토큰을 Redis에 캐싱합니다
  CODEF API 호출마다 토큰을 새로 발급받으면 불필요한 네트워크 비용이 발생합니다. 토큰 유효기간이 7일이므로 Redis에 6일간 캐싱합니다.(키: `codef:oauth:token`)

  #### 6. Spring Framework는 `ObjectMapper`, `RestTemplate`을 자동 등록하지 않습니다
  Spring Boot와 달리 Spring Framework는 이 두 빈을 자동으로 만들어주지 않습니다. `RootConfig`에 직접 `@Bean`으로 등록했습니다.

  #### 7. Tomcat은 .env 파일을 자동으로 읽지 않습니다
  Spring Boot와 달리 Tomcat & Spring Framework 조합에서는 `.env`가 자동 로드되지 않습니다. `WebAppInitializer.onStartup()`을 오버라이드해서 Spring 컨텍스트가 뜨기 전에 `.env`를 읽어 값을 주입하도록 했습니다.


### 📸 스크린샷
#### 예시 요청
엔드포인트: POST `http://localhost:8080/api/v1/assets/link?memberId=1`

Request Body:
```json
{
    "organization": "0020",
    "businessType": "BK",
    "countryCode": "KR",
    "loginType": "1",
    "clientType": "P",
    "id": "금융기관아이디",
    "password": "금융기관비밀번호",
    "birthDate": "주민번호앞6자리",
    "loginTypeLevel": "",
    "clientTypeLevel": "",
    "cardNo": "",
    "cardPassword": ""
}
```

<img width="1427" height="249" alt="스크린샷 2026-07-28 오후 4 00 06" src="https://github.com/user-attachments/assets/04f1e79e-be23-4503-95c5-cc6c8d37e281" />

<img width="1429" height="233" alt="스크린샷 2026-07-28 오후 5 14 13" src="https://github.com/user-attachments/assets/70bb5795-c268-4a64-8e10-76638ffbcadb" />

&nbsp;

액세스 토큰을 Redis에 캐싱
<img width="1503" height="224" alt="스크린샷 2026-07-28 오후 4 24 58" src="https://github.com/user-attachments/assets/4ae87198-f94f-4d6f-b7ab-c39a151629e9" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?