### PR TITLE
hotfix: 카카오 redirect_uri 환경변수 주입으로 전환

### DIFF
--- a/src/main/resources/config/app.properties
+++ b/src/main/resources/config/app.properties
@@ -16,7 +16,7 @@ jwt.refresh-token-validity-ms=1209600000
 # Kakao OAuth
 kakao.client.id=${KAKAO_REST_API_KEY:local-dev-client-id}
 kakao.client.secret=${KAKAO_CLIENT_SECRET:}
-kakao.redirect.uri=http://localhost:5173/callback
+kakao.redirect.uri=${KAKAO_REDIRECT_URI:http://localhost:5173/callback}
 
 # Slack (배치 실패 알림)
 slack.webhook.url=${SLACK_WEBHOOK_URL:}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #31

## 📝작업 내용

`app.properties`에 하드코딩된 `kakao.redirect.uri` 값을 환경변수 주입 방식으로 변경합니다.

**변경 전**
```properties
kakao.redirect.uri=http://localhost:5173/callback
```

**변경 후**
```properties
kakao.redirect.uri=${KAKAO_REDIRECT_URI:http://localhost:5173/callback}
```

- 로컬 환경: 환경변수 미설정 시 기본값 `http://localhost:5173/callback` 자동 사용
- 운영 환경: 서버 `.env`에 `KAKAO_REDIRECT_URI=https://www.nagasseum.com/callback` 추가로 해결

> 기존 `DB_URL`, `REDIS_HOST`, `KAKAO_REST_API_KEY` 등의 처리 방식과 동일한 패턴

## 💬리뷰 요구사항(선택)

운영 서버 `.env` 파일에 아래 값 추가가 필요합니다. 배포 전 확인 부탁드립니다.
```
KAKAO_REDIRECT_URI=https://www.nagasseum.com/callback
```