### PR TITLE
feat: 자산 동기화 배치 스케줄러 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ CODEF_ENCRYPT_KEY=
 KAKAO_REST_API_KEY=
 MOLIT_SERVICE_KEY=
 POLICY_API_KEY=
+SLACK_WEBHOOK_URL=
 
 # JWT
 JWT_SECRET=change-me-to-a-long-random-string-at-least-32-chars

--- a/src/main/java/com/team/independence/asset/mapper/ConnectedAccountMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/ConnectedAccountMapper.java
@@ -3,9 +3,12 @@ package com.team.independence.asset.mapper;
 import com.team.independence.asset.domain.ConnectedAccount;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.List;
+
 @Mapper
 public interface ConnectedAccountMapper {
     ConnectedAccount findByMemberId(Long memberId);
+    List<Long> findAllMemberIds();
     void insert(ConnectedAccount connectedAccount);
     void updateSyncStatus(ConnectedAccount connectedAccount);
     void deleteById(Long id);

--- a/src/main/java/com/team/independence/asset/service/AssetSyncService.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncService.java
@@ -4,4 +4,5 @@ import com.team.independence.asset.dto.AssetSyncResponse;
 
 public interface AssetSyncService {
     AssetSyncResponse syncAccounts(Long memberId);
+    void syncAll();
 }

--- a/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
@@ -20,6 +20,7 @@ import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.common.security.AesEncryptor;
 import com.team.independence.external.codef.CodefClient;
+import com.team.independence.external.slack.SlackNotifier;
 import com.team.independence.external.codef.CodefTokenManager;
 import com.team.independence.external.codef.dto.CodefBankAccountResponse;
 import com.team.independence.external.codef.dto.CodefBankAccountResponse.CodefDepositItem;
@@ -69,6 +70,36 @@ public class AssetSyncServiceImpl implements AssetSyncService {
     private final CodefTokenManager codefTokenManager;
     private final AesEncryptor aesEncryptor;
     private final ObjectMapper objectMapper;
+    private final SlackNotifier slackNotifier;
+
+    @Override
+    public void syncAll() {
+        List<Long> memberIds = connectedAccountMapper.findAllMemberIds();
+        log.info("[배치] 자산 동기화 대상 회원 수: {}", memberIds.size());
+
+        List<SyncFailure> failures = new ArrayList<>();
+        for (Long memberId : memberIds) {
+            try {
+                syncAccounts(memberId);
+            } catch (Exception e) {
+                log.error("[배치] 회원 자산 동기화 실패: memberId={}", memberId, e);
+                failures.add(new SyncFailure(memberId, e));
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            StringBuilder sb = new StringBuilder("[자산 동기화 배치 실패] ")
+                    .append(failures.size()).append("건\n");
+            for (SyncFailure f : failures) {
+                sb.append("• memberId=").append(f.memberId)
+                  .append(" / ").append(f.reason).append("\n");
+            }
+            slackNotifier.sendBatchFailureSummary(sb.toString().trim());
+        }
+
+        log.info("[배치] 자산 동기화 완료 — 성공: {}, 실패: {}",
+                memberIds.size() - failures.size(), failures.size());
+    }
 
     @Override
     @Transactional
@@ -397,6 +428,16 @@ public class AssetSyncServiceImpl implements AssetSyncService {
             return objectMapper.writeValueAsString(obj);
         } catch (JsonProcessingException e) {
             return "{}";
+        }
+    }
+
+    private static class SyncFailure {
+        final Long memberId;
+        final String reason;
+
+        SyncFailure(Long memberId, Throwable e) {
+            this.memberId = memberId;
+            this.reason = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
         }
     }
 

--- a/src/main/java/com/team/independence/external/slack/SlackNotifier.java
+++ b/src/main/java/com/team/independence/external/slack/SlackNotifier.java
@@ -1,0 +1,60 @@
+package com.team.independence.external.slack;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDate;
+import java.time.Duration;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SlackNotifier {
+
+    private static final String DEDUP_KEY_PREFIX = "slack:asset-sync:fail:";
+    private static final Duration DEDUP_TTL = Duration.ofMinutes(30);
+
+    @Value("${slack.webhook.url:}")
+    private String webhookUrl;
+
+    private final RestTemplate restTemplate;
+    private final StringRedisTemplate redisTemplate;
+
+    public void sendBatchFailureSummary(String message) {
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            log.warn("[Slack] webhook URL이 설정되지 않아 알림을 건너뜁니다.");
+            return;
+        }
+
+        String dedupKey = DEDUP_KEY_PREFIX + LocalDate.now();
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(dedupKey))) {
+            log.info("[Slack] 중복 알림 억제 (30분 내 이미 전송): key={}", dedupKey);
+            return;
+        }
+
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            String body = "{\"text\": \"" + escapeJson(message) + "\"}";
+            HttpEntity<String> request = new HttpEntity<>(body, headers);
+
+            restTemplate.exchange(webhookUrl, HttpMethod.POST, request, String.class);
+            redisTemplate.opsForValue().set(dedupKey, "1", DEDUP_TTL);
+            log.info("[Slack] 배치 실패 알림 전송 완료");
+        } catch (Exception e) {
+            log.error("[Slack] 알림 전송 실패 (배치는 계속 진행)", e);
+        }
+    }
+
+    private String escapeJson(String text) {
+        return text.replace("\\", "\\\\")
+                   .replace("\"", "\\\"")
+                   .replace("\n", "\\n");
+    }
+}

