### PR TITLE
[FEATURE] 증권 계좌 동기화 및 인정률 적용

### DIFF
--- a/src/main/java/com/team/independence/asset/dto/AssetAccountQueryItem.java
+++ b/src/main/java/com/team/independence/asset/dto/AssetAccountQueryItem.java
@@ -15,4 +15,6 @@ public class AssetAccountQueryItem {
     private String productName;
     private String accountDisplay;
     private Long currentValue;
+    private Long valuationAmount;
+    private Long depositReceived;
 }

--- a/src/main/java/com/team/independence/asset/service/AssetSummaryServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSummaryServiceImpl.java
@@ -40,7 +40,7 @@ public class AssetSummaryServiceImpl implements AssetSummaryService {
         long investmentTotal = 0L;
 
         for (AssetAccountQueryItem account : accounts) {
-            long balance = account.getCurrentValue() != null ? account.getCurrentValue() : 0L;
+            long balance = computeBalance(account);
             AccountItem item = AccountItem.builder()
                     .institutionName(account.getInstitutionName())
                     .accountType(toResponseAccountType(account.getAccountType()))
@@ -92,6 +92,20 @@ public class AssetSummaryServiceImpl implements AssetSummaryService {
                         .build())
                 .loans(loanItems)
                 .build();
+    }
+
+    /**
+     * STOCK: valuationAmount × 70% + depositReceived
+     * 나머지: current_value 그대로
+     */
+    private long computeBalance(AssetAccountQueryItem account) {
+        String type = account.getAccountType();
+        if (("STOCK".equals(type) || "FUND".equals(type)) && account.getValuationAmount() != null) {
+            long valuation = account.getValuationAmount();
+            long deposit = account.getDepositReceived() != null ? account.getDepositReceived() : 0L;
+            return Math.round(valuation * 0.7) + deposit;
+        }
+        return account.getCurrentValue() != null ? account.getCurrentValue() : 0L;
     }
 
     /**

--- a/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
@@ -43,6 +43,20 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AssetSyncServiceImpl implements AssetSyncService {
 
+    private static final String BUSINESS_TYPE_STOCK = "ST";
+    private static final String BUSINESS_TYPE_BANK = "BK";
+
+    private static final String DEPOSIT_CODE_DEMAND = "11";
+    private static final String DEPOSIT_CODE_SAVINGS = "12";
+    private static final String DEPOSIT_CODE_DEPOSIT = "13";
+
+    private static final String PRODUCT_TYPE_STOCK = "01";
+    private static final String PRODUCT_TYPE_FUND = "02";
+    private static final String PRODUCT_TYPE_DEMAND = "03";
+
+    private static final String CURRENCY_KRW = "KRW";
+    private static final String OVERDRAFT_FLAG = "1";
+
     private final ConnectedAccountMapper connectedAccountMapper;
     private final ConnectedInstitutionMapper connectedInstitutionMapper;
     private final InstitutionMapper institutionMapper;
@@ -110,10 +124,10 @@ public class AssetSyncServiceImpl implements AssetSyncService {
         String institutionCode = institution.getInstitutionCode();
         Institution institutionInfo = institutionMapper.findByCode(institutionCode);
         String orgName = institutionInfo != null ? institutionInfo.getName() : institutionCode;
-        String businessType = institutionInfo != null ? institutionInfo.getBusinessType() : "BK";
+        String businessType = institutionInfo != null ? institutionInfo.getBusinessType() : BUSINESS_TYPE_BANK;
 
         try {
-            if ("ST".equals(businessType)) {
+            if (BUSINESS_TYPE_STOCK.equals(businessType)) {
                 return syncStockInstitution(institution, connectedId, accessToken, institutionCode, orgName);
             }
             return syncBankInstitution(institution, connectedId, birthDate, accessToken, institutionCode, orgName);
@@ -238,9 +252,9 @@ public class AssetSyncServiceImpl implements AssetSyncService {
 
         for (CodefStockItem item : items) {
             String code = item.getResProductTypeCd();
-            if ("01".equals(code)) return "STOCK";
-            if ("02".equals(code)) return "FUND";
-            if ("03".equals(code)) return "DEMAND";
+            if (PRODUCT_TYPE_STOCK.equals(code)) return "STOCK";
+            if (PRODUCT_TYPE_FUND.equals(code)) return "FUND";
+            if (PRODUCT_TYPE_DEMAND.equals(code)) return "DEMAND";
         }
         return "STOCK";
     }
@@ -314,8 +328,8 @@ public class AssetSyncServiceImpl implements AssetSyncService {
      * 마이너스통장 또는 외화 계좌는 제외
      */
     private boolean isExcluded(CodefDepositItem item) {
-        if ("1".equals(item.getResOverdraftAcctYN())) return true;
-        if (item.getResAccountCurrency() != null && !"KRW".equals(item.getResAccountCurrency())) return true;
+        if (OVERDRAFT_FLAG.equals(item.getResOverdraftAcctYN())) return true;
+        if (item.getResAccountCurrency() != null && !CURRENCY_KRW.equals(item.getResAccountCurrency())) return true;
         return false;
     }
 
@@ -326,9 +340,9 @@ public class AssetSyncServiceImpl implements AssetSyncService {
      */
     private String classifyDepositType(CodefDepositItem item) {
         String depositCode = item.getResAccountDeposit();
-        if ("11".equals(depositCode)) return "DEMAND";
-        if ("13".equals(depositCode)) return "DEPOSIT";
-        if ("12".equals(depositCode)) {
+        if (DEPOSIT_CODE_DEMAND.equals(depositCode)) return "DEMAND";
+        if (DEPOSIT_CODE_DEPOSIT.equals(depositCode)) return "DEPOSIT";
+        if (DEPOSIT_CODE_SAVINGS.equals(depositCode)) {
             String name = item.getResAccountName();
             if (name != null && name.contains("청약")) return "SUBSCRIPTION";
             return "SAVINGS";

--- a/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
@@ -24,11 +24,16 @@ import com.team.independence.external.codef.CodefTokenManager;
 import com.team.independence.external.codef.dto.CodefBankAccountResponse;
 import com.team.independence.external.codef.dto.CodefBankAccountResponse.CodefDepositItem;
 import com.team.independence.external.codef.dto.CodefBankAccountResponse.CodefLoanItem;
+import com.team.independence.external.codef.dto.CodefStockAccountResponse;
+import com.team.independence.external.codef.dto.CodefStockAccountResponse.CodefStockAccountItem;
+import com.team.independence.external.codef.dto.CodefStockFinancialAssetsResponse;
+import com.team.independence.external.codef.dto.CodefStockFinancialAssetsResponse.CodefStockItem;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -105,52 +110,147 @@ public class AssetSyncServiceImpl implements AssetSyncService {
         String institutionCode = institution.getInstitutionCode();
         Institution institutionInfo = institutionMapper.findByCode(institutionCode);
         String orgName = institutionInfo != null ? institutionInfo.getName() : institutionCode;
+        String businessType = institutionInfo != null ? institutionInfo.getBusinessType() : "BK";
 
         try {
-            CodefBankAccountResponse response =
-                    codefClient.getBankAccountList(accessToken, connectedId, institutionCode, birthDate);
-
-            if (!response.isSuccess()) {
-                return recordFailure(institution, orgName,
-                        response.getResultCode(), response.getResultMessage());
+            if ("ST".equals(businessType)) {
+                return syncStockInstitution(institution, connectedId, accessToken, institutionCode, orgName);
             }
-
-            CodefBankAccountResponse.CodefBankData data = response.getData();
-            List<AssetAccount> assetAccounts = parseAssetAccounts(institution.getId(), data);
-            List<LoanAccount> loanAccounts = parseLoanAccounts(institution.getId(), data);
-
-            // 동기화: 기존 계좌 전체 삭제 후 재적재
-            assetAccountMapper.deleteByConnectedInstitutionId(institution.getId());
-            loanAccountMapper.deleteByConnectedInstitutionId(institution.getId());
-
-            if (!assetAccounts.isEmpty()) {
-                assetAccountMapper.insertAll(assetAccounts);
-            }
-            if (!loanAccounts.isEmpty()) {
-                loanAccountMapper.insertAll(loanAccounts);
-            }
-
-            institution.setStatus("ACTIVE");
-            institution.setLastSyncedAt(LocalDateTime.now());
-            institution.setLastAttemptedAt(LocalDateTime.now());
-            institution.setLastErrorCode(null);
-            institution.setLastErrorMessage(null);
-            connectedInstitutionMapper.updateSyncResult(institution);
-
-            log.info("계좌 동기화 완료: org={}, 자산계좌={}, 대출계좌={}",
-                    institutionCode, assetAccounts.size(), loanAccounts.size());
-
-            return InstitutionSyncResult.builder()
-                    .organizationCode(institutionCode)
-                    .organizationName(orgName)
-                    .success(true)
-                    .assetAccountCount(assetAccounts.size())
-                    .loanAccountCount(loanAccounts.size())
-                    .build();
-
+            return syncBankInstitution(institution, connectedId, birthDate, accessToken, institutionCode, orgName);
         } catch (Exception e) {
             log.error("계좌 동기화 실패: org={}", institutionCode, e);
             return recordFailure(institution, orgName, "SYNC_ERROR", e.getMessage());
+        }
+    }
+
+    private InstitutionSyncResult syncBankInstitution(ConnectedInstitution institution,
+                                                       String connectedId, String birthDate,
+                                                       String accessToken,
+                                                       String institutionCode, String orgName) {
+        CodefBankAccountResponse response =
+                codefClient.getBankAccountList(accessToken, connectedId, institutionCode, birthDate);
+
+        if (!response.isSuccess()) {
+            return recordFailure(institution, orgName, response.getResultCode(), response.getResultMessage());
+        }
+
+        CodefBankAccountResponse.CodefBankData data = response.getData();
+        List<AssetAccount> assetAccounts = parseAssetAccounts(institution.getId(), data);
+        List<LoanAccount> loanAccounts = parseLoanAccounts(institution.getId(), data);
+
+        saveAccounts(institution, assetAccounts, loanAccounts);
+
+        log.info("은행 계좌 동기화 완료: org={}, 자산계좌={}, 대출계좌={}",
+                institutionCode, assetAccounts.size(), loanAccounts.size());
+
+        return InstitutionSyncResult.builder()
+                .organizationCode(institutionCode)
+                .organizationName(orgName)
+                .success(true)
+                .assetAccountCount(assetAccounts.size())
+                .loanAccountCount(loanAccounts.size())
+                .build();
+    }
+
+    private InstitutionSyncResult syncStockInstitution(ConnectedInstitution institution,
+                                                        String connectedId, String accessToken,
+                                                        String institutionCode, String orgName) {
+        CodefStockAccountResponse accountListResponse =
+                codefClient.getStockAccountList(accessToken, connectedId, institutionCode);
+
+        if (!accountListResponse.isSuccess()) {
+            return recordFailure(institution, orgName,
+                    accountListResponse.getResultCode(), accountListResponse.getResultMessage());
+        }
+
+        List<AssetAccount> assetAccounts = new ArrayList<>();
+        for (CodefStockAccountItem account : accountListResponse.getData()) {
+            // 외화 계좌 제외
+            if (account.getResDepositReceivedF() != null && !account.getResDepositReceivedF().isBlank()) {
+                log.debug("외화 계좌 제외: {}", account.getResAccountDisplay());
+                continue;
+            }
+
+            CodefStockFinancialAssetsResponse assetsResponse =
+                    codefClient.getStockFinancialAssets(accessToken, connectedId, institutionCode,
+                            account.getResAccount());
+
+            String accountType = classifyStockAccountType(account.getResAccountName(),
+                    assetsResponse.isSuccess() ? assetsResponse.getData().getResItemList() : List.of());
+
+            Long valuationAmt = parseAmount(account.getResValuationAmt());
+            Long depositReceived = parseAmount(account.getResDepositReceived());
+            Long currentValue = (valuationAmt != null || depositReceived != null)
+                    ? (valuationAmt != null ? valuationAmt : 0L) + (depositReceived != null ? depositReceived : 0L)
+                    : null;
+            BigDecimal earningsRate = parseRate(account.getResEarningsRate());
+
+            assetAccounts.add(AssetAccount.builder()
+                    .connectedInstitutionId(institution.getId())
+                    .accountType(accountType)
+                    .assetCategory("INVESTMENT")
+                    .accountDisplay(account.getResAccountDisplay())
+                    .productName(account.getResAccountName())
+                    .currentValue(currentValue)
+                    .valuationAmount(valuationAmt)
+                    .depositReceived(depositReceived)
+                    .earningsRate(earningsRate)
+                    .rawResponse(toJson(account))
+                    .build());
+        }
+
+        saveAccounts(institution, assetAccounts, List.of());
+
+        log.info("증권 계좌 동기화 완료: org={}, 자산계좌={}", institutionCode, assetAccounts.size());
+
+        return InstitutionSyncResult.builder()
+                .organizationCode(institutionCode)
+                .organizationName(orgName)
+                .success(true)
+                .assetAccountCount(assetAccounts.size())
+                .loanAccountCount(0)
+                .build();
+    }
+
+    private void saveAccounts(ConnectedInstitution institution,
+                               List<AssetAccount> assetAccounts, List<LoanAccount> loanAccounts) {
+        assetAccountMapper.deleteByConnectedInstitutionId(institution.getId());
+        loanAccountMapper.deleteByConnectedInstitutionId(institution.getId());
+
+        if (!assetAccounts.isEmpty()) assetAccountMapper.insertAll(assetAccounts);
+        if (!loanAccounts.isEmpty()) loanAccountMapper.insertAll(loanAccounts);
+
+        institution.setStatus("ACTIVE");
+        institution.setLastSyncedAt(LocalDateTime.now());
+        institution.setLastAttemptedAt(LocalDateTime.now());
+        institution.setLastErrorCode(null);
+        institution.setLastErrorMessage(null);
+        connectedInstitutionMapper.updateSyncResult(institution);
+    }
+
+    /**
+     * 증권 계좌 유형 분류
+     * CMA 계좌명 우선 → 보유종목 상품유형코드 순서로 판별
+     * 01=주식(STOCK), 02=펀드(FUND), 03=CMA(DEMAND)
+     */
+    private String classifyStockAccountType(String accountName, List<CodefStockItem> items) {
+        if (accountName != null && accountName.contains("CMA")) return "DEMAND";
+
+        for (CodefStockItem item : items) {
+            String code = item.getResProductTypeCd();
+            if ("01".equals(code)) return "STOCK";
+            if ("02".equals(code)) return "FUND";
+            if ("03".equals(code)) return "DEMAND";
+        }
+        return "STOCK";
+    }
+
+    private BigDecimal parseRate(String value) {
+        if (value == null || value.isBlank()) return null;
+        try {
+            return new BigDecimal(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
         }
     }
 

--- a/src/main/java/com/team/independence/external/codef/CodefClient.java
+++ b/src/main/java/com/team/independence/external/codef/CodefClient.java
@@ -7,6 +7,10 @@ import com.team.independence.external.codef.dto.CodefAccountRequest;
 import com.team.independence.external.codef.dto.CodefApiResponse;
 import com.team.independence.external.codef.dto.CodefBankAccountResponse;
 import com.team.independence.external.codef.dto.CodefBankInquiryRequest;
+import com.team.independence.external.codef.dto.CodefStockAccountResponse;
+import com.team.independence.external.codef.dto.CodefStockFinancialAssetsRequest;
+import com.team.independence.external.codef.dto.CodefStockFinancialAssetsResponse;
+import com.team.independence.external.codef.dto.CodefStockInquiryRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
@@ -30,6 +34,8 @@ public class CodefClient {
     private static final String ADD_PATH = "/v1/account/add";
     private static final String DELETE_PATH = "/v1/account/delete";
     private static final String BANK_ACCOUNT_LIST_PATH = "/v1/kr/bank/p/account/account-list";
+    private static final String STOCK_ACCOUNT_LIST_PATH = "/v1/kr/stock/a/account/account-list";
+    private static final String STOCK_FINANCIAL_ASSETS_PATH = "/v1/kr/stock/a/account/financial-assets";
 
     private final CodefProperties properties;
     private final RestTemplate restTemplate;
@@ -82,6 +88,63 @@ public class CodefClient {
 
         } catch (Exception e) {
             log.error("CODEF 계좌조회 실패: org={}", organization, e);
+            throw new BusinessException(ErrorCode.ASSET_CODEF_API_ERROR);
+        }
+    }
+
+    public CodefStockAccountResponse getStockAccountList(String accessToken, String connectedId, String organization) {
+        CodefStockInquiryRequest body = CodefStockInquiryRequest.builder()
+                .connectedId(connectedId)
+                .organization(organization)
+                .build();
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(accessToken);
+
+            HttpEntity<CodefStockInquiryRequest> request = new HttpEntity<>(body, headers);
+            log.debug("CODEF 증권 계좌목록 요청: org={}", organization);
+
+            ResponseEntity<String> response = restTemplate.exchange(
+                    properties.getApiDomain() + STOCK_ACCOUNT_LIST_PATH,
+                    HttpMethod.POST, request, String.class);
+
+            String decoded = URLDecoder.decode(response.getBody(), StandardCharsets.UTF_8);
+            log.debug("CODEF 증권 계좌목록 응답: {}", decoded);
+            return objectMapper.readValue(decoded, CodefStockAccountResponse.class);
+
+        } catch (Exception e) {
+            log.error("CODEF 증권 계좌목록 조회 실패: org={}", organization, e);
+            throw new BusinessException(ErrorCode.ASSET_CODEF_API_ERROR);
+        }
+    }
+
+    public CodefStockFinancialAssetsResponse getStockFinancialAssets(String accessToken, String connectedId,
+                                                                      String organization, String account) {
+        CodefStockFinancialAssetsRequest body = CodefStockFinancialAssetsRequest.builder()
+                .connectedId(connectedId)
+                .organization(organization)
+                .account(account)
+                .build();
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(accessToken);
+
+            HttpEntity<CodefStockFinancialAssetsRequest> request = new HttpEntity<>(body, headers);
+            log.debug("CODEF 종합자산 요청: org={}, account={}...", organization,
+                    account.substring(0, Math.min(4, account.length())));
+
+            ResponseEntity<String> response = restTemplate.exchange(
+                    properties.getApiDomain() + STOCK_FINANCIAL_ASSETS_PATH,
+                    HttpMethod.POST, request, String.class);
+
+            String decoded = URLDecoder.decode(response.getBody(), StandardCharsets.UTF_8);
+            log.debug("CODEF 종합자산 응답: {}", decoded);
+            return objectMapper.readValue(decoded, CodefStockFinancialAssetsResponse.class);
+
+        } catch (Exception e) {
+            log.error("CODEF 종합자산 조회 실패: org={}, account={}", organization, account, e);
             throw new BusinessException(ErrorCode.ASSET_CODEF_API_ERROR);
         }
     }

--- a/src/main/java/com/team/independence/external/codef/dto/CodefBankAccountResponse.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefBankAccountResponse.java
@@ -12,12 +12,14 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CodefBankAccountResponse {
 
+    private static final String SUCCESS_CODE = "CF-00000";
+
     private CodefResult result;
     private CodefBankData data;
     private String connectedId;
 
     public boolean isSuccess() {
-        return result != null && "CF-00000".equals(result.getCode());
+        return result != null && SUCCESS_CODE.equals(result.getCode());
     }
 
     public String getResultCode() {

--- a/src/main/java/com/team/independence/external/codef/dto/CodefStockAccountResponse.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefStockAccountResponse.java
@@ -1,0 +1,64 @@
+package com.team.independence.external.codef.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CodefStockAccountResponse {
+
+    private CodefResult result;
+    private List<CodefStockAccountItem> data;
+    private String connectedId;
+
+    public boolean isSuccess() {
+        return result != null && "CF-00000".equals(result.getCode());
+    }
+
+    public String getResultCode() {
+        return result != null ? result.getCode() : null;
+    }
+
+    public String getResultMessage() {
+        return result != null ? result.getMessage() : null;
+    }
+
+    public List<CodefStockAccountItem> getData() {
+        return data != null ? data : Collections.emptyList();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CodefResult {
+        private String code;
+        private String message;
+        private String transactionId;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CodefStockAccountItem {
+        private String resAccount;  // 계좌번호 (숫자만)
+        private String resAccountDisplay;  // 표시용 계좌번호
+        private String resAccountName;  // 계좌명(유형)
+        private String resAccountNickName; // 계좌별칭
+        private String resDepositReceived;  // 예수금
+        private String resDepositReceivedD1;
+        private String resDepositReceivedD2;
+        private String resDepositReceivedF;  // 외화예수금 (비어있지 않으면 외화 계좌)
+        private String resValuationAmt;  // 평가금액
+        private String resValuationPL;  // 평가손익
+        private String resPurchaseAmount;  // 매입금액
+        private String resEarningsRate;  // 수익률 [%]
+        private String resLoanAmt;  // 대출금액
+        private String resPrincipal;  // 원금
+        private String resWithdrawalAmt;  // 출금가능금액
+    }
+}

--- a/src/main/java/com/team/independence/external/codef/dto/CodefStockAccountResponse.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefStockAccountResponse.java
@@ -12,12 +12,14 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CodefStockAccountResponse {
 
+    private static final String SUCCESS_CODE = "CF-00000";
+
     private CodefResult result;
     private List<CodefStockAccountItem> data;
     private String connectedId;
 
     public boolean isSuccess() {
-        return result != null && "CF-00000".equals(result.getCode());
+        return result != null && SUCCESS_CODE.equals(result.getCode());
     }
 
     public String getResultCode() {

--- a/src/main/java/com/team/independence/external/codef/dto/CodefStockFinancialAssetsRequest.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefStockFinancialAssetsRequest.java
@@ -1,0 +1,18 @@
+package com.team.independence.external.codef.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CodefStockFinancialAssetsRequest {
+    private String organization;
+    private String connectedId;
+    private String account;
+    @Builder.Default
+    private String inquiryType = "0";
+}

--- a/src/main/java/com/team/independence/external/codef/dto/CodefStockFinancialAssetsResponse.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefStockFinancialAssetsResponse.java
@@ -12,12 +12,14 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CodefStockFinancialAssetsResponse {
 
+    private static final String SUCCESS_CODE = "CF-00000";
+
     private CodefResult result;
     private CodefAssetsData data;
     private String connectedId;
 
     public boolean isSuccess() {
-        return result != null && "CF-00000".equals(result.getCode());
+        return result != null && SUCCESS_CODE.equals(result.getCode());
     }
 
     public String getResultCode() {

--- a/src/main/java/com/team/independence/external/codef/dto/CodefStockFinancialAssetsResponse.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefStockFinancialAssetsResponse.java
@@ -1,0 +1,81 @@
+package com.team.independence.external.codef.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CodefStockFinancialAssetsResponse {
+
+    private CodefResult result;
+    private CodefAssetsData data;
+    private String connectedId;
+
+    public boolean isSuccess() {
+        return result != null && "CF-00000".equals(result.getCode());
+    }
+
+    public String getResultCode() {
+        return result != null ? result.getCode() : null;
+    }
+
+    public String getResultMessage() {
+        return result != null ? result.getMessage() : null;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CodefResult {
+        private String code;
+        private String message;
+        private String transactionId;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CodefAssetsData {
+        private String resAccount;
+        private String resAccountEx;
+        private String resDepositReceived;
+        private List<CodefStockItem> resItemList;
+
+        public List<CodefStockItem> getResItemList() {
+            return resItemList != null ? resItemList : Collections.emptyList();
+        }
+    }
+
+    /**
+     * resProductTypeCd: 01=주식, 02=펀드, 03=CMA, 04=해외주식, 05=신탁/퇴직연금,
+     *                   06=채권, 07=RP, 08=CD/CP, 09=ELS/DLS, 10=해외무추얼펀드,
+     *                   11=Wrap, 12=외화RP, 13=연금저축, 14=선물옵션, 99=기타
+     */
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CodefStockItem {
+        private String resProductTypeCd;  // 상품유형코드
+        private String resProductType;  // 상품유형명
+        private String resItemCode;  // 종목코드
+        private String resItemName;  // 종목명
+        private String resQuantity;  // 수량
+        private String resPurchaseAmount; // 매입금액
+        private String resValuationAmt;  // 평가금액
+        private String resValuationPL;  // 평가손익
+        private String resEarningsRate;  // 수익률
+        private String resPresentAmt;  // 현재가
+        private String resAvgPresentAmt;  // 평균매입가
+        private String resDepositReceived;  // 예수금
+        private String resAccountCurrency;  // 통화코드
+        private String resBalanceType;  // 잔고유형
+        private String resSettleQuantity;  // 정산수량
+        private String resResultCode;  // 결과코드
+        private String resResultDesc;  // 결과메시지
+    }
+}

--- a/src/main/java/com/team/independence/external/codef/dto/CodefStockInquiryRequest.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefStockInquiryRequest.java
@@ -1,0 +1,15 @@
+package com.team.independence.external.codef.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CodefStockInquiryRequest {
+    private String organization;
+    private String connectedId;
+}

--- a/src/main/resources/mybatis/mapper/asset/AssetAccountMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/AssetAccountMapper.xml
@@ -34,11 +34,13 @@
     <insert id="insertAll">
         INSERT INTO asset_account
             (connected_institution_id, account_type, asset_category,
-             account_display, product_name, current_value, raw_response)
+             account_display, product_name, current_value,
+             valuation_amount, deposit_received, raw_response)
         VALUES
         <foreach collection="list" item="a" separator=",">
             (#{a.connectedInstitutionId}, #{a.accountType}, #{a.assetCategory},
-             #{a.accountDisplay}, #{a.productName}, #{a.currentValue}, #{a.rawResponse})
+             #{a.accountDisplay}, #{a.productName}, #{a.currentValue},
+             #{a.valuationAmount}, #{a.depositReceived}, #{a.rawResponse})
         </foreach>
     </insert>
 
@@ -56,19 +58,22 @@
     </select>
 
     <resultMap id="assetAccountQueryMap" type="com.team.independence.asset.dto.AssetAccountQueryItem">
-        <result property="id"              column="id"/>
-        <result property="institutionName" column="institution_name"/>
-        <result property="accountType"     column="account_type"/>
-        <result property="assetCategory"   column="asset_category"/>
-        <result property="productName"     column="product_name"/>
-        <result property="accountDisplay"  column="account_display"/>
-        <result property="currentValue"    column="current_value"/>
+        <result property="id"               column="id"/>
+        <result property="institutionName"  column="institution_name"/>
+        <result property="accountType"      column="account_type"/>
+        <result property="assetCategory"    column="asset_category"/>
+        <result property="productName"      column="product_name"/>
+        <result property="accountDisplay"   column="account_display"/>
+        <result property="currentValue"     column="current_value"/>
+        <result property="valuationAmount"  column="valuation_amount"/>
+        <result property="depositReceived"  column="deposit_received"/>
     </resultMap>
 
     <select id="findWithInstitutionByMemberId" parameterType="long" resultMap="assetAccountQueryMap">
         SELECT aa.id, i.name AS institution_name,
                aa.account_type, aa.asset_category, aa.product_name,
-               aa.account_display, aa.current_value
+               aa.account_display, aa.current_value,
+               aa.valuation_amount, aa.deposit_received
           FROM asset_account aa
           JOIN connected_institution ci ON aa.connected_institution_id = ci.id
           JOIN connected_account ca ON ci.connected_account_id = ca.id


### PR DESCRIPTION
## #️⃣연관된 이슈

> #16 

## 📝 작업 내용

은행 계좌 연동 #10 에 이어 CODEF를 통해 연동된 증권사 계좌를 동기화하고, 자산 요약 응답에 인정률을 적용했습니다.

### CODEF API 연동
  
증권 계좌 조회를 위해 아래 2개의 CODEF API를 사용했습니다.
  
  | API | 용도 |
  |-----|------|
  | POST `/v1/kr/stock/a/account/account-list` | 계좌 목록, 평가금액 및 예수금 조회 |
  | POST `/v1/kr/stock/a/account/financial-assets` | 보유 종목 코드로 계좌 유형 분류 |

- 증권 계좌는 `clientType: "A"` 사용 (`"P"` 사용 시 CF-00007 오류)

### 계좌 유형 분류  

1. 계좌명에 `"CMA"` 포함 → `DEMAND`
2. `financial-assets`의 `resProductTypeCd` 기준
   - `01` → `STOCK` / `02` → `FUND` / `03` → `DEMAND`
3. 보유 종목 없거나 판별 불가 → `STOCK` (기본값)

### 인정률 적용 (GET `/api/v1/assets/summary/{memberId}`)

  | 조건 | balance 계산 |
  |------|-------------| 
  | 증권 STOCK / FUND (`valuation_amount NOT NULL`) | `Math.round(valuationAmount * 0.7) + depositReceived` |
  | 은행 FUND (`valuation_amount NULL`) | `currentValue` 그대로 적용 |
  | DEMAND | `currentValue` 그대로 적용 |

증권 계좌(STOCK, FUND)의 경우, 위와 같이 평가금액과 예수금을 `asset_account.valuation_amount`, `deposit_received`에 분리 저장하여 인정률 계산 시 활용할 수 있도록 처리했습니다.


### 📸 스크린샷

**<삼성증권, KB증권 계정 등록>**
<img width="937" height="228" alt="스크린샷 2026-07-31 오후 3 37 54" src="https://github.com/user-attachments/assets/64e4158a-e92d-471d-bbc0-d9f806164c8e" />


&nbsp;

**<자산 동기화 실행>**
<img width="1118" height="818" alt="스크린샷 2026-07-31 오후 3 41 58" src="https://github.com/user-attachments/assets/0bca411f-ca5e-48f7-839e-44def66ab1e1" />


&nbsp;

**<자산 현황 요약 결과>**
<img width="1118" height="826" alt="스크린샷 2026-07-31 오후 3 39 11" src="https://github.com/user-attachments/assets/d231f0db-c562-49e1-8561-d93351ce66ab" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?