### PR TITLE
feat: 기관 마스터 적재 및 연동 기관 관리 API 구현

### DIFF
--- a/sql/institution_master.sql
+++ b/sql/institution_master.sql
@@ -1,0 +1,20 @@
+-- 연동 가능 기관 마스터 데이터
+SET NAMES utf8mb4;
+
+DELETE FROM institution;
+
+INSERT INTO institution (code, name, institution_type, business_type, login_type, product_label, display_order) VALUES
+-- 시중은행
+('0004', 'KB국민은행', 'BANK', 'BK', '1', '예적금 · 대출', 1),
+('0007', '신한은행', 'BANK', 'BK', '1', '예적금 · 대출', 2),
+('0011', 'NH농협은행', 'BANK', 'BK', '1', '예적금 · 대출', 3),
+('0020', '우리은행', 'BANK', 'BK', '1', '예적금 · 대출', 4),
+('0081', '하나은행', 'BANK', 'BK', '1', '예적금 · 대출', 5),
+('0088', 'IBK기업은행', 'BANK', 'BK', '1', '예적금 · 대출', 6),
+
+-- 증권
+('0218', 'KB증권', 'STOCK', 'ST', '1', '주식 · 펀드', 13),
+('0238', '미래에셋증권', 'STOCK', 'ST', '1', '주식 · 펀드', 14),
+('0240', '삼성증권', 'STOCK', 'ST', '1', '주식 · 펀드', 16),
+('0243', '한국투자증권', 'STOCK', 'ST', '1', '주식 · 펀드', 15),
+('0247', 'NH투자증권', 'STOCK', 'ST', '1', '주식 · 펀드', 16);

--- a/src/main/java/com/team/independence/asset/controller/AssetController.java
+++ b/src/main/java/com/team/independence/asset/controller/AssetController.java
@@ -1,11 +1,13 @@
 package com.team.independence.asset.controller;
 
-import com.team.independence.asset.dto.AssetLinkRequest;
-import com.team.independence.asset.dto.AssetLinkResponse;
+import com.team.independence.asset.dto.*;
 import com.team.independence.asset.service.AssetService;
+import com.team.independence.asset.service.InstitutionService;
 import com.team.independence.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/assets")
@@ -13,11 +15,30 @@ import org.springframework.web.bind.annotation.*;
 public class AssetController {
 
     private final AssetService assetService;
+    private final InstitutionService institutionService;
 
     @PostMapping("/link")
     public ApiResponse<AssetLinkResponse> linkAccount(
             @RequestParam Long memberId,
             @RequestBody AssetLinkRequest request) {
         return ApiResponse.ok(assetService.linkAccount(memberId, request));
+    }
+
+    @GetMapping("/organizations")
+    public ApiResponse<List<OrganizationResponse>> getOrganizations() {
+        return ApiResponse.ok(institutionService.getOrganizations());
+    }
+
+    @GetMapping("/connections")
+    public ApiResponse<List<LinkedOrganizationResponse>> getConnections(
+            @RequestParam Long memberId) {
+        return ApiResponse.ok(assetService.getConnections(memberId));
+    }
+
+    @DeleteMapping("/connections/organizations/{organizationCode}")
+    public ApiResponse<UnlinkOrganizationResponse> unlinkOrganization(
+            @RequestParam Long memberId,
+            @PathVariable String organizationCode) {
+        return ApiResponse.ok(assetService.unlinkOrganization(memberId, organizationCode));
     }
 }

--- a/src/main/java/com/team/independence/asset/domain/Institution.java
+++ b/src/main/java/com/team/independence/asset/domain/Institution.java
@@ -1,0 +1,20 @@
+package com.team.independence.asset.domain;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Institution {
+    private String code;
+    private String name;
+    private String institutionType;
+    private String businessType;
+    private String loginType;
+    private String productLabel;
+    private String logoUrl;
+    private int displayOrder;
+    private boolean isActive;
+}

