### PR TITLE
feat: 은행 계좌 동기화 및 자산 요약 조회 구현

### DIFF
--- a/sql/full_schema.sql
+++ b/sql/full_schema.sql
@@ -210,6 +210,7 @@ CREATE TABLE connected_account (
     id                BIGINT       NOT NULL AUTO_INCREMENT,
     member_id         BIGINT       NOT NULL COMMENT '회원 FK(1:1)',
     connected_id      VARCHAR(512) NOT NULL COMMENT 'CODEF Connected ID(암호화 필수)',
+    birth_date        VARCHAR(6)   NULL     COMMENT '생년월일 YYMMDD (계좌 조회 API 재사용)',
     connected_status  VARCHAR(20)  NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/EXPIRED/REVOKED',
     last_synced_at    DATETIME     NULL     COMMENT '마지막 동기화 성공 시각(최초 등록 시 NULL)',
     sync_status       VARCHAR(20)  NULL     COMMENT 'SUCCESS/FAILED/IN_PROGRESS',

--- a/src/main/java/com/team/independence/asset/controller/AssetController.java
+++ b/src/main/java/com/team/independence/asset/controller/AssetController.java
@@ -2,6 +2,8 @@ package com.team.independence.asset.controller;
 
 import com.team.independence.asset.dto.*;
 import com.team.independence.asset.service.AssetService;
+import com.team.independence.asset.service.AssetSummaryService;
+import com.team.independence.asset.service.AssetSyncService;
 import com.team.independence.asset.service.InstitutionService;
 import com.team.independence.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,8 @@ import java.util.List;
 public class AssetController {
 
     private final AssetService assetService;
+    private final AssetSyncService assetSyncService;
+    private final AssetSummaryService assetSummaryService;
     private final InstitutionService institutionService;
 
     @PostMapping("/link")
@@ -33,6 +37,16 @@ public class AssetController {
     public ApiResponse<List<LinkedOrganizationResponse>> getConnections(
             @RequestParam Long memberId) {
         return ApiResponse.ok(assetService.getConnections(memberId));
+    }
+
+    @PostMapping("/sync")
+    public ApiResponse<AssetSyncResponse> syncAccounts(@RequestParam Long memberId) {
+        return ApiResponse.ok(assetSyncService.syncAccounts(memberId));
+    }
+
+    @GetMapping("/summary/{memberId}")
+    public ApiResponse<AssetSummaryResponse> getSummary(@PathVariable Long memberId) {
+        return ApiResponse.ok(assetSummaryService.getSummary(memberId));
     }
 
     @DeleteMapping("/connections/organizations/{organizationCode}")

--- a/src/main/java/com/team/independence/asset/domain/AssetAccount.java
+++ b/src/main/java/com/team/independence/asset/domain/AssetAccount.java
@@ -1,0 +1,29 @@
+package com.team.independence.asset.domain;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AssetAccount {
+    private Long id;
+    private Long connectedInstitutionId;
+    private String accountType;  // DEMAND / DEPOSIT / SAVINGS / SUBSCRIPTION / FUND / STOCK
+    private String assetCategory;  // CASH / DEPOSIT_SAVINGS / INVESTMENT / SUBSCRIPTION / ETC
+    private String accountDisplay;  // 표시용 계좌번호
+    private String productName;  // 계좌명/상품명
+    private Long currentValue;  // 현재가치 (NULL = 기준가 미공시)
+    private Long valuationAmount;  // 증권 평가금액
+    private Long depositReceived;  // 예수금
+    private BigDecimal earningsRate;  // 수익률 (%)
+    private LocalDate maturityDate;  // 만기일
+    private String rawResponse;  // CODEF 원본 응답 (JSON)
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/team/independence/asset/domain/AssetSummary.java
+++ b/src/main/java/com/team/independence/asset/domain/AssetSummary.java
@@ -1,0 +1,21 @@
+package com.team.independence.asset.domain;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AssetSummary {
+    private Long id;
+    private Long memberId;
+    private Long totalAssets;
+    private Long loanBalance;
+    private Long monthlySavings;
+    private LocalDateTime syncedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/team/independence/asset/domain/ConnectedAccount.java
+++ b/src/main/java/com/team/independence/asset/domain/ConnectedAccount.java
@@ -13,6 +13,7 @@ public class ConnectedAccount {
     private Long id;
     private Long memberId;
     private String connectedId;  // AES 암호화된 Connected ID
+    private String birthDate;  // 생년월일 YYMMDD (계좌 조회 API 재사용)
     private String connectedStatus;  // ACTIVE / EXPIRED / REVOKED
     private LocalDateTime lastSyncedAt;
     private String syncStatus;  // SUCCESS / FAILED / IN_PROGRESS

--- a/src/main/java/com/team/independence/asset/domain/LoanAccount.java
+++ b/src/main/java/com/team/independence/asset/domain/LoanAccount.java
@@ -1,0 +1,21 @@
+package com.team.independence.asset.domain;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoanAccount {
+    private Long id;
+    private Long connectedInstitutionId;
+    private String loanName;  // 대출 상품명
+    private String accountDisplay;  // 표시용 계좌번호
+    private Long loanBalance;  // 대출 잔액
+    private String rawResponse;  // CODEF 원본 응답 (JSON)
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/team/independence/asset/dto/AssetAccountQueryItem.java
+++ b/src/main/java/com/team/independence/asset/dto/AssetAccountQueryItem.java
@@ -1,0 +1,18 @@
+package com.team.independence.asset.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AssetAccountQueryItem {
+    private Long id;
+    private String institutionName;
+    private String accountType;
+    private String assetCategory;
+    private String productName;
+    private String accountDisplay;
+    private Long currentValue;
+}

--- a/src/main/java/com/team/independence/asset/dto/AssetSummaryResponse.java
+++ b/src/main/java/com/team/independence/asset/dto/AssetSummaryResponse.java
@@ -1,0 +1,53 @@
+package com.team.independence.asset.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class AssetSummaryResponse {
+    private Long memberId;
+    private Long totalAssets;
+    private Long loanBalance;
+    private Long netAssets;
+    private Long monthlySavings;
+    private LocalDateTime syncedAt;
+    private AssetBreakdown assetBreakdown;
+    private List<LoanItem> loans;
+
+    @Getter
+    @Builder
+    public static class AssetBreakdown {
+        private AssetGroup cashAssets;
+        private AssetGroup investmentAssets;
+    }
+
+    @Getter
+    @Builder
+    public static class AssetGroup {
+        private Long total;
+        private List<AccountItem> accounts;
+    }
+
+    @Getter
+    @Builder
+    public static class AccountItem {
+        private String institutionName;
+        private String accountType;
+        private String productName;
+        private String accountDisplay;
+        private Long balance;
+    }
+
+    @Getter
+    @Builder
+    public static class LoanItem {
+        private String institutionName;
+        private String loanName;
+        private String accountDisplay;
+        private Long loanBalance;
+    }
+}

--- a/src/main/java/com/team/independence/asset/dto/AssetSyncResponse.java
+++ b/src/main/java/com/team/independence/asset/dto/AssetSyncResponse.java
@@ -1,0 +1,26 @@
+package com.team.independence.asset.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AssetSyncResponse {
+    private int syncedCount;
+    private int failedCount;
+    private List<InstitutionSyncResult> institutions;
+
+    @Getter
+    @Builder
+    public static class InstitutionSyncResult {
+        private String organizationCode;
+        private String organizationName;
+        private boolean success;
+        private int assetAccountCount;
+        private int loanAccountCount;
+        private String errorCode;
+        private String errorMessage;
+    }
+}

--- a/src/main/java/com/team/independence/asset/dto/LoanAccountQueryItem.java
+++ b/src/main/java/com/team/independence/asset/dto/LoanAccountQueryItem.java
@@ -1,0 +1,16 @@
+package com.team.independence.asset.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class LoanAccountQueryItem {
+    private Long id;
+    private String institutionName;
+    private String loanName;
+    private String accountDisplay;
+    private Long loanBalance;
+}

--- a/src/main/java/com/team/independence/asset/mapper/AssetAccountMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/AssetAccountMapper.java
@@ -1,0 +1,18 @@
+package com.team.independence.asset.mapper;
+
+import com.team.independence.asset.domain.AssetAccount;
+import com.team.independence.asset.dto.AssetAccountQueryItem;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface AssetAccountMapper {
+    void insert(AssetAccount assetAccount);
+    void insertAll(@Param("list") List<AssetAccount> list);
+    void deleteByConnectedInstitutionId(Long connectedInstitutionId);
+    List<AssetAccount> findByConnectedInstitutionId(Long connectedInstitutionId);
+    List<AssetAccountQueryItem> findWithInstitutionByMemberId(Long memberId);
+    Long sumCurrentValueByMemberId(Long memberId);
+}

--- a/src/main/java/com/team/independence/asset/mapper/AssetSummaryMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/AssetSummaryMapper.java
@@ -1,0 +1,10 @@
+package com.team.independence.asset.mapper;
+
+import com.team.independence.asset.domain.AssetSummary;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface AssetSummaryMapper {
+    AssetSummary findByMemberId(Long memberId);
+    void upsert(AssetSummary assetSummary);
+}

--- a/src/main/java/com/team/independence/asset/mapper/ConnectedAccountMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/ConnectedAccountMapper.java
@@ -7,5 +7,6 @@ import org.apache.ibatis.annotations.Mapper;
 public interface ConnectedAccountMapper {
     ConnectedAccount findByMemberId(Long memberId);
     void insert(ConnectedAccount connectedAccount);
+    void updateSyncStatus(ConnectedAccount connectedAccount);
     void deleteById(Long id);
 }

--- a/src/main/java/com/team/independence/asset/mapper/ConnectedInstitutionMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/ConnectedInstitutionMapper.java
@@ -10,8 +10,10 @@ import java.util.List;
 @Mapper
 public interface ConnectedInstitutionMapper {
     void insert(ConnectedInstitution connectedInstitution);
+    List<ConnectedInstitution> findAllByConnectedAccountId(Long connectedAccountId);
     List<LinkedOrganizationResponse> findAllWithOrganizationByConnectedAccountId(Long connectedAccountId);
     ConnectedInstitution findByConnectedAccountIdAndInstitutionCode(@Param("connectedAccountId") Long connectedAccountId, @Param("institutionCode") String institutionCode);
     void deleteByConnectedAccountIdAndInstitutionCode(@Param("connectedAccountId") Long connectedAccountId, @Param("institutionCode") String institutionCode);
     int countByConnectedAccountId(Long connectedAccountId);
+    void updateSyncResult(ConnectedInstitution connectedInstitution);
 }

--- a/src/main/java/com/team/independence/asset/mapper/LoanAccountMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/LoanAccountMapper.java
@@ -1,0 +1,18 @@
+package com.team.independence.asset.mapper;
+
+import com.team.independence.asset.domain.LoanAccount;
+import com.team.independence.asset.dto.LoanAccountQueryItem;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface LoanAccountMapper {
+    void insert(LoanAccount loanAccount);
+    void insertAll(@Param("list") List<LoanAccount> list);
+    void deleteByConnectedInstitutionId(Long connectedInstitutionId);
+    List<LoanAccount> findByConnectedInstitutionId(Long connectedInstitutionId);
+    List<LoanAccountQueryItem> findWithInstitutionByMemberId(Long memberId);
+    Long sumLoanBalanceByMemberId(Long memberId);
+}

--- a/src/main/java/com/team/independence/asset/service/AssetServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetServiceImpl.java
@@ -98,6 +98,7 @@ public class AssetServiceImpl implements AssetService {
         ConnectedAccount account = ConnectedAccount.builder()
                 .memberId(memberId)
                 .connectedId(aesEncryptor.encrypt(connectedId))
+                .birthDate(request.getBirthDate())
                 .build();
         connectedAccountMapper.insert(account);
 

--- a/src/main/java/com/team/independence/asset/service/AssetSummaryService.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSummaryService.java
@@ -1,0 +1,7 @@
+package com.team.independence.asset.service;
+
+import com.team.independence.asset.dto.AssetSummaryResponse;
+
+public interface AssetSummaryService {
+    AssetSummaryResponse getSummary(Long memberId);
+}

--- a/src/main/java/com/team/independence/asset/service/AssetSummaryServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSummaryServiceImpl.java
@@ -1,0 +1,113 @@
+package com.team.independence.asset.service;
+
+import com.team.independence.asset.domain.AssetSummary;
+import com.team.independence.asset.dto.AssetAccountQueryItem;
+import com.team.independence.asset.dto.AssetSummaryResponse;
+import com.team.independence.asset.dto.AssetSummaryResponse.*;
+import com.team.independence.asset.dto.LoanAccountQueryItem;
+import com.team.independence.asset.mapper.AssetAccountMapper;
+import com.team.independence.asset.mapper.AssetSummaryMapper;
+import com.team.independence.asset.mapper.LoanAccountMapper;
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AssetSummaryServiceImpl implements AssetSummaryService {
+
+    private final AssetSummaryMapper assetSummaryMapper;
+    private final AssetAccountMapper assetAccountMapper;
+    private final LoanAccountMapper loanAccountMapper;
+
+    @Override
+    public AssetSummaryResponse getSummary(Long memberId) {
+        AssetSummary summary = assetSummaryMapper.findByMemberId(memberId);
+        if (summary == null) {
+            throw new BusinessException(ErrorCode.ASSET_SUMMARY_NOT_FOUND);
+        }
+
+        List<AssetAccountQueryItem> accounts = assetAccountMapper.findWithInstitutionByMemberId(memberId);
+        List<LoanAccountQueryItem> loans = loanAccountMapper.findWithInstitutionByMemberId(memberId);
+
+        List<AccountItem> cashList = new ArrayList<>();
+        List<AccountItem> investmentList = new ArrayList<>();
+        long cashTotal = 0L;
+        long investmentTotal = 0L;
+
+        for (AssetAccountQueryItem account : accounts) {
+            long balance = account.getCurrentValue() != null ? account.getCurrentValue() : 0L;
+            AccountItem item = AccountItem.builder()
+                    .institutionName(account.getInstitutionName())
+                    .accountType(toResponseAccountType(account.getAccountType()))
+                    .productName(account.getProductName())
+                    .accountDisplay(account.getAccountDisplay())
+                    .balance(balance)
+                    .build();
+
+            String category = account.getAssetCategory();
+            if ("INVESTMENT".equals(category)) {
+                investmentList.add(item);
+                investmentTotal += balance;
+            } else {
+                // CASH, DEPOSIT_SAVINGS, SUBSCRIPTION 모두 현금성 자산
+                cashList.add(item);
+                cashTotal += balance;
+            }
+        }
+
+        List<LoanItem> loanItems = new ArrayList<>();
+        for (LoanAccountQueryItem loan : loans) {
+            loanItems.add(LoanItem.builder()
+                    .institutionName(loan.getInstitutionName())
+                    .loanName(loan.getLoanName())
+                    .accountDisplay(loan.getAccountDisplay())
+                    .loanBalance(loan.getLoanBalance())
+                    .build());
+        }
+
+        long totalAssets = summary.getTotalAssets();
+        long loanBalance = summary.getLoanBalance();
+
+        return AssetSummaryResponse.builder()
+                .memberId(memberId)
+                .totalAssets(totalAssets)
+                .loanBalance(loanBalance)
+                .netAssets(totalAssets - loanBalance)
+                .monthlySavings(summary.getMonthlySavings())
+                .syncedAt(summary.getSyncedAt())
+                .assetBreakdown(AssetBreakdown.builder()
+                        .cashAssets(AssetGroup.builder()
+                                .total(cashTotal)
+                                .accounts(cashList)
+                                .build())
+                        .investmentAssets(AssetGroup.builder()
+                                .total(investmentTotal)
+                                .accounts(investmentList)
+                                .build())
+                        .build())
+                .loans(loanItems)
+                .build();
+    }
+
+    /**
+     * 내부 account_type → API 응답 accountType
+     * DEMAND(입출금), DEPOSIT(정기예금) → DEPOSIT
+     * SAVINGS(적금), SUBSCRIPTION(청약) → SAVINGS
+     */
+    private String toResponseAccountType(String accountType) {
+        switch (accountType) {
+            case "DEMAND":
+            case "DEPOSIT": return "DEPOSIT";
+            case "SAVINGS":
+            case "SUBSCRIPTION": return "SAVINGS";
+            case "FUND": return "FUND";
+            case "STOCK": return "STOCK";
+            default: return accountType;
+        }
+    }
+}

--- a/src/main/java/com/team/independence/asset/service/AssetSyncService.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncService.java
@@ -1,0 +1,7 @@
+package com.team.independence.asset.service;
+
+import com.team.independence.asset.dto.AssetSyncResponse;
+
+public interface AssetSyncService {
+    AssetSyncResponse syncAccounts(Long memberId);
+}

--- a/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
@@ -1,0 +1,285 @@
+package com.team.independence.asset.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.independence.asset.domain.AssetAccount;
+import com.team.independence.asset.domain.ConnectedAccount;
+import com.team.independence.asset.domain.ConnectedInstitution;
+import com.team.independence.asset.domain.LoanAccount;
+import com.team.independence.asset.dto.AssetSyncResponse;
+import com.team.independence.asset.dto.AssetSyncResponse.InstitutionSyncResult;
+import com.team.independence.asset.domain.AssetSummary;
+import com.team.independence.asset.mapper.AssetAccountMapper;
+import com.team.independence.asset.mapper.AssetSummaryMapper;
+import com.team.independence.asset.mapper.ConnectedAccountMapper;
+import com.team.independence.asset.mapper.ConnectedInstitutionMapper;
+import com.team.independence.asset.mapper.InstitutionMapper;
+import com.team.independence.asset.domain.Institution;
+import com.team.independence.asset.mapper.LoanAccountMapper;
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.common.security.AesEncryptor;
+import com.team.independence.external.codef.CodefClient;
+import com.team.independence.external.codef.CodefTokenManager;
+import com.team.independence.external.codef.dto.CodefBankAccountResponse;
+import com.team.independence.external.codef.dto.CodefBankAccountResponse.CodefDepositItem;
+import com.team.independence.external.codef.dto.CodefBankAccountResponse.CodefLoanItem;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AssetSyncServiceImpl implements AssetSyncService {
+
+    private final ConnectedAccountMapper connectedAccountMapper;
+    private final ConnectedInstitutionMapper connectedInstitutionMapper;
+    private final InstitutionMapper institutionMapper;
+    private final AssetAccountMapper assetAccountMapper;
+    private final LoanAccountMapper loanAccountMapper;
+    private final AssetSummaryMapper assetSummaryMapper;
+    private final CodefClient codefClient;
+    private final CodefTokenManager codefTokenManager;
+    private final AesEncryptor aesEncryptor;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @Transactional
+    public AssetSyncResponse syncAccounts(Long memberId) {
+        ConnectedAccount connectedAccount = connectedAccountMapper.findByMemberId(memberId);
+        if (connectedAccount == null) {
+            throw new BusinessException(ErrorCode.ASSET_NOT_LINKED);
+        }
+
+        String connectedId = aesEncryptor.decrypt(connectedAccount.getConnectedId());
+        String birthDate = connectedAccount.getBirthDate();
+        String accessToken = codefTokenManager.getAccessToken();
+
+        List<ConnectedInstitution> institutions =
+                connectedInstitutionMapper.findAllByConnectedAccountId(connectedAccount.getId());
+
+        List<InstitutionSyncResult> results = new ArrayList<>();
+        int syncedCount = 0;
+        int failedCount = 0;
+
+        for (ConnectedInstitution institution : institutions) {
+            InstitutionSyncResult result = syncInstitution(
+                    institution, connectedId, birthDate, accessToken);
+            results.add(result);
+            if (result.isSuccess()) syncedCount++;
+            else failedCount++;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        connectedAccount.setSyncStatus(failedCount == 0 ? "SUCCESS" : syncedCount > 0 ? "PARTIAL" : "FAILED");
+        connectedAccount.setLastSyncedAt(now);
+        connectedAccountMapper.updateSyncStatus(connectedAccount);
+
+        // 자산 합계 캐시 갱신
+        Long totalAssets = assetAccountMapper.sumCurrentValueByMemberId(memberId);
+        Long loanBalance = loanAccountMapper.sumLoanBalanceByMemberId(memberId);
+        assetSummaryMapper.upsert(AssetSummary.builder()
+                .memberId(memberId)
+                .totalAssets(totalAssets != null ? totalAssets : 0L)
+                .loanBalance(loanBalance != null ? loanBalance : 0L)
+                .syncedAt(now)
+                .build());
+
+        return AssetSyncResponse.builder()
+                .syncedCount(syncedCount)
+                .failedCount(failedCount)
+                .institutions(results)
+                .build();
+    }
+
+    private InstitutionSyncResult syncInstitution(ConnectedInstitution institution,
+                                                   String connectedId,
+                                                   String birthDate,
+                                                   String accessToken) {
+        String institutionCode = institution.getInstitutionCode();
+        Institution institutionInfo = institutionMapper.findByCode(institutionCode);
+        String orgName = institutionInfo != null ? institutionInfo.getName() : institutionCode;
+
+        try {
+            CodefBankAccountResponse response =
+                    codefClient.getBankAccountList(accessToken, connectedId, institutionCode, birthDate);
+
+            if (!response.isSuccess()) {
+                return recordFailure(institution, orgName,
+                        response.getResultCode(), response.getResultMessage());
+            }
+
+            CodefBankAccountResponse.CodefBankData data = response.getData();
+            List<AssetAccount> assetAccounts = parseAssetAccounts(institution.getId(), data);
+            List<LoanAccount> loanAccounts = parseLoanAccounts(institution.getId(), data);
+
+            // 동기화: 기존 계좌 전체 삭제 후 재적재
+            assetAccountMapper.deleteByConnectedInstitutionId(institution.getId());
+            loanAccountMapper.deleteByConnectedInstitutionId(institution.getId());
+
+            if (!assetAccounts.isEmpty()) {
+                assetAccountMapper.insertAll(assetAccounts);
+            }
+            if (!loanAccounts.isEmpty()) {
+                loanAccountMapper.insertAll(loanAccounts);
+            }
+
+            institution.setStatus("ACTIVE");
+            institution.setLastSyncedAt(LocalDateTime.now());
+            institution.setLastAttemptedAt(LocalDateTime.now());
+            institution.setLastErrorCode(null);
+            institution.setLastErrorMessage(null);
+            connectedInstitutionMapper.updateSyncResult(institution);
+
+            log.info("계좌 동기화 완료: org={}, 자산계좌={}, 대출계좌={}",
+                    institutionCode, assetAccounts.size(), loanAccounts.size());
+
+            return InstitutionSyncResult.builder()
+                    .organizationCode(institutionCode)
+                    .organizationName(orgName)
+                    .success(true)
+                    .assetAccountCount(assetAccounts.size())
+                    .loanAccountCount(loanAccounts.size())
+                    .build();
+
+        } catch (Exception e) {
+            log.error("계좌 동기화 실패: org={}", institutionCode, e);
+            return recordFailure(institution, orgName, "SYNC_ERROR", e.getMessage());
+        }
+    }
+
+    private List<AssetAccount> parseAssetAccounts(Long connectedInstitutionId,
+                                                   CodefBankAccountResponse.CodefBankData data) {
+        List<AssetAccount> accounts = new ArrayList<>();
+
+        for (CodefDepositItem item : data.getResDepositTrust()) {
+            if (isExcluded(item)) continue;
+
+            String accountType = classifyDepositType(item);
+            String assetCategory = toAssetCategory(accountType);
+            Long balance = parseAmount(item.getResAccountBalance());
+
+            accounts.add(AssetAccount.builder()
+                    .connectedInstitutionId(connectedInstitutionId)
+                    .accountType(accountType)
+                    .assetCategory(assetCategory)
+                    .accountDisplay(item.getResAccountDisplay())
+                    .productName(item.getResAccountName())
+                    .currentValue(balance)
+                    .rawResponse(toJson(item))
+                    .build());
+        }
+
+        for (CodefBankAccountResponse.CodefFundItem item : data.getResFund()) {
+            Long balance = parseAmount(item.getResAccountBalance());
+            accounts.add(AssetAccount.builder()
+                    .connectedInstitutionId(connectedInstitutionId)
+                    .accountType("FUND")
+                    .assetCategory("INVESTMENT")
+                    .accountDisplay(item.getResAccountDisplay())
+                    .productName(item.getResAccountName())
+                    .currentValue(balance)
+                    .rawResponse(toJson(item))
+                    .build());
+        }
+
+        return accounts;
+    }
+
+    private List<LoanAccount> parseLoanAccounts(Long connectedInstitutionId,
+                                                 CodefBankAccountResponse.CodefBankData data) {
+        List<LoanAccount> loans = new ArrayList<>();
+
+        for (CodefLoanItem item : data.getResLoan()) {
+            Long balance = parseAmount(item.getResLoanBalance());
+            loans.add(LoanAccount.builder()
+                    .connectedInstitutionId(connectedInstitutionId)
+                    .loanName(item.getResAccountName())
+                    .accountDisplay(item.getResAccountDisplay())
+                    .loanBalance(balance != null ? balance : 0L)
+                    .rawResponse(toJson(item))
+                    .build());
+        }
+
+        return loans;
+    }
+
+    /**
+     * 마이너스통장 또는 외화 계좌는 제외
+     */
+    private boolean isExcluded(CodefDepositItem item) {
+        if ("1".equals(item.getResOverdraftAcctYN())) return true;
+        if (item.getResAccountCurrency() != null && !"KRW".equals(item.getResAccountCurrency())) return true;
+        return false;
+    }
+
+    /**
+     * resAccountDeposit 코드 → 계좌 유형
+     * 12코드(적금, 청약 혼용)는 상품명으로 구분
+     * 주택청약종합저축은 법적으로 정해진 단일 상품명이므로 안전한 판별 기준
+     */
+    private String classifyDepositType(CodefDepositItem item) {
+        String depositCode = item.getResAccountDeposit();
+        if ("11".equals(depositCode)) return "DEMAND";
+        if ("13".equals(depositCode)) return "DEPOSIT";
+        if ("12".equals(depositCode)) {
+            String name = item.getResAccountName();
+            if (name != null && name.contains("청약")) return "SUBSCRIPTION";
+            return "SAVINGS";
+        }
+        return "DEPOSIT";
+    }
+
+    private String toAssetCategory(String accountType) {
+        switch (accountType) {
+            case "DEMAND": return "CASH";
+            case "SUBSCRIPTION": return "SUBSCRIPTION";
+            case "FUND":
+            case "STOCK": return "INVESTMENT";
+            default: return "DEPOSIT_SAVINGS";
+        }
+    }
+
+    private Long parseAmount(String value) {
+        if (value == null || value.isBlank()) return null;
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            log.warn("금액 파싱 실패: '{}'", value);
+            return null;
+        }
+    }
+
+    private String toJson(Object obj) {
+        try {
+            return objectMapper.writeValueAsString(obj);
+        } catch (JsonProcessingException e) {
+            return "{}";
+        }
+    }
+
+    private InstitutionSyncResult recordFailure(ConnectedInstitution institution,
+                                                 String orgName,
+                                                 String errorCode,
+                                                 String errorMessage) {
+        institution.setStatus("ERROR");
+        institution.setLastAttemptedAt(LocalDateTime.now());
+        institution.setLastErrorCode(errorCode);
+        institution.setLastErrorMessage(errorMessage);
+        connectedInstitutionMapper.updateSyncResult(institution);
+
+        return InstitutionSyncResult.builder()
+                .organizationCode(institution.getInstitutionCode())
+                .organizationName(orgName)
+                .success(false)
+                .errorCode(errorCode)
+                .errorMessage(errorMessage)
+                .build();
+    }
+}

--- a/src/main/java/com/team/independence/common/exception/ErrorCode.java
+++ b/src/main/java/com/team/independence/common/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     ASSET_RSA_ENCRYPT_FAILED("ASSET_003", "비밀번호 암호화에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ASSET_CODEF_API_ERROR("ASSET_004", "금융 연동 서버 오류가 발생했습니다.", HttpStatus.BAD_GATEWAY),
     ASSET_ORGANIZATION_NOT_CONNECTED("ASSET_005", "연동되지 않은 기관입니다.", HttpStatus.NOT_FOUND),
+    ASSET_SUMMARY_NOT_FOUND("ASSET_006", "자산 연동 정보가 없습니다. 먼저 금융기관을 연동해주세요.", HttpStatus.NOT_FOUND),
 
     // ===== 목표 GOAL_xxx =====
     GOAL_NOT_FOUND("GOAL_001", "목표를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/team/independence/external/codef/CodefClient.java
+++ b/src/main/java/com/team/independence/external/codef/CodefClient.java
@@ -5,6 +5,8 @@ import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.external.codef.dto.CodefAccountRequest;
 import com.team.independence.external.codef.dto.CodefApiResponse;
+import com.team.independence.external.codef.dto.CodefBankAccountResponse;
+import com.team.independence.external.codef.dto.CodefBankInquiryRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
@@ -27,6 +29,7 @@ public class CodefClient {
     private static final String CREATE_PATH = "/v1/account/create";
     private static final String ADD_PATH = "/v1/account/add";
     private static final String DELETE_PATH = "/v1/account/delete";
+    private static final String BANK_ACCOUNT_LIST_PATH = "/v1/kr/bank/p/account/account-list";
 
     private final CodefProperties properties;
     private final RestTemplate restTemplate;
@@ -45,6 +48,42 @@ public class CodefClient {
                 .accountList(List.of(item))
                 .build();
         return call(accessToken, ADD_PATH, body);
+    }
+
+    public CodefBankAccountResponse getBankAccountList(String accessToken, String connectedId,
+                                                       String organization, String birthDate) {
+        CodefBankInquiryRequest body = CodefBankInquiryRequest.builder()
+                .connectedId(connectedId)
+                .organization(organization)
+                .birthDate(birthDate)
+                .build();
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(accessToken);
+
+            HttpEntity<CodefBankInquiryRequest> request = new HttpEntity<>(body, headers);
+
+            log.debug("CODEF 계좌조회 요청: org={}, connectedId={}...",
+                    organization, connectedId.substring(0, Math.min(8, connectedId.length())));
+
+            ResponseEntity<String> response = restTemplate.exchange(
+                    properties.getApiDomain() + BANK_ACCOUNT_LIST_PATH,
+                    HttpMethod.POST,
+                    request,
+                    String.class
+            );
+
+            log.debug("CODEF 계좌조회 원본 응답: {}", response.getBody());
+            String decoded = URLDecoder.decode(response.getBody(), StandardCharsets.UTF_8);
+            CodefBankAccountResponse result = objectMapper.readValue(decoded, CodefBankAccountResponse.class);
+            log.debug("CODEF 계좌조회 결과: code={}", result.getResultCode());
+            return result;
+
+        } catch (Exception e) {
+            log.error("CODEF 계좌조회 실패: org={}", organization, e);
+            throw new BusinessException(ErrorCode.ASSET_CODEF_API_ERROR);
+        }
     }
 
     public CodefApiResponse deleteAccount(String accessToken, String connectedId, CodefAccountRequest.CodefAccountItem item) {

--- a/src/main/java/com/team/independence/external/codef/dto/CodefBankAccountResponse.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefBankAccountResponse.java
@@ -1,0 +1,106 @@
+package com.team.independence.external.codef.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CodefBankAccountResponse {
+
+    private CodefResult result;
+    private CodefBankData data;
+    private String connectedId;
+
+    public boolean isSuccess() {
+        return result != null && "CF-00000".equals(result.getCode());
+    }
+
+    public String getResultCode() {
+        return result != null ? result.getCode() : null;
+    }
+
+    public String getResultMessage() {
+        return result != null ? result.getMessage() : null;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CodefResult {
+        private String code;
+        private String message;
+        private String transactionId;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CodefBankData {
+        private List<CodefDepositItem> resDepositTrust;
+        private List<CodefFundItem> resFund;
+        private List<CodefLoanItem> resLoan;
+
+        public List<CodefDepositItem> getResDepositTrust() {
+            return resDepositTrust != null ? resDepositTrust : Collections.emptyList();
+        }
+
+        public List<CodefFundItem> getResFund() {
+            return resFund != null ? resFund : Collections.emptyList();
+        }
+
+        public List<CodefLoanItem> getResLoan() {
+            return resLoan != null ? resLoan : Collections.emptyList();
+        }
+    }
+
+    /**
+     * resAccountDeposit: 11=입출금, 12=적금·청약(혼용), 13=정기예금
+     * resOverdraftAcctYN: 1이면 마이너스통장 → 제외
+     */
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CodefDepositItem {
+        private String resAccount;
+        private String resAccountDisplay;
+        private String resAccountBalance;
+        private String resAccountDeposit;
+        private String resAccountName;
+        private String resAccountCurrency;
+        private String resLastTranDate;
+        private String resOverdraftAcctYN;
+        private String resAccountStartDate;
+        private String resAccountEndDate;
+        private String resLoanKind;
+        private String resLoanBalance;
+        private String resLoanStartDate;
+        private String resLoanEndDate;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CodefFundItem {
+        private String resAccount;
+        private String resAccountDisplay;
+        private String resAccountBalance;
+        private String resAccountName;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CodefLoanItem {
+        private String resAccount;
+        private String resAccountDisplay;
+        private String resAccountName;
+        private String resLoanBalance;
+        private String resLoanStartDate;
+        private String resLoanEndDate;
+    }
+}

--- a/src/main/java/com/team/independence/external/codef/dto/CodefBankInquiryRequest.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefBankInquiryRequest.java
@@ -1,0 +1,20 @@
+package com.team.independence.external.codef.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CodefBankInquiryRequest {
+    private String organization;
+    private String connectedId;
+    private String birthDate;
+    @Builder.Default
+    private String withdrawAccountNo = "";
+    @Builder.Default
+    private String withdrawAccountPassword = "";
+}

--- a/src/main/resources/mybatis/mapper/asset/AssetAccountMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/AssetAccountMapper.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.team.independence.asset.mapper.AssetAccountMapper">
+
+    <resultMap id="assetAccountMap" type="com.team.independence.asset.domain.AssetAccount">
+        <id     property="id"                       column="id"/>
+        <result property="connectedInstitutionId"   column="connected_institution_id"/>
+        <result property="accountType"              column="account_type"/>
+        <result property="assetCategory"            column="asset_category"/>
+        <result property="accountDisplay"           column="account_display"/>
+        <result property="productName"              column="product_name"/>
+        <result property="currentValue"             column="current_value"/>
+        <result property="valuationAmount"          column="valuation_amount"/>
+        <result property="depositReceived"          column="deposit_received"/>
+        <result property="earningsRate"             column="earnings_rate"/>
+        <result property="maturityDate"             column="maturity_date"/>
+        <result property="rawResponse"              column="raw_response"/>
+        <result property="createdAt"                column="created_at"/>
+        <result property="updatedAt"                column="updated_at"/>
+    </resultMap>
+
+    <insert id="insert" parameterType="com.team.independence.asset.domain.AssetAccount"
+            useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO asset_account
+            (connected_institution_id, account_type, asset_category,
+             account_display, product_name, current_value, raw_response)
+        VALUES
+            (#{connectedInstitutionId}, #{accountType}, #{assetCategory},
+             #{accountDisplay}, #{productName}, #{currentValue}, #{rawResponse})
+    </insert>
+
+    <insert id="insertAll">
+        INSERT INTO asset_account
+            (connected_institution_id, account_type, asset_category,
+             account_display, product_name, current_value, raw_response)
+        VALUES
+        <foreach collection="list" item="a" separator=",">
+            (#{a.connectedInstitutionId}, #{a.accountType}, #{a.assetCategory},
+             #{a.accountDisplay}, #{a.productName}, #{a.currentValue}, #{a.rawResponse})
+        </foreach>
+    </insert>
+
+    <delete id="deleteByConnectedInstitutionId" parameterType="long">
+        DELETE FROM asset_account WHERE connected_institution_id = #{connectedInstitutionId}
+    </delete>
+
+    <select id="findByConnectedInstitutionId" parameterType="long" resultMap="assetAccountMap">
+        SELECT id, connected_institution_id, account_type, asset_category,
+               account_display, product_name, current_value, valuation_amount,
+               deposit_received, earnings_rate, maturity_date, raw_response,
+               created_at, updated_at
+          FROM asset_account
+         WHERE connected_institution_id = #{connectedInstitutionId}
+    </select>
+
+    <resultMap id="assetAccountQueryMap" type="com.team.independence.asset.dto.AssetAccountQueryItem">
+        <result property="id"              column="id"/>
+        <result property="institutionName" column="institution_name"/>
+        <result property="accountType"     column="account_type"/>
+        <result property="assetCategory"   column="asset_category"/>
+        <result property="productName"     column="product_name"/>
+        <result property="accountDisplay"  column="account_display"/>
+        <result property="currentValue"    column="current_value"/>
+    </resultMap>
+
+    <select id="findWithInstitutionByMemberId" parameterType="long" resultMap="assetAccountQueryMap">
+        SELECT aa.id, i.name AS institution_name,
+               aa.account_type, aa.asset_category, aa.product_name,
+               aa.account_display, aa.current_value
+          FROM asset_account aa
+          JOIN connected_institution ci ON aa.connected_institution_id = ci.id
+          JOIN connected_account ca ON ci.connected_account_id = ca.id
+          JOIN institution i ON ci.institution_code = i.code
+         WHERE ca.member_id = #{memberId}
+         ORDER BY aa.asset_category, i.name
+    </select>
+
+    <select id="sumCurrentValueByMemberId" parameterType="long" resultType="java.lang.Long">
+        SELECT COALESCE(SUM(aa.current_value), 0)
+          FROM asset_account aa
+          JOIN connected_institution ci ON aa.connected_institution_id = ci.id
+          JOIN connected_account ca ON ci.connected_account_id = ca.id
+         WHERE ca.member_id = #{memberId}
+    </select>
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/asset/AssetSummaryMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/AssetSummaryMapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.team.independence.asset.mapper.AssetSummaryMapper">
+
+    <resultMap id="assetSummaryMap" type="com.team.independence.asset.domain.AssetSummary">
+        <id     property="id"             column="id"/>
+        <result property="memberId"       column="member_id"/>
+        <result property="totalAssets"    column="total_assets"/>
+        <result property="loanBalance"    column="loan_balance"/>
+        <result property="monthlySavings" column="monthly_savings"/>
+        <result property="syncedAt"       column="synced_at"/>
+        <result property="createdAt"      column="created_at"/>
+        <result property="updatedAt"      column="updated_at"/>
+    </resultMap>
+
+    <select id="findByMemberId" parameterType="long" resultMap="assetSummaryMap">
+        SELECT id, member_id, total_assets, loan_balance, monthly_savings,
+               synced_at, created_at, updated_at
+          FROM asset_summary
+         WHERE member_id = #{memberId}
+    </select>
+
+    <insert id="upsert" parameterType="com.team.independence.asset.domain.AssetSummary">
+        INSERT INTO asset_summary (member_id, total_assets, loan_balance, synced_at)
+        VALUES (#{memberId}, #{totalAssets}, #{loanBalance}, #{syncedAt})
+        ON DUPLICATE KEY UPDATE
+            total_assets = VALUES(total_assets),
+            loan_balance = VALUES(loan_balance),
+            synced_at    = VALUES(synced_at)
+    </insert>
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/asset/ConnectedAccountMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/ConnectedAccountMapper.xml
@@ -8,6 +8,7 @@
         <id     property="id"              column="id"/>
         <result property="memberId"        column="member_id"/>
         <result property="connectedId"     column="connected_id"/>
+        <result property="birthDate"       column="birth_date"/>
         <result property="connectedStatus" column="connected_status"/>
         <result property="lastSyncedAt"    column="last_synced_at"/>
         <result property="syncStatus"      column="sync_status"/>
@@ -16,7 +17,7 @@
     </resultMap>
 
     <select id="findByMemberId" parameterType="long" resultMap="connectedAccountMap">
-        SELECT id, member_id, connected_id, connected_status,
+        SELECT id, member_id, connected_id, birth_date, connected_status,
                last_synced_at, sync_status, created_at, updated_at
           FROM connected_account
          WHERE member_id = #{memberId}
@@ -24,9 +25,16 @@
 
     <insert id="insert" parameterType="com.team.independence.asset.domain.ConnectedAccount"
             useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO connected_account (member_id, connected_id, connected_status)
-        VALUES (#{memberId}, #{connectedId}, 'ACTIVE')
+        INSERT INTO connected_account (member_id, connected_id, birth_date, connected_status)
+        VALUES (#{memberId}, #{connectedId}, #{birthDate}, 'ACTIVE')
     </insert>
+
+    <update id="updateSyncStatus" parameterType="com.team.independence.asset.domain.ConnectedAccount">
+        UPDATE connected_account
+           SET sync_status    = #{syncStatus},
+               last_synced_at = #{lastSyncedAt}
+         WHERE id = #{id}
+    </update>
 
     <delete id="deleteById" parameterType="long">
         DELETE FROM connected_account WHERE id = #{id}

--- a/src/main/resources/mybatis/mapper/asset/ConnectedInstitutionMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/ConnectedInstitutionMapper.xml
@@ -24,6 +24,25 @@
         <result property="connectedAt"      column="created_at"/>
     </resultMap>
 
+    <select id="findAllByConnectedAccountId" parameterType="long" resultMap="connectedInstitutionMap">
+        SELECT id, connected_account_id, institution_code, status,
+               last_synced_at, last_error_code, last_error_message,
+               last_attempted_at, created_at, updated_at
+          FROM connected_institution
+         WHERE connected_account_id = #{connectedAccountId}
+         ORDER BY created_at
+    </select>
+
+    <update id="updateSyncResult" parameterType="com.team.independence.asset.domain.ConnectedInstitution">
+        UPDATE connected_institution
+           SET status              = #{status},
+               last_synced_at      = #{lastSyncedAt},
+               last_error_code     = #{lastErrorCode},
+               last_error_message  = #{lastErrorMessage},
+               last_attempted_at   = #{lastAttemptedAt}
+         WHERE id = #{id}
+    </update>
+
     <insert id="insert" parameterType="com.team.independence.asset.domain.ConnectedInstitution">
         INSERT INTO connected_institution (connected_account_id, institution_code, status)
         VALUES (#{connectedAccountId}, #{institutionCode}, 'ACTIVE')

--- a/src/main/resources/mybatis/mapper/asset/LoanAccountMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/LoanAccountMapper.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.team.independence.asset.mapper.LoanAccountMapper">
+
+    <resultMap id="loanAccountMap" type="com.team.independence.asset.domain.LoanAccount">
+        <id     property="id"                       column="id"/>
+        <result property="connectedInstitutionId"   column="connected_institution_id"/>
+        <result property="loanName"                 column="loan_name"/>
+        <result property="accountDisplay"           column="account_display"/>
+        <result property="loanBalance"              column="loan_balance"/>
+        <result property="rawResponse"              column="raw_response"/>
+        <result property="createdAt"                column="created_at"/>
+        <result property="updatedAt"                column="updated_at"/>
+    </resultMap>
+
+    <insert id="insert" parameterType="com.team.independence.asset.domain.LoanAccount"
+            useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO loan_account
+            (connected_institution_id, loan_name, account_display, loan_balance, raw_response)
+        VALUES
+            (#{connectedInstitutionId}, #{loanName}, #{accountDisplay}, #{loanBalance}, #{rawResponse})
+    </insert>
+
+    <insert id="insertAll">
+        INSERT INTO loan_account
+            (connected_institution_id, loan_name, account_display, loan_balance, raw_response)
+        VALUES
+        <foreach collection="list" item="l" separator=",">
+            (#{l.connectedInstitutionId}, #{l.loanName}, #{l.accountDisplay}, #{l.loanBalance}, #{l.rawResponse})
+        </foreach>
+    </insert>
+
+    <delete id="deleteByConnectedInstitutionId" parameterType="long">
+        DELETE FROM loan_account WHERE connected_institution_id = #{connectedInstitutionId}
+    </delete>
+
+    <select id="findByConnectedInstitutionId" parameterType="long" resultMap="loanAccountMap">
+        SELECT id, connected_institution_id, loan_name, account_display,
+               loan_balance, raw_response, created_at, updated_at
+          FROM loan_account
+         WHERE connected_institution_id = #{connectedInstitutionId}
+    </select>
+
+    <resultMap id="loanAccountQueryMap" type="com.team.independence.asset.dto.LoanAccountQueryItem">
+        <result property="id"              column="id"/>
+        <result property="institutionName" column="institution_name"/>
+        <result property="loanName"        column="loan_name"/>
+        <result property="accountDisplay"  column="account_display"/>
+        <result property="loanBalance"     column="loan_balance"/>
+    </resultMap>
+
+    <select id="findWithInstitutionByMemberId" parameterType="long" resultMap="loanAccountQueryMap">
+        SELECT la.id, i.name AS institution_name,
+               la.loan_name, la.account_display, la.loan_balance
+          FROM loan_account la
+          JOIN connected_institution ci ON la.connected_institution_id = ci.id
+          JOIN connected_account ca ON ci.connected_account_id = ca.id
+          JOIN institution i ON ci.institution_code = i.code
+         WHERE ca.member_id = #{memberId}
+         ORDER BY i.name
+    </select>
+
+    <select id="sumLoanBalanceByMemberId" parameterType="long" resultType="java.lang.Long">
+        SELECT COALESCE(SUM(la.loan_balance), 0)
+          FROM loan_account la
+          JOIN connected_institution ci ON la.connected_institution_id = ci.id
+          JOIN connected_account ca ON ci.connected_account_id = ca.id
+         WHERE ca.member_id = #{memberId}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #10 

## 📝 작업 내용

CODEF Connected ID를 통해 연동된 은행 계좌를 동기화하고, 동기화된 자산 데이터를 기반으로 자산 요약 정보를 조회하는 API를 구현했습니다. 

### 1. DB 스키마 변경
- `connected_account` 테이블에 `birth_date VARCHAR(6)` 컬럼 추가
- CODEF 계좌 조회 API 시 우리 서비스는 매 요청마다 생년월일(YYMMDD)을 입력 받기로 해서, 기관 연동 시점에 수집한 값을 저장하여 동기화 시 재사용 하도록 처리했습니다.

### 2. CODEF 은행 계좌 조회 클라이언트
- 엔드포인트: POST `/v1/kr/bank/p/account/account-list`
- 요청: `organization`, `connectedId`, `birthDate`
- 응답 구조 파악 (실제 Postman 테스트 기반):
  - `resDepositTrust[]`: 입출금/예적금/청약
  - `resFund[]`: 펀드 (기준가 미공시 시 balance 빈 문자열)
  - `resLoan[]`: 대출
  - `resForeignCurrency[]`, `resInsurance[]`: 제외 대상

### 3. 계좌 수동 동기화
- 엔드포인트: POST `/api/v1/assets/sync`

**계좌 유형 분류 기준 (`resAccountDeposit` 코드)**

  | 코드 | 조건 | account_type | asset_category |
  |------|------|-------------|----------------|
  | 11 | — | DEMAND (입출금) | CASH |
  | 12 | 상품명에 "청약" 포함 | SUBSCRIPTION (청약) | SUBSCRIPTION |
  | 12 | 그 외 | SAVINGS (적금) | DEPOSIT_SAVINGS |
  | 13 | — | DEPOSIT (정기예금) | DEPOSIT_SAVINGS |
  | — | resFund | FUND (펀드) | INVESTMENT |

**제외 대상**
- `resOverdraftAcctYN = "1"` → 마이너스통장
- `resAccountCurrency ≠ "KRW"` → 외화 계좌

**동기화 방식**
- 기존 `asset_account` / `loan_account` 전체 삭제 후 재적재
- CODEF 응답에 없는 계좌는 자동 제거
- 기관별 성공/실패를 `connected_institution.status` / `last_error_code` / `last_error_message`에 기록
- 전체 동기화 완료 후 `connected_account.sync_status` 업데이트 (`SUCCESS` / `PARTIAL` / `FAILED`)
- 동기화 완료 시 `asset_summary` UPSERT (총자산/대출잔액 갱신)

**응답 예시**
```json
{
  "success": true,
  "data": {
    "syncedCount": 1,
    "failedCount": 0,
    "institutions": [
      {
        "organizationCode": "0020",
        "organizationName": "우리은행",
        "success": true,
        "assetAccountCount": 2,
        "loanAccountCount": 0
      }
    ]
  }
}
```

### 4. 자산 요약 조회
- 엔드포인트: GET `/api/v1/assets/summary/{memberId}`

`asset_summary` 캐시에서 합계를 읽고, `asset_account` / `loan_account`를 `institution`과 JOIN하여 계좌 목록을 포함한 요약을 반환합니다.

- `netAssets` = `totalAssets` − `loanBalance` (서버 계산, DB 미저장)
- `cashAssets` = CASH / DEPOSIT_SAVINGS / SUBSCRIPTION 카테고리 계좌
- `investmentAssets` = INVESTMENT 카테고리 계좌 (펀드/주식)
- 연동 이력 없을 경우 ASSET_006 ASSET_SUMMARY_NOT_FOUND 반환

**응답 예시**

```json
{
  "success": true,
  "data": {
    "memberId": 1,
    "totalAssets": 7000000,
    "loanBalance": 0,
    "netAssets": 7000000,
    "monthlySavings": 0,
    "assetBreakdown": {
      "cashAssets": { 
        "total": 7000000,
        "accounts": [
          {
            "institutionName": "우리은행",
            "accountType": "DEPOSIT",
            "productName": "우리SUPER주거래통장",
            "accountDisplay": "0000-000-000000",
            "balance": 2000000
          },
          {
            "institutionName": "우리은행",
            "accountType": "SAVINGS",
            "productName": "주택청약종합저축",
            "accountDisplay": "0000-000-000000",
            "balance": 5000000
          } 
        ] 
      },
      "investmentAssets": {
        "total": 0,
        "accounts": []
      } 
    },
    "loans": []
  }
}
```



### 📸 스크린샷
**<자산 동기화 요청 및 응답>**
<img width="1118" height="629" alt="스크린샷 2026-07-30 오후 3 21 10" src="https://github.com/user-attachments/assets/297b77d0-33be-46a0-aaed-2dd98d2a30d0" />

&nbsp;

**<자산 요약 요청 및 응답>**
<img width="1116" height="825" alt="스크린샷 2026-07-30 오후 3 39 38" src="https://github.com/user-attachments/assets/f5a15732-94ea-4ab2-8f02-e7bd62678f4c" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?