### PR TITLE
refactor(auth): AuthInterceptor @Profile 기반으로 분리 및 CORS 설정 추가

### DIFF
--- a/src/main/java/com/team/independence/auth/interceptor/DevAuthInterceptor.java
+++ b/src/main/java/com/team/independence/auth/interceptor/DevAuthInterceptor.java
@@ -1,0 +1,25 @@
+package com.team.independence.auth.interceptor;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+@Profile("local")
+public class DevAuthInterceptor implements HandlerInterceptor {
+
+    private static final Long DEV_MEMBER_ID = 1L;
+
+    @Override
+    public boolean preHandle(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull Object handler) {
+        request.setAttribute("memberId", DEV_MEMBER_ID);
+        return true;
+    }
+}

--- a/src/main/java/com/team/independence/auth/interceptor/ProdAuthInterceptor.java
+++ b/src/main/java/com/team/independence/auth/interceptor/ProdAuthInterceptor.java
@@ -3,9 +3,10 @@ package com.team.independence.auth.interceptor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team.independence.auth.jwt.JwtUtil;
 import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -14,38 +15,28 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Component
+@Profile("!local")
 @RequiredArgsConstructor
-public class AuthInterceptor implements HandlerInterceptor {
-
-    private static final Long DEV_MEMBER_ID = 1L;
+public class ProdAuthInterceptor implements HandlerInterceptor {
 
     private final JwtUtil jwtUtil;
     private final ObjectMapper objectMapper;
 
-    @Value("${kakao.auth.enabled:false}")
-    private boolean kakaoAuthEnabled;
-
     @Override
     public boolean preHandle(
             @NonNull HttpServletRequest request,
-            @NonNull HttpServletResponse response, @NonNull Object handler) throws Exception {
-        if (!kakaoAuthEnabled) {
-            request.setAttribute("memberId", DEV_MEMBER_ID);
-            return true;
-        }
-
+            @NonNull HttpServletResponse response,
+            @NonNull Object handler) throws Exception {
         String token = extractToken(request);
         if (token == null) {
-            writeError(response, new BusinessException(
-                    com.team.independence.common.exception.ErrorCode.UNAUTHORIZED));
+            writeError(response, new BusinessException(ErrorCode.UNAUTHORIZED));
             return false;
         }
 
         try {
             jwtUtil.validateOrThrow(token);
             if (!jwtUtil.isAccessToken(token)) {
-                writeError(response, new BusinessException(
-                        com.team.independence.common.exception.ErrorCode.AUTH_INVALID_TOKEN));
+                writeError(response, new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
                 return false;
             }
             request.setAttribute("memberId", jwtUtil.getMemberId(token));

--- a/src/main/java/com/team/independence/config/WebConfig.java
+++ b/src/main/java/com/team/independence/config/WebConfig.java
@@ -1,8 +1,8 @@
 package com.team.independence.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.team.independence.auth.interceptor.AuthInterceptor;
 import com.team.independence.common.resolver.LoginMemberArgumentResolver;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
@@ -36,11 +36,11 @@ import java.util.List;
         })
 public class WebConfig implements WebMvcConfigurer {
 
-    private final AuthInterceptor authInterceptor;
+    private final HandlerInterceptor authInterceptor;
     private final ObjectMapper objectMapper;
     private final LoginMemberArgumentResolver loginMemberArgumentResolver;
 
-    public WebConfig(AuthInterceptor authInterceptor, ObjectMapper objectMapper,
+    public WebConfig(HandlerInterceptor authInterceptor, ObjectMapper objectMapper,
                      LoginMemberArgumentResolver loginMemberArgumentResolver) {
         this.authInterceptor = authInterceptor;
         this.objectMapper = objectMapper;
@@ -50,7 +50,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins("http://localhost:5173")
+                .allowedOrigins("http://localhost:5173", "https://www.nagasseum.com")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/resources/config/app.properties
+++ b/src/main/resources/config/app.properties
@@ -14,9 +14,6 @@ jwt.access-token-validity-ms=1800000
 jwt.refresh-token-validity-ms=1209600000
 
 # Kakao OAuth
-# false: 시연 모드 (카카오 로그인 없이 DEV_MEMBER_ID 자동 주입)
-# true:  실제 카카오 로그인 + JWT 검증 활성화
-kakao.auth.enabled=false
 kakao.client.id=${KAKAO_REST_API_KEY:local-dev-client-id}
 kakao.client.secret=${KAKAO_CLIENT_SECRET:}
 kakao.redirect.uri=http://localhost:5173/callback


### PR DESCRIPTION
## #️⃣연관된 이슈

- #28 

## 📝작업 내용

`AuthInterceptor` 내부의 `@Value` 런타임 분기를 제거하고, `@Profile`을 통해 빌드 타임에 dev/prod 동작을 결정하도록 구조를 변경했습니다.

### 변경 전

```java
// AuthInterceptor.java — 하나의 클래스에 dev/prod 로직 혼재
@Value("${kakao.auth.enabled:false}")
private boolean kakaoAuthEnabled;

if (!kakaoAuthEnabled) {
    request.setAttribute("memberId", DEV_MEMBER_ID);  // dev 통과
    return true;
}
// JWT 검증...
```

### 변경 후

| 클래스 | 프로파일 | 동작 |
|---|---|---|
| `DevAuthInterceptor` | `@Profile("local")` | DEV_MEMBER_ID=1 자동 주입 |
| `ProdAuthInterceptor` | `@Profile("!local")` | JWT 검증만 수행 |

### 주요 변경 사항

- `AuthInterceptor` 삭제 → `DevAuthInterceptor` / `ProdAuthInterceptor`로 분리
- `WebConfig`: 주입 타입 `AuthInterceptor` → `HandlerInterceptor` 인터페이스로 변경
- CORS `allowedOrigins`에 `https://www.nagasseum.com` 추가 (운영 도메인 콜백 CORS 오류 해소)
- `app.properties`: 불필요해진 `kakao.auth.enabled` 제거

## 💬리뷰 요구사항(선택)