--- a/src/main/java/com/team/independence/asset/dto/LinkedOrganizationResponse.java
+++ b/src/main/java/com/team/independence/asset/dto/LinkedOrganizationResponse.java
@@ -1,0 +1,15 @@
+package com.team.independence.asset.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class LinkedOrganizationResponse {
+    private String organizationCode;
+    private String organizationName;
+    private String businessType;
+    private LocalDateTime connectedAt;
+}

--- a/src/main/java/com/team/independence/asset/dto/OrganizationResponse.java
+++ b/src/main/java/com/team/independence/asset/dto/OrganizationResponse.java
@@ -1,0 +1,25 @@
+package com.team.independence.asset.dto;
+
+import com.team.independence.asset.domain.Institution;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class OrganizationResponse {
+    private String organizationCode;
+    private String organizationName;
+    private String businessType;
+    private List<String> supportedLoginTypes;
+
+    public static OrganizationResponse from(Institution institution) {
+        return OrganizationResponse.builder()
+                .organizationCode(institution.getCode())
+                .organizationName(institution.getName())
+                .businessType(institution.getBusinessType())
+                .supportedLoginTypes(List.of("ID"))
+                .build();
+    }
+}

--- a/src/main/java/com/team/independence/asset/dto/UnlinkOrganizationResponse.java
+++ b/src/main/java/com/team/independence/asset/dto/UnlinkOrganizationResponse.java
@@ -1,0 +1,11 @@
+package com.team.independence.asset.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UnlinkOrganizationResponse {
+    private String organizationCode;
+    private String organizationName;
+}

--- a/src/main/java/com/team/independence/asset/mapper/ConnectedAccountMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/ConnectedAccountMapper.java
@@ -7,4 +7,5 @@ import org.apache.ibatis.annotations.Mapper;
 public interface ConnectedAccountMapper {
     ConnectedAccount findByMemberId(Long memberId);
     void insert(ConnectedAccount connectedAccount);
+    void deleteById(Long id);
 }

--- a/src/main/java/com/team/independence/asset/mapper/ConnectedInstitutionMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/ConnectedInstitutionMapper.java
@@ -1,9 +1,17 @@
 package com.team.independence.asset.mapper;
 
 import com.team.independence.asset.domain.ConnectedInstitution;
+import com.team.independence.asset.dto.LinkedOrganizationResponse;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface ConnectedInstitutionMapper {
     void insert(ConnectedInstitution connectedInstitution);
+    List<LinkedOrganizationResponse> findAllWithOrganizationByConnectedAccountId(Long connectedAccountId);
+    ConnectedInstitution findByConnectedAccountIdAndInstitutionCode(@Param("connectedAccountId") Long connectedAccountId, @Param("institutionCode") String institutionCode);
+    void deleteByConnectedAccountIdAndInstitutionCode(@Param("connectedAccountId") Long connectedAccountId, @Param("institutionCode") String institutionCode);
+    int countByConnectedAccountId(Long connectedAccountId);
 }

--- a/src/main/java/com/team/independence/asset/mapper/InstitutionMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/InstitutionMapper.java
@@ -1,0 +1,12 @@
+package com.team.independence.asset.mapper;
+
+import com.team.independence.asset.domain.Institution;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface InstitutionMapper {
+    List<Institution> findAllActive();
+    Institution findByCode(String code);
+}

--- a/src/main/java/com/team/independence/asset/service/AssetService.java
+++ b/src/main/java/com/team/independence/asset/service/AssetService.java
@@ -2,7 +2,13 @@ package com.team.independence.asset.service;
 
 import com.team.independence.asset.dto.AssetLinkRequest;
 import com.team.independence.asset.dto.AssetLinkResponse;
+import com.team.independence.asset.dto.LinkedOrganizationResponse;
+import com.team.independence.asset.dto.UnlinkOrganizationResponse;
+
+import java.util.List;
 
 public interface AssetService {
     AssetLinkResponse linkAccount(Long memberId, AssetLinkRequest request);
+    List<LinkedOrganizationResponse> getConnections(Long memberId);
+    UnlinkOrganizationResponse unlinkOrganization(Long memberId, String organizationCode);
 }

