### PR TITLE
refactor: 전월세 주택유형/거래유형을 문자열에서 enum으로 전환

### DIFF
--- a/sql/full_schema.sql
+++ b/sql/full_schema.sql
@@ -89,7 +89,7 @@ CREATE TABLE rent_transaction (
     jibun          VARCHAR(30)   NULL     COMMENT '지번(단독/다가구 미제공)',
     complex_name   VARCHAR(100)  NULL     COMMENT '단지명(단독/다가구 미제공)',
     area           DECIMAL(10,2) NOT NULL COMMENT '전용면적 / 연면적(단독다가구)',
-    deal_type      VARCHAR(10)   NOT NULL COMMENT '전세 / 월세 (monthly_rent=0이면 전세)',
+    deal_type      VARCHAR(10)   NOT NULL COMMENT 'JEONSE / WOLSE (monthly_rent=0이면 JEONSE)',
     deposit        BIGINT        NOT NULL DEFAULT 0 COMMENT '보증금(원)',
     monthly_rent   BIGINT        NOT NULL DEFAULT 0 COMMENT '월세(원, 전세=0)',
     floor          INT           NULL     COMMENT '층(단독/다가구 미제공)',

--- a/src/main/java/com/team/independence/property/domain/DealType.java
+++ b/src/main/java/com/team/independence/property/domain/DealType.java
@@ -1,0 +1,21 @@
+package com.team.independence.property.domain;
+
+/**
+ * 전월세 거래 유형.
+ *
+ * <p>MyBatis 기본 EnumTypeHandler가 상수명을 그대로 저장/조회하므로
+ * 상수명 = deal_type 컬럼 값이다. 이름을 바꾸면 기존 데이터와 어긋난다.
+ *
+ * <p>국토부가 내려주는 값이 아니라 월세액에서 파생시키는 값이다.
+ */
+public enum DealType {
+    /** 전세 */
+    JEONSE,
+    /** 월세 */
+    WOLSE;
+
+    /** 월세가 0이면 전세 거래다. */
+    public static DealType from(long monthlyRent) {
+        return monthlyRent == 0 ? JEONSE : WOLSE;
+    }
+}

--- a/src/main/java/com/team/independence/property/domain/HousingType.java
+++ b/src/main/java/com/team/independence/property/domain/HousingType.java
@@ -1,0 +1,18 @@
+package com.team.independence.property.domain;
+
+/**
+ * 국토부 전월세 실거래 4종 주택유형.
+ *
+ * <p>MyBatis 기본 EnumTypeHandler가 상수명을 그대로 저장/조회하므로
+ * 상수명 = housing_type 컬럼 값이다. 이름을 바꾸면 기존 데이터와 어긋난다.
+ */
+public enum HousingType {
+    /** 아파트 */
+    APT,
+    /** 연립다세대 */
+    ROW_HOUSE,
+    /** 오피스텔 */
+    OFFICETEL,
+    /** 단독다가구 */
+    DETACHED
+}

--- a/src/main/java/com/team/independence/property/domain/RentSyncLog.java
+++ b/src/main/java/com/team/independence/property/domain/RentSyncLog.java
@@ -17,7 +17,7 @@ public class RentSyncLog {
 
     private String regionCode;
     private String dealYm;
-    private String housingType;
+    private HousingType housingType;
     /** 래퍼 타입 고정: primitive boolean이면 Lombok이 setSuccess()를 만들어 is_success 매핑이 깨진다 */
     private Boolean isSuccess;
     private Integer insertedCnt;

--- a/src/main/java/com/team/independence/property/domain/RentTransaction.java
+++ b/src/main/java/com/team/independence/property/domain/RentTransaction.java
@@ -14,12 +14,12 @@ import lombok.NoArgsConstructor;
 public class RentTransaction {
     private Long id;
     private String regionCode;
-    private String housingType;
+    private HousingType housingType;
     private String dongName;
     private String jibun;
     private String complexName;
     private BigDecimal area;
-    private String dealType;
+    private DealType dealType;
     private Long deposit;
     private Long monthlyRent;
     private Integer floor;

--- a/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
+++ b/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
@@ -1,5 +1,6 @@
 package com.team.independence.property.mapper;
 
+import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.domain.RentTransaction;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
@@ -13,5 +14,5 @@ public interface RentTransactionMapper {
     /** (지역, 연월, 유형) 단위 재적재를 위한 구간 삭제 */
     int deleteByUnit(@Param("regionCode") String regionCode,
                      @Param("dealYm") String dealYm,
-                     @Param("housingType") String housingType);
+                     @Param("housingType") HousingType housingType);
 }

--- a/src/main/java/com/team/independence/property/service/RentTransactionSyncService.java
+++ b/src/main/java/com/team/independence/property/service/RentTransactionSyncService.java
@@ -1,5 +1,7 @@
 package com.team.independence.property.service;
 
+import com.team.independence.property.domain.HousingType;
+
 /**
  * 국토부 전월세 실거래 API에서 거래 내역을 수집한다.
  *
@@ -23,5 +25,5 @@ public interface RentTransactionSyncService {
      * 이 메서드에는 {@code @Transactional}을 붙이면 안 된다 — 외부 API 응답을 기다리는 동안
      * DB 커넥션을 점유하게 된다.
      */
-    void collectAndSync(String regionCode, String dealYm, String housingType);
+    void collectAndSync(String regionCode, String dealYm, HousingType housingType);
 }

--- a/src/main/java/com/team/independence/property/service/RentTransactionSyncServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/RentTransactionSyncServiceImpl.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.domain.RentSyncLog;
 import com.team.independence.property.domain.RentTransaction;
 import com.team.independence.property.dto.RentItemDto;
@@ -41,11 +43,11 @@ public class RentTransactionSyncServiceImpl implements RentTransactionSyncServic
     private final XmlMapper xmlMapper = new XmlMapper();
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private static final Map<String, String> API_URLS = Map.of(
-        "APT", "https://apis.data.go.kr/1613000/RTMSDataSvcAptRent/getRTMSDataSvcAptRent",
-        "OFFICETEL", "https://apis.data.go.kr/1613000/RTMSDataSvcOffiRent/getRTMSDataSvcOffiRent",
-        "ROW_HOUSE", "https://apis.data.go.kr/1613000/RTMSDataSvcRHRent/getRTMSDataSvcRHRent",
-        "DETACHED", "https://apis.data.go.kr/1613000/RTMSDataSvcSHRent/getRTMSDataSvcSHRent"
+    private static final Map<HousingType, String> API_URLS = Map.of(
+        HousingType.APT, "https://apis.data.go.kr/1613000/RTMSDataSvcAptRent/getRTMSDataSvcAptRent",
+        HousingType.OFFICETEL, "https://apis.data.go.kr/1613000/RTMSDataSvcOffiRent/getRTMSDataSvcOffiRent",
+        HousingType.ROW_HOUSE, "https://apis.data.go.kr/1613000/RTMSDataSvcRHRent/getRTMSDataSvcRHRent",
+        HousingType.DETACHED, "https://apis.data.go.kr/1613000/RTMSDataSvcSHRent/getRTMSDataSvcSHRent"
     );
 
     private static final DateTimeFormatter DEAL_YM = DateTimeFormatter.ofPattern("yyyyMM");
@@ -81,7 +83,7 @@ public class RentTransactionSyncServiceImpl implements RentTransactionSyncServic
             boolean alwaysResync = monthsAgo < ALWAYS_RESYNC_MONTHS;
 
             for (String regionCode : regionCodes) {
-                for (String housingType : API_URLS.keySet()) {
+                for (HousingType housingType : HousingType.values()) {
 
                     if (!alwaysResync && isCollected(history, regionCode, dealYm, housingType)) {
                         skipped++;
@@ -107,7 +109,7 @@ public class RentTransactionSyncServiceImpl implements RentTransactionSyncServic
     }
 
     @Override
-    public void collectAndSync(String regionCode, String dealYm, String housingType) {
+    public void collectAndSync(String regionCode, String dealYm, HousingType housingType) {
         String baseUrl = API_URLS.get(housingType);
         if (baseUrl == null) {
             throw new IllegalArgumentException("지원하지 않는 주택유형: " + housingType);
@@ -127,7 +129,7 @@ public class RentTransactionSyncServiceImpl implements RentTransactionSyncServic
      * <p>페이지를 끝까지 돌지 않으면 뒷부분이 잘리는데, 재적재 구조에서 잘림은 곧 삭제다.
      * 그래서 상한을 넘기면 부분 결과를 반환하지 않고 예외를 던져 유닛 자체를 실패시킨다.
      */
-    private List<RentTransaction> fetchAndParse(String baseUrl, String housingType,
+    private List<RentTransaction> fetchAndParse(String baseUrl, HousingType housingType,
                                                 String regionCode, String dealYm) {
         List<RentTransaction> result = new ArrayList<>();
 
@@ -212,17 +214,17 @@ public class RentTransactionSyncServiceImpl implements RentTransactionSyncServic
     }
 
     private boolean isCollected(Map<String, RentSyncLog> history,
-                                String regionCode, String dealYm, String housingType) {
+                                String regionCode, String dealYm, HousingType housingType) {
         RentSyncLog syncLog = history.get(historyKey(regionCode, dealYm, housingType));
         return syncLog != null && Boolean.TRUE.equals(syncLog.getIsSuccess());
     }
 
-    private String historyKey(String regionCode, String dealYm, String housingType) {
-        return regionCode + "|" + dealYm + "|" + housingType;
+    private String historyKey(String regionCode, String dealYm, HousingType housingType) {
+        return regionCode + "|" + dealYm + "|" + housingType.name();
     }
 
     /** 실패 기록마저 실패해도 전체 순회는 멈추지 않는다(다음 실행에서 이력 없음 → 재시도 대상). */
-    private void markFailed(String regionCode, String dealYm, String housingType) {
+    private void markFailed(String regionCode, String dealYm, HousingType housingType) {
         try {
             rentSyncLogMapper.upsert(RentSyncLog.builder()
                 .regionCode(regionCode)
@@ -243,10 +245,10 @@ public class RentTransactionSyncServiceImpl implements RentTransactionSyncServic
      * RentItemDto → RentTransaction 변환
      * API 응답 필드명/형식이 DB 컬럼과 달라서 여기서 정제한다.
      */
-    private RentTransaction toRentTransaction(RentItemDto dto, String housingType, String regionCode) {
+    private RentTransaction toRentTransaction(RentItemDto dto, HousingType housingType, String regionCode) {
         // "24,000" 형태의 금액 → 콤마 제거 후 숫자 문자열로
         String deposit = parseAmount(dto.getDeposit());
-        String monthlyRent = parseAmount(dto.getMonthlyRent());
+        long monthlyRent = parseLong(parseAmount(dto.getMonthlyRent()));
 
         // dealYear("2015") + dealMonth("12") → dealYm("201512")
         String dealYm = dto.getDealYear().trim()
@@ -262,9 +264,9 @@ public class RentTransactionSyncServiceImpl implements RentTransactionSyncServic
             .jibun(trim(dto.getJibun()))
             .complexName(dto.getComplexName())          // 4종 단지명 헬퍼로 통일
             .area(area != null ? new BigDecimal(area) : BigDecimal.ZERO)
-            .dealType("0".equals(monthlyRent) ? "전세" : "월세") // monthlyRent=0이면 전세
+            .dealType(DealType.from(monthlyRent))
             .deposit(parseLong(deposit))
-            .monthlyRent(parseLong(monthlyRent))
+            .monthlyRent(monthlyRent)
             .floor(parseInteger(dto.getFloor()))
             .buildYear(parseInteger(dto.getBuildYear()))
             .dealYm(dealYm)

--- a/src/main/java/com/team/independence/property/service/RentTransactionUnitSyncService.java
+++ b/src/main/java/com/team/independence/property/service/RentTransactionUnitSyncService.java
@@ -1,5 +1,6 @@
 package com.team.independence.property.service;
 
+import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.domain.RentTransaction;
 import java.util.List;
 
@@ -18,5 +19,5 @@ public interface RentTransactionUnitSyncService {
     /**
      * @param items 이미 파싱이 끝난 거래 목록. HTTP 호출은 트랜잭션 밖에서 끝내고 결과만 넘긴다.
      */
-    void sync(String regionCode, String dealYm, String housingType, List<RentTransaction> items);
+    void sync(String regionCode, String dealYm, HousingType housingType, List<RentTransaction> items);
 }

--- a/src/main/java/com/team/independence/property/service/RentTransactionUnitSyncServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/RentTransactionUnitSyncServiceImpl.java
@@ -1,5 +1,6 @@
 package com.team.independence.property.service;
 
+import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.domain.RentSyncLog;
 import com.team.independence.property.domain.RentTransaction;
 import com.team.independence.property.mapper.RentSyncLogMapper;
@@ -20,7 +21,7 @@ public class RentTransactionUnitSyncServiceImpl implements RentTransactionUnitSy
 
     @Override
     @Transactional
-    public void sync(String regionCode, String dealYm, String housingType,
+    public void sync(String regionCode, String dealYm, HousingType housingType,
                      List<RentTransaction> items) {
 
         int deleted = rentTransactionMapper.deleteByUnit(regionCode, dealYm, housingType);

--- a/src/test/java/com/team/independence/property/service/RentTransactionSyncServiceIntegrationTest.java
+++ b/src/test/java/com/team/independence/property/service/RentTransactionSyncServiceIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.team.independence.property.service;
 
 import com.team.independence.config.RootConfig;
+import com.team.independence.property.domain.HousingType;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,7 @@ class RentTransactionSyncServiceIntegrationTest {
 
     @Test
     void collectAndSync_저장확인() {
-        rentTransactionSyncService.collectAndSync("11110", "201512", "APT");
+        rentTransactionSyncService.collectAndSync("11110", "201512", HousingType.APT);
 
         JdbcTemplate jdbc = new JdbcTemplate(dataSource);
         Integer count = jdbc.queryForObject(
@@ -49,13 +50,13 @@ class RentTransactionSyncServiceIntegrationTest {
     void collectAndSync_두_번_실행해도_건수_동일() {
         JdbcTemplate jdbc = new JdbcTemplate(dataSource);
 
-        rentTransactionSyncService.collectAndSync("11110", "201512", "APT");
+        rentTransactionSyncService.collectAndSync("11110", "201512", HousingType.APT);
         Integer first = jdbc.queryForObject(
             "SELECT COUNT(*) FROM rent_transaction WHERE region_code = ? AND deal_ym = ? AND housing_type = ?",
             Integer.class, "11110", "201512", "APT"
         );
 
-        rentTransactionSyncService.collectAndSync("11110", "201512", "APT");
+        rentTransactionSyncService.collectAndSync("11110", "201512", HousingType.APT);
         Integer second = jdbc.queryForObject(
             "SELECT COUNT(*) FROM rent_transaction WHERE region_code = ? AND deal_ym = ? AND housing_type = ?",
             Integer.class, "11110", "201512", "APT"


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #7 

## 📝작업 내용

- HousingType(APT/ROW_HOUSE/OFFICETEL/DETACHED), DealType(JEONSE/WOLSE) 추가
- RentTransaction, RentSyncLog, Mapper, Sync 서비스 시그니처를 enum으로 통일
- API_URLS 맵 키를 HousingType으로 바꿔 유효하지 않은 유형이 컴파일 단계에서 걸리도록 함
- deal_type 값을 '전세'/'월세' → JEONSE/WOLSE 로 변경 (MyBatis 기본 EnumTypeHandler가 상수명 저장)
- monthlyRent 파싱을 long으로 앞당겨 문자열 "0" 비교 제거