### PR TITLE
feat: 회원 정보 수정 API 구현

### DIFF
--- a/src/main/java/com/team/independence/config/WebConfig.java
+++ b/src/main/java/com/team/independence/config/WebConfig.java
@@ -6,6 +6,7 @@ import com.team.independence.common.resolver.LoginMemberArgumentResolver;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -69,6 +70,12 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginMemberArgumentResolver);
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(String.class, com.team.independence.member.domain.Agreement.AgreementType.class,
+                source -> com.team.independence.member.domain.Agreement.AgreementType.valueOf(source.toUpperCase()));
     }
 
     /** LocalDate/LocalDateTime을 ISO-8601 문자열로 직렬화 */

--- a/src/main/java/com/team/independence/member/controller/MemberController.java
+++ b/src/main/java/com/team/independence/member/controller/MemberController.java
@@ -3,6 +3,8 @@ package com.team.independence.member.controller;
 import com.team.independence.common.annotation.LoginMember;
 import com.team.independence.common.response.ApiResponse;
 import com.team.independence.member.domain.Agreement;
+import com.team.independence.member.domain.Agreement.AgreementType;
+import com.team.independence.member.dto.AgreementSingleUpdateRequest;
 import com.team.independence.member.dto.AgreementUpdateRequest;
 import com.team.independence.member.dto.MemberProfileResponse;
 import com.team.independence.member.service.AgreementService;
@@ -38,6 +40,15 @@ public class MemberController {
                         .build())
                 .collect(Collectors.toList());
         agreementService.updateAll(memberId, agreements);
+        return ApiResponse.ok(null);
+    }
+
+    @PatchMapping("/me/agreements/{type}")
+    public ApiResponse<Void> updateAgreement(
+            @LoginMember Long memberId,
+            @PathVariable AgreementType type,
+            @RequestBody AgreementSingleUpdateRequest request) {
+        agreementService.updateOne(memberId, type, request.agreed());
         return ApiResponse.ok(null);
     }
 

--- a/src/main/java/com/team/independence/member/controller/MemberController.java
+++ b/src/main/java/com/team/independence/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.team.independence.member.domain.Agreement.AgreementType;
 import com.team.independence.member.dto.AgreementSingleUpdateRequest;
 import com.team.independence.member.dto.AgreementUpdateRequest;
 import com.team.independence.member.dto.MemberProfileResponse;
