### PR TITLE
feat(asset): 금융기관 목록 조회 시 연동 여부(isConnected) 포함

### DIFF
--- a/src/main/java/com/team/independence/asset/controller/AssetController.java
+++ b/src/main/java/com/team/independence/asset/controller/AssetController.java
@@ -7,6 +7,7 @@ import com.team.independence.asset.service.AssetSummaryService;
 import com.team.independence.asset.service.AssetSyncService;
 import com.team.independence.asset.service.InstitutionService;
 import com.team.independence.asset.service.ManualAssetService;
+import com.team.independence.common.annotation.LoginMember;
 import com.team.independence.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -33,8 +34,9 @@ public class AssetController {
     }
 
     @GetMapping("/organizations")
-    public ApiResponse<List<OrganizationResponse>> getOrganizations() {
-        return ApiResponse.ok(institutionService.getOrganizations());
+    public ApiResponse<List<OrganizationResponse>> getOrganizations(
+            @LoginMember Long memberId) {
+        return ApiResponse.ok(institutionService.getOrganizations(memberId));
     }
 
     @GetMapping("/connections")

--- a/src/main/java/com/team/independence/asset/domain/Institution.java
+++ b/src/main/java/com/team/independence/asset/domain/Institution.java
@@ -17,4 +17,5 @@ public class Institution {
     private String logoUrl;
     private int displayOrder;
     private boolean isActive;
+    private boolean isConnected;
 }

--- a/src/main/java/com/team/independence/asset/dto/OrganizationResponse.java
+++ b/src/main/java/com/team/independence/asset/dto/OrganizationResponse.java
@@ -13,6 +13,7 @@ public class OrganizationResponse {
     private String organizationName;
     private String businessType;
     private List<String> supportedLoginTypes;
+    private boolean isConnected;
 
     public static OrganizationResponse from(Institution institution) {
         return OrganizationResponse.builder()
@@ -20,6 +21,7 @@ public class OrganizationResponse {
                 .organizationName(institution.getName())
                 .businessType(institution.getBusinessType())
                 .supportedLoginTypes(List.of("ID"))
+                .isConnected(institution.isConnected())
                 .build();
     }
 }

--- a/src/main/java/com/team/independence/asset/mapper/InstitutionMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/InstitutionMapper.java
@@ -2,11 +2,13 @@ package com.team.independence.asset.mapper;
 
 import com.team.independence.asset.domain.Institution;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
 @Mapper
 public interface InstitutionMapper {
     List<Institution> findAllActive();
+    List<Institution> findAllActiveWithConnectionStatus(@Param("memberId") Long memberId);
     Institution findByCode(String code);
 }

--- a/src/main/java/com/team/independence/asset/service/InstitutionService.java
+++ b/src/main/java/com/team/independence/asset/service/InstitutionService.java
@@ -6,6 +6,6 @@ import com.team.independence.asset.dto.OrganizationResponse;
 import java.util.List;
 
 public interface InstitutionService {
-    List<OrganizationResponse> getOrganizations();
+    List<OrganizationResponse> getOrganizations(Long memberId);
     Institution getByCode(String code);
 }

--- a/src/main/java/com/team/independence/asset/service/InstitutionServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/InstitutionServiceImpl.java
@@ -16,8 +16,8 @@ public class InstitutionServiceImpl implements InstitutionService {
     private final InstitutionMapper institutionMapper;
 
     @Override
-    public List<OrganizationResponse> getOrganizations() {
-        return institutionMapper.findAllActive().stream()
+    public List<OrganizationResponse> getOrganizations(Long memberId) {
+        return institutionMapper.findAllActiveWithConnectionStatus(memberId).stream()
                 .map(OrganizationResponse::from)
                 .collect(Collectors.toList());
     }

--- a/src/main/resources/mybatis/mapper/asset/InstitutionMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/InstitutionMapper.xml
@@ -16,6 +16,25 @@
         <result property="isActive"        column="is_active"/>
     </resultMap>
 
+    <resultMap id="institutionWithStatusMap" type="com.team.independence.asset.domain.Institution"
+               extends="institutionMap">
+        <result property="isConnected" column="is_connected"/>
+    </resultMap>
+
+    <select id="findAllActiveWithConnectionStatus" resultMap="institutionWithStatusMap">
+        SELECT i.code, i.name, i.institution_type, i.business_type, i.login_type,
+               i.product_label, i.logo_url, i.display_order, i.is_active,
+               CASE WHEN ci.institution_code IS NOT NULL THEN TRUE ELSE FALSE END AS is_connected
+          FROM institution i
+          LEFT JOIN connected_institution ci
+            ON ci.institution_code = i.code
+           AND ci.connected_account_id = (
+                 SELECT id FROM connected_account WHERE member_id = #{memberId}
+               )
+         WHERE i.is_active = TRUE
+         ORDER BY i.display_order
+    </select>
+
     <select id="findAllActive" resultMap="institutionMap">
         SELECT code, name, institution_type, business_type, login_type,
                product_label, logo_url, display_order, is_active


### PR DESCRIPTION
## #️⃣연관된 이슈

- #34 

## 📝작업 내용

`GET /api/v1/assets/organizations` 응답에 `isConnected` 필드를 추가하여, 이미 연동된 기관인지 여부를 파악할 수 있도록 합니다.


**`Institution` 도메인**
- `isConnected` 필드 추가 (DB 컬럼 아님, 쿼리 시 계산되는 값)

**`InstitutionMapper` + XML**
- `findAllActiveWithConnectionStatus(memberId)` 추가
- `institution` LEFT JOIN `connected_institution` (connected_account_id 서브쿼리 기준)
- `institutionWithStatusMap` resultMap 추가 (`institutionMap` 확장)

**`OrganizationResponse`**
- `isConnected: Boolean` 필드 추가
- `from(Institution)` 팩토리 메서드에서 `institution.isConnected()` 읽도록 수정

**`InstitutionService / InstitutionServiceImpl`**
- `getOrganizations()` → `getOrganizations(Long memberId)` 시그니처 변경

**`AssetController`**
- `@RequestParam Long memberId` → `@LoginMember Long memberId` 로 전환

### 응답 예시

```json
{
  "success": true,
  "data": [
    {
      "organizationCode": "0004",
      "organizationName": "KB국민은행",
      "businessType": "BK",
      "supportedLoginTypes": ["ID"],
      "isConnected": true
    },
    {
      "organizationCode": "0020",
      "organizationName": "우리은행",
      "businessType": "BK",
      "supportedLoginTypes": ["ID"],
      "isConnected": false
    }
  ],
  "error": null
}
```

### 엣지 케이스

- `connected_account`가 없는 신규 회원: 서브쿼리가 빈 결과 반환 → LEFT JOIN 조건 불성립 → 전체 `isConnected: false` (안전)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?