--- a/src/main/java/com/team/independence/asset/service/AssetServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetServiceImpl.java
@@ -4,8 +4,12 @@ import com.team.independence.asset.domain.ConnectedAccount;
 import com.team.independence.asset.domain.ConnectedInstitution;
 import com.team.independence.asset.dto.AssetLinkRequest;
 import com.team.independence.asset.dto.AssetLinkResponse;
+import com.team.independence.asset.dto.LinkedOrganizationResponse;
+import com.team.independence.asset.dto.UnlinkOrganizationResponse;
+import com.team.independence.asset.domain.Institution;
 import com.team.independence.asset.mapper.ConnectedAccountMapper;
 import com.team.independence.asset.mapper.ConnectedInstitutionMapper;
+import com.team.independence.asset.mapper.InstitutionMapper;
 import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.common.security.AesEncryptor;
@@ -21,6 +25,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -33,6 +38,7 @@ public class AssetServiceImpl implements AssetService {
 
     private final ConnectedAccountMapper connectedAccountMapper;
     private final ConnectedInstitutionMapper connectedInstitutionMapper;
+    private final InstitutionMapper institutionMapper;
     private final CodefClient codefClient;
     private final CodefTokenManager codefTokenManager;
     private final CodefProperties codefProperties;
@@ -125,5 +131,56 @@ public class AssetServiceImpl implements AssetService {
                 .institutionCode(request.getOrganization())
                 .build();
         connectedInstitutionMapper.insert(institution);
+    }
+
+    @Override
+    public List<LinkedOrganizationResponse> getConnections(Long memberId) {
+        ConnectedAccount account = connectedAccountMapper.findByMemberId(memberId);
+        if (account == null) {
+            return List.of();
+        }
+        return connectedInstitutionMapper.findAllWithOrganizationByConnectedAccountId(account.getId());
+    }
+
+    @Override
+    @Transactional
+    public UnlinkOrganizationResponse unlinkOrganization(Long memberId, String organizationCode) {
+        ConnectedAccount account = connectedAccountMapper.findByMemberId(memberId);
+        if (account == null) {
+            throw new BusinessException(ErrorCode.ASSET_ORGANIZATION_NOT_CONNECTED);
+        }
+
+        ConnectedInstitution institution = connectedInstitutionMapper
+                .findByConnectedAccountIdAndInstitutionCode(account.getId(), organizationCode);
+        if (institution == null) {
+            throw new BusinessException(ErrorCode.ASSET_ORGANIZATION_NOT_CONNECTED);
+        }
+
+        Institution institutionInfo = institutionMapper.findByCode(organizationCode);
+
+        String connectedId = aesEncryptor.decrypt(account.getConnectedId());
+        String accessToken = codefTokenManager.getAccessToken();
+
+        CodefAccountRequest.CodefAccountItem item = CodefAccountRequest.CodefAccountItem.builder()
+                .countryCode("KR")
+                .businessType(institutionInfo.getBusinessType())
+                .clientType("P")
+                .organization(organizationCode)
+                .loginType(institutionInfo.getLoginType())
+                .build();
+
+        // CODEF 삭제 성공 후에만 DB 삭제
+        codefClient.deleteAccount(accessToken, connectedId, item);
+
+        connectedInstitutionMapper.deleteByConnectedAccountIdAndInstitutionCode(account.getId(), organizationCode);
+
+        if (connectedInstitutionMapper.countByConnectedAccountId(account.getId()) == 0) {
+            connectedAccountMapper.deleteById(account.getId());
+        }
+
+        return UnlinkOrganizationResponse.builder()
+                .organizationCode(organizationCode)
+                .organizationName(institutionInfo.getName())
+                .build();
     }
 }

--- a/src/main/java/com/team/independence/asset/service/InstitutionService.java
+++ b/src/main/java/com/team/independence/asset/service/InstitutionService.java
@@ -1,0 +1,11 @@
+package com.team.independence.asset.service;
+
+import com.team.independence.asset.domain.Institution;
+import com.team.independence.asset.dto.OrganizationResponse;
+
+import java.util.List;
+
+public interface InstitutionService {
+    List<OrganizationResponse> getOrganizations();
+    Institution getByCode(String code);
+}

