### PR TITLE
feat: 실거래 매물 중앙값 조회 구현

### DIFF
--- a/src/main/java/com/team/independence/common/exception/ErrorCode.java
+++ b/src/main/java/com/team/independence/common/exception/ErrorCode.java
@@ -38,7 +38,10 @@ public enum ErrorCode {
     GOAL_NOT_FOUND("GOAL_001", "목표를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // ===== 정책 POLICY_xxx =====
-    POLICY_NOT_FOUND("POLICY_001", "정책을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    POLICY_NOT_FOUND("POLICY_001", "정책을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    // ===== 부동산 PROPERTY_xxx =====
+    REGION_NOT_FOUND("PROPERTY_001", "존재하지 않는 지역 코드입니다.", HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/team/independence/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/team/independence/common/exception/GlobalExceptionHandler.java
@@ -3,9 +3,13 @@ package com.team.independence.common.exception;
 import com.team.independence.common.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 /**
  * 전역 예외 처리. 모든 예외를 ApiResponse 포맷으로 변환한다.
@@ -33,11 +37,52 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(ErrorCode.INVALID_INPUT, message));
     }
 
+    /**
+     * 쿼리 파라미터를 객체로 받을 때(@ModelAttribute)의 바인딩·검증 실패.
+     * 위 MethodArgumentNotValidException이 더 구체적인 타입이므로 @RequestBody 경로는 그쪽이 처리한다.
+     */
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBind(BindException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(this::describe)
+                .orElse(ErrorCode.INVALID_INPUT.getMessage());
+        return badRequest(message);
+    }
+
+    /** 단일 파라미터(@RequestParam / @PathVariable) 타입 변환 실패. 정의되지 않은 enum 값 등 */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        return badRequest(e.getName() + ": 허용되지 않은 값입니다. (" + e.getValue() + ")");
+    }
+
+    /** 필수 쿼리 파라미터 누락 */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMissingParam(MissingServletRequestParameterException e) {
+        return badRequest(e.getParameterName() + ": 필수 파라미터입니다.");
+    }
+
     /** 예상치 못한 예외 */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleUnexpected(Exception e) {
         log.error("Unexpected error", e);
         return ResponseEntity.status(ErrorCode.INTERNAL_ERROR.getStatus())
                 .body(ApiResponse.fail(ErrorCode.INTERNAL_ERROR));
+    }
+
+    /**
+     * 타입 변환 실패의 기본 메시지("Failed to convert property value of type...")는
+     * 내부 타입명이 드러나 그대로 노출할 수 없어 따로 문구를 만든다.
+     */
+    private String describe(FieldError err) {
+        if ("typeMismatch".equals(err.getCode())) {
+            return err.getField() + ": 허용되지 않은 값입니다. (" + err.getRejectedValue() + ")";
+        }
+        return err.getField() + ": " + err.getDefaultMessage();
+    }
+
+    private ResponseEntity<ApiResponse<Void>> badRequest(String message) {
+        return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(ApiResponse.fail(ErrorCode.INVALID_INPUT, message));
     }
 }

--- a/src/main/java/com/team/independence/property/controller/PropertyController.java
+++ b/src/main/java/com/team/independence/property/controller/PropertyController.java
@@ -1,0 +1,31 @@
+package com.team.independence.property.controller;
+
+import com.team.independence.common.response.ApiResponse;
+import com.team.independence.property.dto.RentMedianRequest;
+import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.service.RentMedianService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/properties")
+@RequiredArgsConstructor
+public class   PropertyController {
+
+    private final RentMedianService rentMedianService;
+
+    /**
+     * 실거래 매물 중앙값 조회.
+     *
+     * <p>조건을 @ModelAttribute로 묶어 받으므로 타입 변환 실패·필수값 누락·min&gt;max가
+     * 모두 BindException 하나로 모여 컨트롤러 진입 전에 400으로 떨어진다.
+     */
+    @GetMapping("/median")
+    public ApiResponse<RentMedianResponse> getMedian(@Valid @ModelAttribute RentMedianRequest request) {
+        return ApiResponse.ok(rentMedianService.getMedian(request));
+    }
+}

--- a/src/main/java/com/team/independence/property/dto/RentMedianAmount.java
+++ b/src/main/java/com/team/independence/property/dto/RentMedianAmount.java
@@ -1,0 +1,23 @@
+package com.team.independence.property.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 중앙값 집계에 필요한 금액 두 개만 담는 조회 결과.
+ *
+ * <p>분위값은 보증금·월세를 각각 따로 정렬해야 나오므로 집계된 값이 아니라 원본 행을 받아온다.
+ * RentTransaction 전체를 읽으면 원본 JSON 컬럼까지 딸려 오기 때문에 별도 프로젝션을 둔다.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class RentMedianAmount {
+
+    /** 보증금(원) */
+    private long deposit;
+
+    /** 월세(원). 전세 거래는 0 */
+    private long monthlyRent;
+}

--- a/src/main/java/com/team/independence/property/dto/RentMedianRequest.java
+++ b/src/main/java/com/team/independence/property/dto/RentMedianRequest.java
@@ -1,0 +1,88 @@
+package com.team.independence.property.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 실거래 매물 중앙값 조회 조건.
+ *
+ * <p>쿼리 파라미터를 @ModelAttribute로 받으므로 기본 생성자와 setter가 필요하다.
+ * (응답 DTO의 @Builder 패턴과 다른 이유)
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class RentMedianRequest {
+
+    /** 지역 코드(법정동코드 앞 5자리) */
+    @NotBlank(message = "지역 코드는 필수입니다.")
+    private String regionCode;
+
+    /** 주거 형태 */
+    @NotNull(message = "주거 형태는 필수입니다.")
+    private HousingType housingType;
+
+    /** 거래 유형 */
+    @NotNull(message = "거래 유형은 필수입니다.")
+    private DealType dealType;
+
+    /** 희망 최소 평수(평) */
+    @NotNull(message = "최소 평수는 필수입니다.")
+    @Positive(message = "최소 평수는 0보다 커야 합니다.")
+    private Integer areaMin;
+
+    /** 희망 최대 평수(평) */
+    @NotNull(message = "최대 평수는 필수입니다.")
+    @Positive(message = "최대 평수는 0보다 커야 합니다.")
+    private Integer areaMax;
+
+    /** 희망 최소 보증금(원) */
+    @NotNull(message = "최소 보증금은 필수입니다.")
+    @PositiveOrZero(message = "최소 보증금은 0 이상이어야 합니다.")
+    private Long depositMin;
+
+    /** 희망 최대 보증금(원) */
+    @NotNull(message = "최대 보증금은 필수입니다.")
+    @PositiveOrZero(message = "최대 보증금은 0 이상이어야 합니다.")
+    private Long depositMax;
+
+    /** 희망 최소 월세(원). dealType=WOLSE 일 때만 사용 */
+    @PositiveOrZero(message = "최소 월세는 0 이상이어야 합니다.")
+    private Long monthlyRentMin;
+
+    /** 희망 최대 월세(원). dealType=WOLSE 일 때만 사용 */
+    @PositiveOrZero(message = "최대 월세는 0 이상이어야 합니다.")
+    private Long monthlyRentMax;
+
+    /**
+     * min/max 교차 검증은 개별 필드 제약으로 표현할 수 없어 @AssertTrue로 처리한다.
+     * null 검사는 @NotNull이 이미 하므로 여기서는 통과시켜 에러 메시지가 중복되지 않게 한다.
+     */
+    @AssertTrue(message = "최소 평수는 최대 평수보다 클 수 없습니다.")
+    public boolean isAreaRangeValid() {
+        return areaMin == null || areaMax == null || areaMin <= areaMax;
+    }
+
+    @AssertTrue(message = "최소 보증금은 최대 보증금보다 클 수 없습니다.")
+    public boolean isDepositRangeValid() {
+        return depositMin == null || depositMax == null || depositMin <= depositMax;
+    }
+
+    @AssertTrue(message = "최소 월세는 최대 월세보다 클 수 없습니다.")
+    public boolean isMonthlyRentRangeValid() {
+        return monthlyRentMin == null || monthlyRentMax == null || monthlyRentMin <= monthlyRentMax;
+    }
+
+    /** 월세 조건은 월세 거래에만 의미가 있다. 전세 조회 시 들어온 값은 무시한다. */
+    public boolean usesMonthlyRentFilter() {
+        return dealType == DealType.WOLSE;
+    }
+}

--- a/src/main/java/com/team/independence/property/dto/RentMedianResponse.java
+++ b/src/main/java/com/team/independence/property/dto/RentMedianResponse.java
@@ -1,0 +1,76 @@
+package com.team.independence.property.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 조건에 부합하는 최근 6개월 실거래의 보증금·월세 4분위값.
+ *
+ * <p>표본이 적은 조건(단독다가구·비수도권 등)에서는 sampleCount가 한 자릿수까지 떨어질 수 있어,
+ * 프론트가 신뢰도를 함께 노출하도록 건수를 그대로 내려준다.
+ */
+@Getter
+@Builder
+public class RentMedianResponse {
+
+    /** 지역 코드 */
+    private final String regionCode;
+
+    /** 지역 전체 지명 */
+    private final String regionName;
+
+    /** 주거 형태 */
+    private final HousingType housingType;
+
+    /** 거래 유형 */
+    private final DealType dealType;
+
+    /** 집계 시작 연월 (YYYYMM) */
+    private final String baseStartYm;
+
+    /** 집계 종료 연월 (YYYYMM) */
+    private final String baseEndYm;
+
+    /** 집계에 사용된 실거래 건수 */
+    private final int sampleCount;
+
+    /** 보증금 분위값. 표본이 없으면(sampleCount=0) 세 값 모두 null */
+    private final Quartile deposit;
+
+    /** 월세 분위값. 전세 조회이거나 표본이 없으면 세 값 모두 null */
+    private final Quartile monthlyRent;
+
+    /**
+     * 4분위값 묶음. 객체 자체는 항상 존재하고 값만 null이 될 수 있다.
+     * 프론트가 deposit/monthlyRent를 null 체크 없이 타고 들어갈 수 있도록 한 계약이다.
+     */
+    @Getter
+    public static class Quartile {
+
+        /** 25% 분위값 (원) */
+        private final Long q1;
+
+        /** 중앙값 (원) */
+        private final Long median;
+
+        /** 75% 분위값 (원) */
+        private final Long q3;
+
+        private Quartile(Long q1, Long median, Long q3) {
+            this.q1 = q1;
+            this.median = median;
+            this.q3 = q3;
+        }
+
+        public static Quartile of(long q1, long median, long q3) {
+            return new Quartile(q1, median, q3);
+        }
+
+        /** 집계 대상이 없거나(표본 0건) 해당 지표를 쓰지 않는 경우(전세의 월세) */
+        public static Quartile empty() {
+            return new Quartile(null, null, null);
+        }
+    }
+}

--- a/src/main/java/com/team/independence/property/mapper/RegionMapper.java
+++ b/src/main/java/com/team/independence/property/mapper/RegionMapper.java
@@ -2,8 +2,15 @@ package com.team.independence.property.mapper;
 
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface RegionMapper {
     List<String> findAllCodes();
+
+    /**
+     * 지역 코드의 전체 지명을 조회한다.
+     * 존재하지 않는 코드면 null을 반환하므로, 코드 유효성 검증도 이 메서드로 겸한다.
+     */
+    String findFullNameByCode(@Param("code") String code);
 }

--- a/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
+++ b/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
@@ -2,6 +2,8 @@ package com.team.independence.property.mapper;
 
 import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.domain.RentTransaction;
+import com.team.independence.property.dto.RentMedianAmount;
+import com.team.independence.property.dto.RentMedianRequest;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -15,4 +17,17 @@ public interface RentTransactionMapper {
     int deleteByUnit(@Param("regionCode") String regionCode,
                      @Param("dealYm") String dealYm,
                      @Param("housingType") HousingType housingType);
+
+    /**
+     * 분위값 계산용 금액 목록. 조건에 맞는 거래가 없으면 빈 리스트를 반환한다.
+     * 정렬은 보증금·월세를 각각 따로 해야 하므로 SQL에서 하지 않는다.
+     *
+     * @param areaMinSqm 요청의 평수를 ㎡로 환산한 하한 (버림)
+     * @param areaMaxSqm 요청의 평수를 ㎡로 환산한 상한 (버림)
+     */
+    List<RentMedianAmount> findAmountsForMedian(@Param("request") RentMedianRequest request,
+                                                @Param("areaMinSqm") long areaMinSqm,
+                                                @Param("areaMaxSqm") long areaMaxSqm,
+                                                @Param("startYm") String startYm,
+                                                @Param("endYm") String endYm);
 }

--- a/src/main/java/com/team/independence/property/service/RentMedianService.java
+++ b/src/main/java/com/team/independence/property/service/RentMedianService.java
@@ -1,0 +1,14 @@
+package com.team.independence.property.service;
+
+import com.team.independence.property.dto.RentMedianRequest;
+import com.team.independence.property.dto.RentMedianResponse;
+
+public interface RentMedianService {
+
+    /**
+     * 조건에 부합하는 최근 6개월 실거래의 보증금·월세 4분위값을 조회한다.
+     *
+     * @throws com.team.independence.common.exception.BusinessException 지역 코드가 존재하지 않으면
+     */
+    RentMedianResponse getMedian(RentMedianRequest request);
+}

--- a/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
@@ -1,0 +1,95 @@
+package com.team.independence.property.service;
+
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.property.dto.RentMedianAmount;
+import com.team.independence.property.dto.RentMedianRequest;
+import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.dto.RentMedianResponse.Quartile;
+import com.team.independence.property.mapper.RegionMapper;
+import com.team.independence.property.mapper.RentTransactionMapper;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.function.ToLongFunction;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RentMedianServiceImpl implements RentMedianService {
+
+    /** 집계 구간 길이. 조회 시점 월을 포함해 6개월 */
+    private static final int MONTHS = 6;
+
+    /** 평 → ㎡ 환산 계수 (1평 = 3.305785㎡) */
+    private static final double PYEONG_TO_SQM = 3.305785;
+
+    private static final DateTimeFormatter YM = DateTimeFormatter.ofPattern("yyyyMM");
+
+    private final RegionMapper regionMapper;
+    private final RentTransactionMapper rentTransactionMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public RentMedianResponse getMedian(RentMedianRequest request) {
+        // full_name은 NOT NULL이므로 null이면 그 지역 코드가 없다는 뜻이다.
+        String regionName = regionMapper.findFullNameByCode(request.getRegionCode());
+        if (regionName == null) {
+            throw new BusinessException(ErrorCode.REGION_NOT_FOUND);
+        }
+
+        YearMonth end = YearMonth.now();
+        YearMonth start = end.minusMonths(MONTHS - 1);
+        String startYm = start.format(YM);
+        String endYm = end.format(YM);
+
+        List<RentMedianAmount> amounts = rentTransactionMapper.findAmountsForMedian(
+                request,
+                toSqm(request.getAreaMin()),
+                toSqm(request.getAreaMax()),
+                startYm,
+                endYm);
+
+        return RentMedianResponse.builder()
+                .regionCode(request.getRegionCode())
+                .regionName(regionName)
+                .housingType(request.getHousingType())
+                .dealType(request.getDealType())
+                .baseStartYm(startYm)
+                .baseEndYm(endYm)
+                .sampleCount(amounts.size())
+                .deposit(quartile(amounts, RentMedianAmount::getDeposit))
+                // 전세는 월세가 0으로 적재되어 분위값이 전부 0이 되므로 계산하지 않는다.
+                .monthlyRent(request.usesMonthlyRentFilter()
+                        ? quartile(amounts, RentMedianAmount::getMonthlyRent)
+                        : Quartile.empty())
+                .build();
+    }
+
+    /** 평수를 ㎡로 환산한다. 양쪽 모두 버림이라 하한은 넓어지고 상한은 좁아지는데, 명세서가 정한 규칙이다. */
+    private long toSqm(int pyeong) {
+        return (long) Math.floor(pyeong * PYEONG_TO_SQM);
+    }
+
+    private Quartile quartile(List<RentMedianAmount> amounts, ToLongFunction<RentMedianAmount> amount) {
+        if (amounts.isEmpty()) {
+            return Quartile.empty();
+        }
+        long[] sorted = amounts.stream().mapToLong(amount).sorted().toArray();
+        return Quartile.of(
+                percentile(sorted, 0.25),
+                percentile(sorted, 0.50),
+                percentile(sorted, 0.75));
+    }
+
+    /**
+     * nearest-rank 방식. 보간하지 않으므로 결과가 항상 실제 거래 금액이고,
+     * 표본이 한 자릿수인 조건(단독다가구·비수도권)에서도 값이 왜곡되지 않는다.
+     */
+    private long percentile(long[] sorted, double ratio) {
+        int index = (int) Math.ceil(ratio * sorted.length) - 1;
+        return sorted[Math.max(index, 0)];
+    }
+}

--- a/src/main/resources/mybatis/mapper/property/RegionMapper.xml
+++ b/src/main/resources/mybatis/mapper/property/RegionMapper.xml
@@ -8,4 +8,10 @@
         SELECT code FROM region
     </select>
 
+    <select id="findFullNameByCode" resultType="string">
+        SELECT full_name
+          FROM region
+         WHERE code = #{code}
+    </select>
+
 </mapper>

--- a/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
+++ b/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
@@ -40,4 +40,24 @@
            AND housing_type = #{housingType}
     </delete>
 
+    <!-- 분위값 계산용 금액 조회. 집계는 애플리케이션에서 하므로 원본 금액만 뽑는다.
+         deposit = 0 은 보증금 없이 기록된 이상치라 집계에서 제외한다. -->
+    <select id="findAmountsForMedian" resultType="com.team.independence.property.dto.RentMedianAmount">
+        SELECT deposit, monthly_rent
+          FROM rent_transaction
+         WHERE region_code = #{request.regionCode}
+           AND housing_type = #{request.housingType}
+           AND deal_type = #{request.dealType}
+           AND deal_ym BETWEEN #{startYm} AND #{endYm}
+           AND area BETWEEN #{areaMinSqm} AND #{areaMaxSqm}
+           AND deposit BETWEEN #{request.depositMin} AND #{request.depositMax}
+           AND deposit &gt; 0
+        <if test="request.usesMonthlyRentFilter() and request.monthlyRentMin != null">
+           AND monthly_rent &gt;= #{request.monthlyRentMin}
+        </if>
+        <if test="request.usesMonthlyRentFilter() and request.monthlyRentMax != null">
+           AND monthly_rent &lt;= #{request.monthlyRentMax}
+        </if>
+    </select>
+
 </mapper>

--- a/src/test/java/com/team/independence/property/service/RentMedianIntegrationTest.java
+++ b/src/test/java/com/team/independence/property/service/RentMedianIntegrationTest.java
@@ -1,0 +1,150 @@
+package com.team.independence.property.service;
+
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.config.RootConfig;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.RentMedianAmount;
+import com.team.independence.property.dto.RentMedianRequest;
+import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.mapper.RentTransactionMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 중앙값 조회의 MyBatis 바인딩과 응답 조립을 실제 DB로 확인하는 통합 테스트.
+ * RentTransactionSyncServiceIntegrationTest와 같은 유닛(11110/201512/APT)을 적재해두고 조회한다.
+ *
+ * <p>사전 조건: docker compose up -d, 환경변수 MOLIT_SERVICE_KEY
+ */
+@Disabled("실제 DB와 국토부 API가 필요해 로컬에서만 실행")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = RootConfig.class)
+class RentMedianIntegrationTest {
+
+    private static final String REGION_CODE = "11110";
+    private static final String DEAL_YM = "201512";
+
+    /** 평수·보증금·월세를 사실상 무제한으로 두어 지역·유형·기간만으로 조회한다. */
+    private static final long AREA_MIN_SQM = 0L;
+    private static final long AREA_MAX_SQM = 999_999L;
+    private static final long DEPOSIT_MIN = 0L;
+    private static final long DEPOSIT_MAX = 999_999_999_999L;
+    private static final long MONTHLY_RENT_MIN = 0L;
+    private static final long MONTHLY_RENT_MAX = 999_999_999L;
+
+    @Autowired
+    private RentTransactionSyncService rentTransactionSyncService;
+
+    @Autowired
+    private RentTransactionMapper rentTransactionMapper;
+
+    @Autowired
+    private RentMedianService rentMedianService;
+
+    @BeforeEach
+    void 조회할_데이터_적재() {
+        rentTransactionSyncService.collectAndSync(REGION_CODE, DEAL_YM, HousingType.APT);
+    }
+
+    /**
+     * 서비스는 집계 구간을 "최근 6개월"로 고정하므로 2015년 데이터로는 검증할 수 없다.
+     * 매퍼를 직접 불러 구간을 201512로 지정한다.
+     */
+    @Test
+    void 전세_금액_조회() {
+        List<RentMedianAmount> amounts = rentTransactionMapper.findAmountsForMedian(
+                request(DealType.JEONSE, null, null),
+                AREA_MIN_SQM, AREA_MAX_SQM, DEAL_YM, DEAL_YM);
+
+        System.out.println("전세 조회 건수: " + amounts.size());
+        assertFalse(amounts.isEmpty(), "전세 실거래가 조회되지 않았습니다.");
+        assertAll(
+                () -> assertTrue(amounts.stream().allMatch(a -> a.getDeposit() > 0),
+                        "deposit > 0 필터가 동작하지 않았습니다."),
+                () -> assertTrue(amounts.stream().allMatch(a -> a.getMonthlyRent() == 0),
+                        "전세인데 월세가 0이 아닌 행이 있습니다."));
+    }
+
+    /** 월세 조건 <if> 분기와 monthly_rent → monthlyRent 매핑을 함께 확인한다. */
+    @Test
+    void 월세_금액_조회() {
+        List<RentMedianAmount> amounts = rentTransactionMapper.findAmountsForMedian(
+                request(DealType.WOLSE, MONTHLY_RENT_MIN, MONTHLY_RENT_MAX),
+                AREA_MIN_SQM, AREA_MAX_SQM, DEAL_YM, DEAL_YM);
+
+        System.out.println("월세 조회 건수: " + amounts.size());
+        assertFalse(amounts.isEmpty(), "월세 실거래가 조회되지 않았습니다.");
+        assertTrue(amounts.stream().allMatch(a -> a.getMonthlyRent() > 0),
+                "월세 거래인데 monthly_rent가 0인 행이 있습니다. 매핑이나 필터를 확인하세요.");
+    }
+
+    /** 없는 지역 코드는 조회 전에 PROPERTY_001로 끊긴다. */
+    @Test
+    void 존재하지_않는_지역코드() {
+        RentMedianRequest request = request(DealType.JEONSE, null, null);
+        request.setRegionCode("00000");
+
+        BusinessException e = assertThrows(BusinessException.class,
+                () -> rentMedianService.getMedian(request));
+        assertEquals(ErrorCode.REGION_NOT_FOUND, e.getErrorCode());
+    }
+
+    /**
+     * 서비스 전체 경로. 집계 구간이 최근 6개월이라 2015년 데이터는 잡히지 않으므로
+     * 건수는 단정하지 않고, 응답 조립과 표본 0건 처리만 확인한다.
+     */
+    @Test
+    void 서비스_응답_조립() {
+        RentMedianResponse response = rentMedianService.getMedian(request(DealType.JEONSE, null, null));
+
+        System.out.println("최근 6개월 표본: " + response.getSampleCount()
+                + " (" + response.getBaseStartYm() + " ~ " + response.getBaseEndYm() + ")");
+
+        assertAll(
+                () -> assertEquals(REGION_CODE, response.getRegionCode()),
+                () -> assertNotNull(response.getRegionName(), "region.full_name이 조회되지 않았습니다."),
+                () -> assertEquals(6, monthSpan(response), "집계 구간이 6개월이 아닙니다."),
+                // 전세 조회라 월세 분위값은 계산하지 않는다.
+                () -> assertNull(response.getMonthlyRent().getMedian()),
+                () -> assertEquals(response.getSampleCount() == 0,
+                        response.getDeposit().getMedian() == null,
+                        "표본 유무와 보증금 분위값의 null 여부가 어긋납니다."));
+    }
+
+    private RentMedianRequest request(DealType dealType, Long monthlyRentMin, Long monthlyRentMax) {
+        RentMedianRequest request = new RentMedianRequest();
+        request.setRegionCode(REGION_CODE);
+        request.setHousingType(HousingType.APT);
+        request.setDealType(dealType);
+        request.setAreaMin(1);
+        request.setAreaMax(10_000);
+        request.setDepositMin(DEPOSIT_MIN);
+        request.setDepositMax(DEPOSIT_MAX);
+        request.setMonthlyRentMin(monthlyRentMin);
+        request.setMonthlyRentMax(monthlyRentMax);
+        return request;
+    }
+
+    /** baseStartYm ~ baseEndYm이 몇 개 월을 덮는지 (양끝 포함) */
+    private int monthSpan(RentMedianResponse response) {
+        int start = Integer.parseInt(response.getBaseStartYm());
+        int end = Integer.parseInt(response.getBaseEndYm());
+        return (end / 100 * 12 + end % 100) - (start / 100 * 12 + start % 100) + 1;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #9 

## 📝작업 내용

실거래 매물 중앙값 조회 API를 구현했습니다.

```
GET /api/v1/properties/median
```

조건(지역·주거형태·거래유형·평수·보증금·월세)에 부합하는 최근 6개월 실거래를 필터링해 보증금과 월세의 4분위값(25% / 50% / 75%)을 반환합니다. 주거 목표 생성의 `targetRentMiddleAmount` 산출과 목표 상세의 시세 비교 기준으로 사용됩니다.

---

### 커밋 1. `fix: 쿼리 파라미터 바인딩 실패가 500으로 응답되는 문제`

쿼리 파라미터 검증 실패가 `GlobalExceptionHandler`의 catch-all(`Exception`)에 걸려 500으로 나가던 문제를 고쳤습니다. 핸들러 3개를 추가해 400 + `COMMON_001`로 변환합니다.

| Exception | 잡는 상황 |
|---|---|
| `BindException` | `@ModelAttribute` 바인딩·검증 실패 (필수값 누락, 잘못된 enum 값, min > max) |
| `MethodArgumentTypeMismatchException` | `@RequestParam` / `@PathVariable` 타입 변환 실패 |
| `MissingServletRequestParameterException` | 필수 `@RequestParam` 누락 |

### 커밋 2. `feat: 실거래 매물 중앙값 조회 API 추가`

아래 응답과 레이어 흐름으로 기능을 구현했습니다.

---

## 📮응답 예시

### 월세 조회 — 표본 있음

```
GET /api/v1/properties/median?regionCode=11680&housingType=APT&dealType=WOLSE
    &areaMin=10&areaMax=25&depositMin=10000000&depositMax=100000000
    &monthlyRentMin=300000&monthlyRentMax=1500000
```

```json
{
  "success": true,
  "data": {
    "regionCode": "11680",
    "regionName": "서울특별시 강남구",
    "housingType": "APT",
    "dealType": "WOLSE",
    "baseStartYm": "202602",
    "baseEndYm": "202607",
    "sampleCount": 47,
    "deposit": {
      "q1": 30000000,
      "median": 50000000,
      "q3": 80000000
    },
    "monthlyRent": {
      "q1": 700000,
      "median": 900000,
      "q3": 1200000
    }
  },
  "error": null
}
```

### 전세 조회 — 월세 분위값은 계산하지 않음

전세는 `monthly_rent`가 0으로 적재되어 분위값이 전부 0이 나옵니다. 0은 "월세 0원"으로 읽혀 "해당 없음"과 구분되지 않으므로 `null`로 내려보냅니다.

```json
{
  "success": true,
  "data": {
    "regionCode": "11680",
    "regionName": "서울특별시 강남구",
    "housingType": "APT",
    "dealType": "JEONSE",
    "baseStartYm": "202602",
    "baseEndYm": "202607",
    "sampleCount": 132,
    "deposit": {
      "q1": 620000000,
      "median": 750000000,
      "q3": 910000000
    },
    "monthlyRent": {
      "q1": null,
      "median": null,
      "q3": null
    }
  },
  "error": null
}
```

### 조건에 맞는 거래가 없음

`deposit`·`monthlyRent` 객체 자체는 항상 존재하고 값만 `null`이 됩니다. 프론트가 `res.deposit.median`을 null 체크 없이 타고 들어갈 수 있도록 한 계약입니다. 표본 유무는 `sampleCount`로 판단하시면 됩니다.

```json
{
  "success": true,
  "data": {
    "regionCode": "11680",
    "regionName": "서울특별시 강남구",
    "housingType": "DETACHED",
    "dealType": "JEONSE",
    "baseStartYm": "202602",
    "baseEndYm": "202607",
    "sampleCount": 0,
    "deposit": { "q1": null, "median": null, "q3": null },
    "monthlyRent": { "q1": null, "median": null, "q3": null }
  },
  "error": null
}
```

### 에러

```json
{
  "success": false,
  "data": null,
  "error": {
    "code": "PROPERTY_001",
    "message": "존재하지 않는 지역 코드입니다."
  }
}
```

| 에러 코드 | HTTP | 상황 |
|---|---|---|
| `COMMON_001` | 400 | 필수 파라미터 누락, 잘못된 enum 값, min > max |
| `PROPERTY_001` | 404 | `region`에 없는 지역 코드 |

---

## 🔀레이어 흐름

```
GET /api/v1/properties/median?regionCode=11680&housingType=APT&dealType=WOLSE
    &areaMin=10&areaMax=25&depositMin=10000000&depositMax=100000000
    &monthlyRentMin=300000&monthlyRentMax=1500000
        │
        ▼
① AuthInterceptor            JWT 검증
        │
        ▼
② PropertyController         쿼리스트링 → RentMedianRequest 바인딩 + @Valid 검증
        │                    실패하면 여기서 400, 컨트롤러 본문에 진입하지 않음
        ▼
③ RentMedianService          지역 검증 → 집계 구간 계산 → 조회 → 분위값 산출
        │
        ├─▶ RegionMapper      "11680" → "서울특별시 강남구"
        │                     null이면 PROPERTY_001 (404)
        │
        ├─  집계 구간          202602 ~ 202607 (조회 시점 월 포함 6개 월)
        ├─  평 → ㎡ 환산       10평~25평 → 33㎡ ~ 82㎡ (버림)
        │
        ├─▶ RentTransactionMapper
        │                     WHERE 지역 · 유형 · 거래유형 · 기간 · 면적 · 보증금
        │                           (+ WOLSE일 때만 월세 조건)
        │                     → [(3000만, 70만), (5000만, 90만), ...] 47건
        │
        └─  분위값 산출        보증금·월세를 각각 정렬해 q1 / median / q3
        │
        ▼
④ ApiResponse.ok(...)        위 응답 JSON
```

**② 컨트롤러** — 조건 9개를 `@ModelAttribute` + `@Valid`로 묶어 받습니다. `housingType`·`dealType`을 enum으로 선언해 `APTT` 같은 오타가 "빈 결과"로 둔갑하지 않고 서비스 진입 전에 400으로 떨어집니다.

**③ 서비스** — 분위값은 **nearest-rank** 방식으로 계산합니다. 보간하지 않으므로 결과가 항상 실제 거래 금액이고, 표본이 한 자릿수로 떨어지는 조건(단독다가구·비수도권)에서도 값이 왜곡되지 않습니다.

**매퍼** — SQL은 조건 필터링만 하고 집계는 애플리케이션에서 합니다. WHERE가 지역 · 주택유형 · 거래유형 · 평수 · 보증금 · 6개월로 좁혀서 조회되는 행은 보통 수십~수백 건이고, 행당 `BIGINT` 두 개(16바이트)라 전송량은 부담이 되지 않습니다. 보증금과 월세를 각각 정렬해야 해서 SQL로 뽑으려면 쿼리를 두 번 날려야 하는데, 두 쿼리의 WHERE가 완전히 동일해 **같은 구간을 두 번 스캔하고 정렬도 두 번** 하게 됩니다. 아끼는 것은 N행 전송뿐이라 지금 규모에서는 손해라고 판단했습니다. 

---

## ✅테스트

### 통합 테스트 — `RentMedianIntegrationTest`

기존 동기화 테스트와 같은 유닛(`11110` / `201512` / `APT`)을 적재한 뒤 조회했고, **4개 모두 통과했습니다.**

| 테스트 | 확인한 것 |
|---|---|
| `전세_금액_조회` | 조회 결과가 비어 있지 않고, `deposit > 0` 필터와 전세 조건이 적용됨 |
| `월세_금액_조회` | 월세 조건 분기가 동작하고 `monthly_rent` → `monthlyRent` 매핑이 정상 |
| `존재하지_않는_지역코드` | `PROPERTY_001` 예외 발생 |
| `서비스_응답_조립` | 집계 구간이 6개 월, `regionName` 조회, 표본 유무와 분위값 null 여부가 일치 |

서비스가 집계 구간을 최근 6개월로 고정하므로 2015년 데이터로는 검증할 수 없어, 금액 조회 두 건은 매퍼를 직접 호출해 구간을 지정했습니다. 국토부 API 호출이 필요해 기존 통합 테스트와 동일하게 `@Disabled`를 붙였습니다.