+import com.team.independence.member.dto.MemberUpdateRequest;
 import com.team.independence.member.service.AgreementService;
 import com.team.independence.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,14 @@ public class MemberController {
     @GetMapping("/me")
     public ApiResponse<MemberProfileResponse> getMe(@LoginMember Long memberId) {
         return ApiResponse.ok(memberService.getMember(memberId));
+    }
+
+    @PatchMapping("/me")
+    public ApiResponse<Void> updateMe(
+            @LoginMember Long memberId,
+            @RequestBody MemberUpdateRequest request) {
+        memberService.updateMember(memberId, request.nickname(), request.incomeBracket());
+        return ApiResponse.ok(null);
     }
 
     @PatchMapping("/me/agreements")

--- a/src/main/java/com/team/independence/member/dto/AgreementSingleUpdateRequest.java
+++ b/src/main/java/com/team/independence/member/dto/AgreementSingleUpdateRequest.java
@@ -1,0 +1,3 @@
+package com.team.independence.member.dto;
+
+public record AgreementSingleUpdateRequest(boolean agreed) {}

--- a/src/main/java/com/team/independence/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/com/team/independence/member/dto/MemberUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.team.independence.member.dto;
+
+import com.team.independence.member.domain.IncomeBracket;
+
+public record MemberUpdateRequest(
+        String nickname,
+        IncomeBracket incomeBracket
+) {}

--- a/src/main/java/com/team/independence/member/mapper/MemberMapper.java
+++ b/src/main/java/com/team/independence/member/mapper/MemberMapper.java
@@ -22,4 +22,7 @@ public interface MemberMapper {
 
     /** 신규 회원 등록 (생성된 PK를 member.id에 반영) */
     void insert(Member member);
+
+    /** 닉네임·소득분위 수정 (null 필드는 UPDATE 제외) */
+    void update(Member member);
 }

--- a/src/main/java/com/team/independence/member/service/AgreementService.java
+++ b/src/main/java/com/team/independence/member/service/AgreementService.java
@@ -15,6 +15,9 @@ public interface AgreementService {
     /** 동의 항목 일괄 변경 (저장하기 버튼) */
     void updateAll(Long memberId, List<Agreement> agreements);
 
+    /** 단일 동의 항목 변경 */
+    void updateOne(Long memberId, Agreement.AgreementType type, boolean agreed);
+
     /** 회원 탈퇴 시 전체 삭제 */
     void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/team/independence/member/service/AgreementServiceImpl.java
+++ b/src/main/java/com/team/independence/member/service/AgreementServiceImpl.java
@@ -40,6 +40,14 @@ public class AgreementServiceImpl implements AgreementService {
 
     @Override
     @Transactional
+    public void updateOne(Long memberId, Agreement.AgreementType type, boolean agreed) {
+        agreementMapper.findByMemberIdAndType(memberId, type)
+                .orElseThrow(() -> new BusinessException(ErrorCode.AGREEMENT_NOT_FOUND));
+        agreementMapper.updateAgreed(memberId, type, agreed);
+    }
+
+    @Override
+    @Transactional
     public void deleteByMemberId(Long memberId) {
         agreementMapper.deleteByMemberId(memberId);
     }

--- a/src/main/java/com/team/independence/member/service/MemberService.java
+++ b/src/main/java/com/team/independence/member/service/MemberService.java
@@ -19,4 +19,7 @@ public interface MemberService {
 
     /** 신규 회원 등록 후 memberId 반환. 이미 가입된 kakaoId면 예외 */
     Long createMember(String kakaoId, String nickname, LocalDate birthDate, IncomeBracket incomeBracket);
+
+    /** 닉네임·소득분위 수정. null 필드는 변경하지 않음 */
+    void updateMember(Long memberId, String nickname, IncomeBracket incomeBracket);
 }

--- a/src/main/java/com/team/independence/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/team/independence/member/service/MemberServiceImpl.java
@@ -40,6 +40,20 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
+    public void updateMember(Long memberId, String nickname, IncomeBracket incomeBracket) {
+        memberMapper.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Member member = Member.builder()
+                .id(memberId)
+                .nickname(nickname)
+                .incomeBracket(incomeBracket)
+                .build();
+        memberMapper.update(member);
+    }
+
+    @Override
+    @Transactional
     public Long createMember(String kakaoId, String nickname, LocalDate birthDate, IncomeBracket incomeBracket) {
         memberMapper.findByKakaoId(kakaoId)
                 .ifPresent(m -> { throw new BusinessException(ErrorCode.MEMBER_ALREADY_EXISTS); });

--- a/src/main/resources/mybatis/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mybatis/mapper/member/MemberMapper.xml
@@ -35,6 +35,19 @@
          WHERE kakao_id = #{kakaoId}
     </select>
 
+    <update id="update" parameterType="com.team.independence.member.domain.Member">
+        UPDATE member
+        <set>
+            <if test="nickname != null">nickname = #{nickname},</if>
+            <if test="incomeBracket != null">
+                income_bracket = #{incomeBracket},
+                income_bracket_updated_at = NOW(),
+            </if>
+            updated_at = NOW()
+        </set>
+        WHERE id = #{id}
+    </update>
+
     <insert id="insert" parameterType="com.team.independence.member.domain.Member" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO member (kakao_id, nickname, birth_date, income_bracket, created_at, updated_at)
         VALUES (#{kakaoId}, #{nickname}, #{birthDate}, #{incomeBracket}, NOW(), NOW())


### PR DESCRIPTION
## #️⃣연관된 이슈

- #17 

## 📝작업 내용

### 회원 정보 수정 API — `PATCH /api/v1/members/me`

닉네임과 소득분위를 부분 수정할 수 있는 엔드포인트를 추가했습니다.

- `MemberUpdateRequest` 레코드 추가 (`nickname`, `incomeBracket` — 각각 null 허용)
- `MemberService.updateMember` / `MemberServiceImpl` 구현
  - 존재 확인 → `MEMBER_NOT_FOUND` 처리
  - null 필드는 UPDATE 제외 (MyBatis `<set><if>` 동적 쿼리)
  - `incomeBracket` 변경 시 `income_bracket_updated_at` 자동 갱신
- `MemberMapper.update` 인터페이스 및 XML 추가

**요청 예시**
```json
PATCH /api/v1/members/me
{ "nickname": "새닉네임", "incomeBracket": null }
```

---

### 단일 동의 항목 변경 API — `PATCH /api/v1/members/me/agreements/{type}`

기존 일괄 변경(`PATCH /me/agreements`) 외에, 개별 항목(마케팅 등)을 토글할 수 있는 엔드포인트를 추가했습니다.

- `AgreementSingleUpdateRequest` 레코드 추가 (`agreed: boolean`)
- `AgreementService.updateOne` / `AgreementServiceImpl` 구현
  - `findByMemberIdAndType` 존재 검증 → `AGREEMENT_NOT_FOUND` 처리
  - `updateAgreed(memberId, type, agreed)` 호출
- `MemberController`에 `@PatchMapping("/me/agreements/{type}")` 추가

**요청 예시**
```json
PATCH /api/v1/members/me/agreements/MARKETING
{ "agreed": true }
```

## 💬리뷰 요구사항(선택)

> 회원 탈퇴 API는 MVP 구현 단계에서 제외했습니다. 탈퇴 이외의 기존에 설계했던 `회원관리&인증/인가` 도메인의 모든 API를 구현 완료했습니다.