--- a/src/main/java/com/team/independence/scheduler/AssetSyncScheduler.java
+++ b/src/main/java/com/team/independence/scheduler/AssetSyncScheduler.java
@@ -1,28 +1,28 @@
 package com.team.independence.scheduler;
 
+import com.team.independence.asset.service.AssetSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * ★ 배치 표준 패턴 ★
- *  - BatchConfig(@Profile("batch"))의 컴포넌트 스캔 대상
- *  - api 프로필로 실행하면 이 빈은 등록조차 되지 않는다
- *  - 로직은 없다. Service를 호출만 한다 (Controller의 배치 버전)
+ * 배치 표준 패턴:
+ *  BatchConfig(@Profile("batch"))의 컴포넌트 스캔 대상
+ *  api 프로필로 실행하면 이 빈은 등록 자체가 되지 않습니다.
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class AssetSyncScheduler {
 
-    // private final AssetSyncService assetSyncService;   // 담당자가 구현 후 주입
+    private final AssetSyncService assetSyncService;
 
-    /** 매일 새벽 4시 전체 회원 자산 동기화 */
+    // 매일 새벽 4시 전체 회원 자산 동기화 (추후 변경 가능)
     @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
     public void syncAllMembers() {
         log.info("[배치] 자산 동기화 시작");
-        // assetSyncService.syncAll();   // 로직은 Service에
-        log.info("[배치] 자산 동기화 완료");
+        assetSyncService.syncAll();
+        log.info("[배치] 자산 동기화 종료");
     }
 }

--- a/src/main/resources/config/app.properties
+++ b/src/main/resources/config/app.properties
@@ -20,3 +20,6 @@ kakao.auth.enabled=false
 kakao.client.id=${KAKAO_REST_API_KEY:local-dev-client-id}
 kakao.client.secret=${KAKAO_CLIENT_SECRET:}
 kakao.redirect.uri=http://localhost:5173/callback
+
+# Slack (배치 실패 알림)
+slack.webhook.url=${SLACK_WEBHOOK_URL:}

--- a/src/main/resources/mybatis/mapper/asset/ConnectedAccountMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/ConnectedAccountMapper.xml
@@ -23,6 +23,10 @@
          WHERE member_id = #{memberId}
     </select>
 
+    <select id="findAllMemberIds" resultType="java.lang.Long">
+        SELECT member_id FROM connected_account WHERE connected_status = 'ACTIVE'
+    </select>
+
     <insert id="insert" parameterType="com.team.independence.asset.domain.ConnectedAccount"
             useGeneratedKeys="true" keyProperty="id">
         INSERT INTO connected_account (member_id, connected_id, birth_date, connected_status)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #24

## 📝작업 내용

매일 새벽 4시(추후 논의를 통해 변경 가능) 전체 회원의 자산 정보를 CODEF API로 동기화하는 배치 스케줄러를 `@Scheduled`와 `batch` 프로필 방식으로 구현했습니다. 

### 1. `AssetSyncScheduler`: 스케줄러 완성
  - `@Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")`로 매일 새벽 4시 실행
  - 로직 없이 assetSyncService.syncAll() 위임만 수행
  - batch 프로필에서만 빈이 등록됨
  
### 2. `AssetSyncService` / `AssetSyncServiceImpl`: `syncAll()` 구현
- `connected_status = 'ACTIVE'`인 전체 회원을 순회하며 `syncAccounts()` 호출
- 한 회원 실패 시 예외를 격리해 다른 회원 동기화가 중단되지 않도록 처리
- 실패 정보는 `SyncFailure` 내부 클래스로 수집
- 순회 완료 후 실패 건이 있으면 Slack에 한 번에 요약 알림 발송

### 3. SlackNotifier: Slack 웹훅 알림 컴포넌트
- `external/slack/` 패키지에 위치
- Redis로 30분 내 중복 알림 억제
- Slack 전송 실패 시 예외를 삼켜 배치 진행에 영향 없음
- `slack.webhook.url`이 미설정이면 알림 건너뜀 
  
### 4. `ConnectedAccountMapper`: `findAllMemberIds()` 추가
- `connected_status = 'ACTIVE'` 조건으로 동기화 대상 회원 ID 전체 조회

### 5. 환경 변수
- `app.properties`에 `slack.webhook.url` 추가
- `.env.example`에 `SLACK_WEBHOOK_URL=` 추가

### Slack 알림 예시 (실패 시 예시)
```
[테스트] 자산 동기화 배치 실패
• memberId=999 / 연결 계좌 없음 (테스트용)
```


### 스크린샷
<img width="1116" height="253" alt="스크린샷 2026-08-03 오후 2 40 14" src="https://github.com/user-attachments/assets/3f1b2f0f-b289-4cf2-b7d0-e95ad4cabccd" />

<img width="1118" height="259" alt="스크린샷 2026-08-03 오후 2 41 17" src="https://github.com/user-attachments/assets/d9fb98ea-3c92-42ad-9442-60f94bc3cf9b" />

<img width="975" height="353" alt="스크린샷 2026-08-03 오후 2 42 10" src="https://github.com/user-attachments/assets/a091ccee-7644-4e36-af6d-60b7ed2d0435" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?