--- a/src/main/java/com/team/independence/asset/service/InstitutionServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/InstitutionServiceImpl.java
@@ -1,0 +1,29 @@
+package com.team.independence.asset.service;
+
+import com.team.independence.asset.domain.Institution;
+import com.team.independence.asset.dto.OrganizationResponse;
+import com.team.independence.asset.mapper.InstitutionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class InstitutionServiceImpl implements InstitutionService {
+
+    private final InstitutionMapper institutionMapper;
+
+    @Override
+    public List<OrganizationResponse> getOrganizations() {
+        return institutionMapper.findAllActive().stream()
+                .map(OrganizationResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Institution getByCode(String code) {
+        return institutionMapper.findByCode(code);
+    }
+}

--- a/src/main/java/com/team/independence/common/exception/ErrorCode.java
+++ b/src/main/java/com/team/independence/common/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     ASSET_SYNC_IN_PROGRESS("ASSET_002", "동기화가 이미 진행 중입니다.", HttpStatus.CONFLICT),
     ASSET_RSA_ENCRYPT_FAILED("ASSET_003", "비밀번호 암호화에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ASSET_CODEF_API_ERROR("ASSET_004", "금융 연동 서버 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY),
+    ASSET_ORGANIZATION_NOT_CONNECTED("ASSET_005", "연동되지 않은 기관입니다.", HttpStatus.NOT_FOUND),
 
     // ===== 목표 GOAL_xxx =====
     GOAL_NOT_FOUND("GOAL_001", "목표를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/team/independence/external/codef/CodefClient.java
+++ b/src/main/java/com/team/independence/external/codef/CodefClient.java
@@ -24,9 +24,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CodefClient {
 
-    // 계정 등록 데모 버전 Endpoint
     private static final String CREATE_PATH = "/v1/account/create";
     private static final String ADD_PATH = "/v1/account/add";
+    private static final String DELETE_PATH = "/v1/account/delete";
 
     private final CodefProperties properties;
     private final RestTemplate restTemplate;
@@ -45,6 +45,14 @@ public class CodefClient {
                 .accountList(List.of(item))
                 .build();
         return call(accessToken, ADD_PATH, body);
+    }
+
+    public CodefApiResponse deleteAccount(String accessToken, String connectedId, CodefAccountRequest.CodefAccountItem item) {
+        CodefAccountRequest body = CodefAccountRequest.builder()
+                .connectedId(connectedId)
+                .accountList(List.of(item))
+                .build();
+        return call(accessToken, DELETE_PATH, body);
     }
 
     private CodefApiResponse call(String accessToken, String path, CodefAccountRequest body) {

--- a/src/main/resources/mybatis/mapper/asset/ConnectedAccountMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/ConnectedAccountMapper.xml
@@ -28,4 +28,8 @@
         VALUES (#{memberId}, #{connectedId}, 'ACTIVE')
     </insert>
 
+    <delete id="deleteById" parameterType="long">
+        DELETE FROM connected_account WHERE id = #{id}
+    </delete>
+
 </mapper>

--- a/src/main/resources/mybatis/mapper/asset/ConnectedInstitutionMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/ConnectedInstitutionMapper.xml
@@ -4,9 +4,57 @@
 
 <mapper namespace="com.team.independence.asset.mapper.ConnectedInstitutionMapper">
 
+    <resultMap id="connectedInstitutionMap" type="com.team.independence.asset.domain.ConnectedInstitution">
+        <id     property="id"                   column="id"/>
+        <result property="connectedAccountId"   column="connected_account_id"/>
+        <result property="institutionCode"      column="institution_code"/>
+        <result property="status"               column="status"/>
+        <result property="lastSyncedAt"         column="last_synced_at"/>
+        <result property="lastErrorCode"        column="last_error_code"/>
+        <result property="lastErrorMessage"     column="last_error_message"/>
+        <result property="lastAttemptedAt"      column="last_attempted_at"/>
+        <result property="createdAt"            column="created_at"/>
+        <result property="updatedAt"            column="updated_at"/>
+    </resultMap>
+
+    <resultMap id="linkedOrgMap" type="com.team.independence.asset.dto.LinkedOrganizationResponse">
+        <result property="organizationCode" column="institution_code"/>
+        <result property="organizationName" column="name"/>
+        <result property="businessType"     column="business_type"/>
+        <result property="connectedAt"      column="created_at"/>
+    </resultMap>
+
     <insert id="insert" parameterType="com.team.independence.asset.domain.ConnectedInstitution">
         INSERT INTO connected_institution (connected_account_id, institution_code, status)
         VALUES (#{connectedAccountId}, #{institutionCode}, 'ACTIVE')
     </insert>
+
+    <select id="findAllWithOrganizationByConnectedAccountId" parameterType="long" resultMap="linkedOrgMap">
+        SELECT ci.institution_code, i.name, i.business_type, ci.created_at
+          FROM connected_institution ci
+          JOIN institution i ON ci.institution_code = i.code
+         WHERE ci.connected_account_id = #{connectedAccountId}
+         ORDER BY ci.created_at
+    </select>
+
+    <select id="findByConnectedAccountIdAndInstitutionCode" resultMap="connectedInstitutionMap">
+        SELECT id, connected_account_id, institution_code, status,
+               last_synced_at, last_error_code, last_error_message,
+               last_attempted_at, created_at, updated_at
+          FROM connected_institution
+         WHERE connected_account_id = #{connectedAccountId}
+           AND institution_code = #{institutionCode}
+    </select>
+
+    <delete id="deleteByConnectedAccountIdAndInstitutionCode">
+        DELETE FROM connected_institution
+         WHERE connected_account_id = #{connectedAccountId}
+           AND institution_code = #{institutionCode}
+    </delete>
+
+    <select id="countByConnectedAccountId" parameterType="long" resultType="int">
+        SELECT COUNT(*) FROM connected_institution
+         WHERE connected_account_id = #{connectedAccountId}
+    </select>
 
 </mapper>

--- a/src/main/resources/mybatis/mapper/asset/InstitutionMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/InstitutionMapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.team.independence.asset.mapper.InstitutionMapper">
+
+    <resultMap id="institutionMap" type="com.team.independence.asset.domain.Institution">
+        <id     property="code"            column="code"/>
+        <result property="name"            column="name"/>
+        <result property="institutionType" column="institution_type"/>
+        <result property="businessType"    column="business_type"/>
+        <result property="loginType"       column="login_type"/>
+        <result property="productLabel"    column="product_label"/>
+        <result property="logoUrl"         column="logo_url"/>
+        <result property="displayOrder"    column="display_order"/>
+        <result property="isActive"        column="is_active"/>
+    </resultMap>
+
+    <select id="findAllActive" resultMap="institutionMap">
+        SELECT code, name, institution_type, business_type, login_type,
+               product_label, logo_url, display_order, is_active
+          FROM institution
+         WHERE is_active = TRUE
+         ORDER BY display_order
+    </select>
+
+    <select id="findByCode" parameterType="string" resultMap="institutionMap">
+        SELECT code, name, institution_type, business_type, login_type,
+               product_label, logo_url, display_order, is_active
+          FROM institution
+         WHERE code = #{code}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈

#2 

## 📝작업 내용

기관 목록 조회, 내 연동 기관 조회, 기관 연동 해제 기능을 구현했습니다. 이전 PR #1 에서 Connected ID 발급과 기관 등록을 완성했고, 이번 PR에서 연동 후 관리 흐름을 완성했습니다.

구현한 API는 아래와 같습니다.
### GET `/api/v1/assets/organizations`
`institution` 테이블에서 활성화된 기관을 정렬 순서대로 반환합니다. 기관은 현재 아이디 로그인 방식을 지원하는 주요 기관만을 선정했습니다. `supportedLoginTypes`는 아이디/비밀번호 방식만 지원하므로 `["ID"]`로 고정 처리했습니다.
- 시중은행 6개(KB국민은행, 신한은행, NH농협은행, 우리은행, 하나은행, IBK기업은행)
- 증권사 5개(KB증권, 미래에셋증권, 삼성증권, 한국투자증권, NH투자증권)

<details>
  <summary>실제 응답 결과</summary>

```json
{
    "success": true,
    "data": [
        {
            "organizationCode": "0004",
            "organizationName": "KB국민은행",
            "businessType": "BK",
            "supportedLoginTypes": [
                "ID"
            ]
        },
        {
            "organizationCode": "0007",
            "organizationName": "신한은행",
            "businessType": "BK",
            "supportedLoginTypes": [
                "ID"
            ]
        },
        {
            "organizationCode": "0011",
            "organizationName": "NH농협은행",
            "businessType": "BK",
            "supportedLoginTypes": [
                "ID"
            ]
        },
        {
            "organizationCode": "0020",
            "organizationName": "우리은행",
            "businessType": "BK",
            "supportedLoginTypes": [
                "ID"
            ]
        },
        {
            "organizationCode": "0081",
            "organizationName": "하나은행",
            "businessType": "BK",
            "supportedLoginTypes": [
                "ID"
            ]
        },
        {
            "organizationCode": "0088",
            "organizationName": "IBK기업은행",
            "businessType": "BK",
            "supportedLoginTypes": [
                "ID"
            ]
        },
        {
            "organizationCode": "0218",
            "organizationName": "KB증권",
            "businessType": "ST",
            "supportedLoginTypes": [
                "ID"
            ]
        },
        {
            "organizationCode": "0238",
            "organizationName": "미래에셋증권",
            "businessType": "ST",
            "supportedLoginTypes": [
                "ID"
            ]
        },
        {
            "organizationCode": "0243",
            "organizationName": "한국투자증권",
            "businessType": "ST",
            "supportedLoginTypes": [
                "ID"
            ]
        },
        {
            "organizationCode": "0240",
            "organizationName": "삼성증권",
            "businessType": "ST",
            "supportedLoginTypes": [
                "ID"
            ]
        },
        {
            "organizationCode": "0247",
            "organizationName": "NH투자증권",
            "businessType": "ST",
            "supportedLoginTypes": [
                "ID"
            ]
        }
    ],
    "error": null
}

```
</details>

&nbsp;

### GET `/api/v1/assets/connections`
`connected_institution`과 `institution`을 JOIN해서 사용자가 연동한 기관 목록을 반환합니다. 한 번도 연동하지 않은 회원은 예외 없이 빈 배열을 반환합니다. 아래는 실제 응답 결과입니다.


<details>
  <summary>실제 응답 결과</summary>

```json
{
    "success": true,
    "data": [
        {
            "organizationCode": "0020",
            "organizationName": "우리은행",
            "businessType": "BK",
            "connectedAt": "2026-07-29T10:45:03"
        }
    ],
    "error": null
}

```
</details>

  
&nbsp;

### DELETE `/api/v1/assets/connections/organizations/{organizationCode}`
연동된 기관 해제 기능은 아래 순서로 처리합니다. CODEF 삭제가 성공해야만 DB를 변경합니다.

1. 연동 기관 존재 확인 → 없으면 `ASSET_ORGANIZATION_NOT_CONNECTED`
2. CODEF `/v1/account/delete` 호출 → 실패 시 DB 변경 없이 예외 반환
3. 성공 시 `connected_institution` 행 삭제
4. 남은 기관이 0개면 `connected_account`도 삭제

<details>
  <summary>실제 응답 결과</summary>

```json
{
    "success": true,
    "data": {
        "organizationCode": "0020",
        "organizationName": "우리은행"
    },
    "error": null
}

```
</details>

&nbsp;

### 📸 스크린샷
#### <연동 가능 기관 조회 결과>
<img width="1223" height="660" alt="연동 가능 기관 조회 결과" src="https://github.com/user-attachments/assets/5edbc8e0-a61f-48ff-a327-f22da88924ec" />

#### <연동 기관 목록 조회 결과>
<img width="1221" height="462" alt="연동 기관 목록 조회 결과" src="https://github.com/user-attachments/assets/6d293d28-af8e-4d74-9325-98ed86ba1b47" />

#### <연동 기관 삭제 결과>
<img width="1223" height="377" alt="연동 기관 삭제 결과" src="https://github.com/user-attachments/assets/72199254-529d-426d-b903-c886cf00c468" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?