### PR TITLE
feat(goal): 목표 달성 상세 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 logs/
 .claude/
 CLAUDE.md
+pr.md

--- a/src/main/java/com/team/independence/common/exception/ErrorCode.java
+++ b/src/main/java/com/team/independence/common/exception/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
     GOAL_MONTHLY_SAVINGS_ZERO("GOAL_005", "월 저축액은 0보다 커야 합니다.", HttpStatus.BAD_REQUEST),
     GOAL_MONTHLY_RENT_REQUIRED("GOAL_006", "월세 거래는 월세 상한(monthlyRentMax) 입력이 필요합니다.", HttpStatus.BAD_REQUEST),
     GOAL_NO_MARKET_DATA("GOAL_007", "해당 조건의 실거래 데이터가 없습니다.", HttpStatus.NOT_FOUND),
+    GOAL_FORBIDDEN("GOAL_008", "접근할 수 없는 목표입니다.", HttpStatus.FORBIDDEN),
 
     // ===== 또래 비교 COMPARE_xxx =====
     COMPARE_SNAPSHOT_NOT_FOUND("COMPARE_001", "비교할 집계 데이터가 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/team/independence/goal/controller/GoalController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalController.java
@@ -1,13 +1,18 @@
 package com.team.independence.goal.controller;
 
+import com.team.independence.common.annotation.LoginMember;
 import com.team.independence.common.response.ApiResponse;
 import com.team.independence.goal.dto.GoalCreateRequest;
+import com.team.independence.goal.dto.GoalDetailResponse;
 import com.team.independence.goal.dto.GoalDiagnosisRequest;
 import com.team.independence.goal.dto.GoalDiagnosisResponse;
 import com.team.independence.goal.dto.GoalResponse;
+import com.team.independence.goal.service.GoalDetailService;
 import com.team.independence.goal.service.GoalService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class GoalController {
 
     private final GoalService goalService;
+    private final GoalDetailService goalDetailService;
 
     @PostMapping("/diagnosis")
     public ApiResponse<GoalDiagnosisResponse> diagnose(
@@ -33,5 +39,12 @@ public class GoalController {
             @RequestParam Long memberId,
             @Valid @RequestBody GoalCreateRequest request) {
         return ApiResponse.ok(goalService.createGoal(memberId, request));
+    }
+
+    @GetMapping("/{goalId}/detail")
+    public ApiResponse<GoalDetailResponse> getGoalDetail(
+            @LoginMember Long memberId,
+            @PathVariable Long goalId) {
+        return ApiResponse.ok(goalDetailService.getGoalDetail(memberId, goalId));
     }
 }

--- a/src/main/java/com/team/independence/goal/domain/Goal.java
+++ b/src/main/java/com/team/independence/goal/domain/Goal.java
@@ -2,10 +2,17 @@ package com.team.independence.goal.domain;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+/** 기본 생성자와 setter는 MyBatis가 조회 결과를 매핑할 때 쓴다. */
 @Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class Goal {
     private Long id;

--- a/src/main/java/com/team/independence/goal/domain/GoalHousing.java
+++ b/src/main/java/com/team/independence/goal/domain/GoalHousing.java
@@ -2,10 +2,17 @@ package com.team.independence.goal.domain;
 
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+/** 기본 생성자와 setter는 MyBatis가 조회 결과를 매핑할 때 쓴다. */
 @Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class GoalHousing {
     private Long goalId;

--- a/src/main/java/com/team/independence/goal/domain/SavingBasis.java
+++ b/src/main/java/com/team/independence/goal/domain/SavingBasis.java
@@ -1,0 +1,11 @@
+package com.team.independence.goal.domain;
+
+/** 예상 달성 시점을 계산할 때 기준으로 삼는 월 저축액의 출처. */
+public enum SavingBasis {
+    /** 목표에 설정된 고정 저축액 (goal.monthly_saving) */
+    FIXED,
+    /** 최근 3개월 실제 저축액 평균 */
+    RECENT_AVERAGE,
+    /** 가장 최근 달 실제 저축액 */
+    LATEST
+}

--- a/src/main/java/com/team/independence/goal/domain/SavingRecord.java
+++ b/src/main/java/com/team/independence/goal/domain/SavingRecord.java
@@ -1,0 +1,29 @@
+package com.team.independence.goal.domain;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** 목표별 월 저축 기록. 목표당 월 1건(uk_saving_goal_ym). */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SavingRecord {
+    private Long id;
+    private Long goalId;
+    /** 기록 연월 YYYYMM */
+    private String recordYm;
+    /** 그 달 목표 저축액(그 시점 goal.monthly_saving 복사 고정) */
+    private Long targetSaving;
+    /** 그 달 실제 저축액(기본값은 목표와 동일, 다르게 저축한 달만 수정) */
+    private Long actualSaving;
+    /** 사용자가 actualSaving을 직접 수정했는지 여부 */
+    private Boolean isModified;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/team/independence/goal/dto/GoalDetailResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalDetailResponse.java
@@ -1,0 +1,87 @@
+package com.team.independence.goal.dto;
+
+import com.team.independence.goal.domain.SavingBasis;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 목표 상세 화면 응답.
+ * YearMonth는 "2027-12" 형태로 직렬화된다(RootConfig의 JavaTimeModule + WRITE_DATES_AS_TIMESTAMPS=false).
+ * 원시 타입 대신 래퍼 타입을 쓴다 — 값이 없는 경우를 null로 표현해야 하고,
+ * boolean 필드는 Lombok getter 이름 때문에 JSON 키가 잘리는 문제가 있다.
+ */
+@Getter
+@Builder
+public class GoalDetailResponse {
+
+    private Long goalId;
+    private String goalType;
+    /** ACTIVE / ACHIEVED / ARCHIVED */
+    private String status;
+    /** 목표 시점 */
+    private YearMonth targetDate;
+
+    private Housing housing;
+    private Progress progress;
+    private SavingStatus savingStatus;
+    /** 저축 기준별 예상 달성 시점 */
+    private List<Forecast> forecasts;
+
+    /** 희망 주거 조건 (goal_housing) */
+    @Getter
+    @Builder
+    public static class Housing {
+        private String regionCode;
+        private HousingType housingType;
+        private DealType dealType;
+        /** 희망 평수 범위 */
+        private Integer areaMin;
+        private Integer areaMax;
+        /** 희망 보증금 범위 */
+        private Long depositMin;
+        private Long depositMax;
+    }
+
+    /** 목표 달성 현황 */
+    @Getter
+    @Builder
+    public static class Progress {
+        /** 목표 금액(설정 시점 고정) */
+        private Long targetAmount;
+        /** 현재 자금(순자산) */
+        private Long currentAmount;
+        /** 남은 금액 = 목표 − 현재, 최소 0 */
+        private Long remainingAmount;
+        /** 달성률(%) */
+        private Double achievementRate;
+    }
+
+    /** 월 저축 현황. 저축 기록이 없으면 고정 저축액을 뺀 나머지는 null. */
+    @Getter
+    @Builder
+    public static class SavingStatus {
+        /** 고정 저축액 (goal.monthly_saving) */
+        private Long fixedSaving;
+        /** 최근 3개월 평균 실제 저축액. 기록 3건 미만이면 null */
+        private Long recentAverageSaving;
+        /** 가장 최근 달 실제 저축액. 기록이 없으면 null */
+        private Long latestSaving;
+    }
+
+    /** 특정 월 저축액을 유지했을 때의 예상 달성 시점 */
+    @Getter
+    @Builder
+    public static class Forecast {
+        private SavingBasis basis;
+        /** 해당 기준의 월 저축액 */
+        private Long monthlySaving;
+        /** 예상 달성 시점. 이미 달성했거나 탐색 상한 내에 도달하지 못하면 null */
+        private YearMonth expectedDate;
+        /** 고정 기준 대비 앞당겨진 개월 수(양수=단축, 0=동일, 음수=지연). 비교 불가면 null */
+        private Integer monthsDiff;
+    }
+}

--- a/src/main/java/com/team/independence/goal/mapper/GoalHousingMapper.java
+++ b/src/main/java/com/team/independence/goal/mapper/GoalHousingMapper.java
@@ -2,8 +2,12 @@ package com.team.independence.goal.mapper;
 
 import com.team.independence.goal.domain.GoalHousing;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface GoalHousingMapper {
     void insert(GoalHousing goalHousing);
+
+    /** 목표의 주거 희망 조건 조회(목표 1 : 1). */
+    GoalHousing findByGoalId(@Param("goalId") Long goalId);
 }

--- a/src/main/java/com/team/independence/goal/mapper/GoalMapper.java
+++ b/src/main/java/com/team/independence/goal/mapper/GoalMapper.java
@@ -10,4 +10,7 @@ public interface GoalMapper {
 
     /** 회원에게 ACTIVE 목표가 이미 있는지 확인한다(동시 ACTIVE 목표는 1개만 허용). */
     boolean existsActiveByMemberId(@Param("memberId") Long memberId);
+
+    /** 목표 단건 조회. 소유권 검증은 호출부에서 memberId를 비교해 수행한다. */
+    Goal findById(@Param("id") Long id);
 }

--- a/src/main/java/com/team/independence/goal/mapper/SavingRecordMapper.java
+++ b/src/main/java/com/team/independence/goal/mapper/SavingRecordMapper.java
@@ -1,0 +1,16 @@
+package com.team.independence.goal.mapper;
+
+import com.team.independence.goal.domain.SavingRecord;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface SavingRecordMapper {
+
+    /**
+     * 최근 저축 기록을 연월 내림차순으로 조회한다(첫 번째가 가장 최근 달).
+     * 최근 3개월 평균·가장 최근 달 저축액 산출에 쓴다.
+     */
+    List<SavingRecord> findRecentByGoalId(@Param("goalId") Long goalId, @Param("limit") int limit);
+}

--- a/src/main/java/com/team/independence/goal/service/GoalDetailService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalDetailService.java
@@ -1,0 +1,12 @@
+package com.team.independence.goal.service;
+
+import com.team.independence.goal.dto.GoalDetailResponse;
+
+public interface GoalDetailService {
+
+    /**
+     * 목표 상세 화면 데이터를 조회한다.
+     * 목표가 없으면 GOAL_NOT_FOUND, 다른 회원의 목표면 GOAL_FORBIDDEN.
+     */
+    GoalDetailResponse getGoalDetail(Long memberId, Long goalId);
+}

--- a/src/main/java/com/team/independence/goal/service/GoalDetailServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalDetailServiceImpl.java
@@ -1,0 +1,189 @@
+package com.team.independence.goal.service;
+
+import com.team.independence.asset.dto.AssetNetWorthBreakdown;
+import com.team.independence.asset.service.AssetService;
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.goal.domain.Goal;
+import com.team.independence.goal.domain.GoalHousing;
+import com.team.independence.goal.domain.SavingBasis;
+import com.team.independence.goal.domain.SavingRecord;
+import com.team.independence.goal.dto.GoalDetailResponse;
+import com.team.independence.goal.mapper.GoalHousingMapper;
+import com.team.independence.goal.mapper.GoalMapper;
+import com.team.independence.goal.mapper.SavingRecordMapper;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 목표 상세 화면 데이터를 모아서 반환한다.
+ * 예상 달성 시점(forecasts)은 목표 진단과 같은 복리 계산을 쓴다 —
+ * 월 저축액만 기준별로 바꿔 넣고 목표 금액에 닿는 시점을 GoalService에서 구한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class GoalDetailServiceImpl implements GoalDetailService {
+
+    /** 최근 평균 저축액을 낼 때 보는 개월 수. 이보다 기록이 적으면 평균을 내지 않는다. */
+    private static final int RECENT_MONTHS = 3;
+
+    private final GoalMapper goalMapper;
+    private final GoalHousingMapper goalHousingMapper;
+    private final SavingRecordMapper savingRecordMapper;
+    private final AssetService assetService;
+    private final GoalService goalService; // 진단과 동일한 복리 계산 재사용
+
+    @Override
+    public GoalDetailResponse getGoalDetail(Long memberId, Long goalId) {
+        Goal goal = findOwnedGoal(memberId, goalId);
+        GoalHousing housing = goalHousingMapper.findByGoalId(goalId);
+
+        assetService.validateConnectedAccountExists(memberId);
+        AssetNetWorthBreakdown netWorth = assetService.getNetWorthBreakdown(memberId);
+        long currentAmount = netWorth.getInterestBearingAssets() + netWorth.getFlatRecognizedAssets();
+
+        long targetAmount = goal.getTargetAmount();
+        long remainingAmount = Math.max(0, targetAmount - currentAmount);
+
+        List<SavingRecord> recentRecords = savingRecordMapper.findRecentByGoalId(goalId, RECENT_MONTHS);
+        GoalDetailResponse.SavingStatus savingStatus = buildSavingStatus(goal, recentRecords);
+
+        return GoalDetailResponse.builder()
+                .goalId(goal.getId())
+                .goalType(goal.getGoalType())
+                .status(goal.getStatus())
+                .targetDate(YearMonth.from(goal.getTargetDate()))
+                .housing(buildHousing(housing))
+                .progress(GoalDetailResponse.Progress.builder()
+                        .targetAmount(targetAmount)
+                        .currentAmount(currentAmount)
+                        .remainingAmount(remainingAmount)
+                        .achievementRate(calculateAchievementRate(currentAmount, targetAmount))
+                        .build())
+                .savingStatus(savingStatus)
+                .forecasts(buildForecasts(netWorth, targetAmount, remainingAmount, savingStatus))
+                .build();
+    }
+
+    /** 목표를 찾고 소유자인지 확인한다. */
+    private Goal findOwnedGoal(Long memberId, Long goalId) {
+        Goal goal = goalMapper.findById(goalId);
+        if (goal == null) {
+            throw new BusinessException(ErrorCode.GOAL_NOT_FOUND);
+        }
+        if (!goal.getMemberId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.GOAL_FORBIDDEN);
+        }
+        return goal;
+    }
+
+    private GoalDetailResponse.Housing buildHousing(GoalHousing housing) {
+        if (housing == null) {
+            return null;
+        }
+        return GoalDetailResponse.Housing.builder()
+                .regionCode(housing.getRegionCode())
+                .housingType(housing.getHousingType())
+                .dealType(housing.getDealType())
+                .areaMin(housing.getAreaMin())
+                .areaMax(housing.getAreaMax())
+                .depositMin(housing.getDepositMin())
+                .depositMax(housing.getDepositMax())
+                .build();
+    }
+
+    /**
+     * 고정 저축액은 목표에서, 최근 저축액은 기록에서 뽑는다.
+     * 기록이 RECENT_MONTHS건에 못 미치면 평균은 신뢰할 수 없다고 보고 내지 않는다.
+     */
+    private GoalDetailResponse.SavingStatus buildSavingStatus(Goal goal, List<SavingRecord> recentRecords) {
+        Long latestSaving = recentRecords.isEmpty() ? null : recentRecords.get(0).getActualSaving();
+
+        Long recentAverageSaving = null;
+        if (recentRecords.size() >= RECENT_MONTHS) {
+            long sum = 0;
+            for (SavingRecord record : recentRecords) {
+                sum += record.getActualSaving();
+            }
+            recentAverageSaving = Math.round((double) sum / recentRecords.size());
+        }
+
+        return GoalDetailResponse.SavingStatus.builder()
+                .fixedSaving(goal.getMonthlySaving())
+                .recentAverageSaving(recentAverageSaving)
+                .latestSaving(latestSaving)
+                .build();
+    }
+
+    /** 달성률(%). 0~100으로 자른다 — 또래 비교 집계(goal_snapshot)와 같은 규칙. */
+    private Double calculateAchievementRate(long currentAmount, long targetAmount) {
+        if (targetAmount <= 0) {
+            return 0.0;
+        }
+        double rate = currentAmount * 100.0 / targetAmount;
+        double clamped = Math.min(100.0, Math.max(0.0, rate));
+        return Math.round(clamped * 100) / 100.0;
+    }
+
+    /**
+     * 저축 기준별 예상 달성 시점.
+     * 기준 금액이 없거나 0 이하면 계산이 불가하므로 목록에서 뺀다.
+     * monthsDiff는 고정 저축액 기준과 비교한 값이라, 고정 기준을 못 구하면 null이 된다.
+     */
+    private List<GoalDetailResponse.Forecast> buildForecasts(AssetNetWorthBreakdown netWorth,
+                                                             long targetAmount,
+                                                             long remainingAmount,
+                                                             GoalDetailResponse.SavingStatus savingStatus) {
+        Long fixedMonths = calculateMonths(netWorth, savingStatus.getFixedSaving(), targetAmount);
+
+        List<GoalDetailResponse.Forecast> forecasts = new ArrayList<>();
+        addForecast(forecasts, SavingBasis.FIXED, savingStatus.getFixedSaving(),
+                netWorth, targetAmount, remainingAmount, fixedMonths);
+        addForecast(forecasts, SavingBasis.RECENT_AVERAGE, savingStatus.getRecentAverageSaving(),
+                netWorth, targetAmount, remainingAmount, fixedMonths);
+        addForecast(forecasts, SavingBasis.LATEST, savingStatus.getLatestSaving(),
+                netWorth, targetAmount, remainingAmount, fixedMonths);
+        return forecasts;
+    }
+
+    private void addForecast(List<GoalDetailResponse.Forecast> forecasts,
+                             SavingBasis basis,
+                             Long monthlySaving,
+                             AssetNetWorthBreakdown netWorth,
+                             long targetAmount,
+                             long remainingAmount,
+                             Long fixedMonths) {
+        if (monthlySaving == null || monthlySaving <= 0) {
+            return;
+        }
+
+        // 이미 달성했으면 예상 시점을 따질 게 없다.
+        if (remainingAmount == 0) {
+            forecasts.add(GoalDetailResponse.Forecast.builder()
+                    .basis(basis)
+                    .monthlySaving(monthlySaving)
+                    .expectedDate(null)
+                    .monthsDiff(0)
+                    .build());
+            return;
+        }
+
+        Long months = calculateMonths(netWorth, monthlySaving, targetAmount);
+        forecasts.add(GoalDetailResponse.Forecast.builder()
+                .basis(basis)
+                .monthlySaving(monthlySaving)
+                .expectedDate(months == null ? null : YearMonth.now().plusMonths(months))
+                .monthsDiff(fixedMonths == null || months == null ? null : (int) (fixedMonths - months))
+                .build());
+    }
+
+    private Long calculateMonths(AssetNetWorthBreakdown netWorth, Long monthlySaving, long targetAmount) {
+        if (monthlySaving == null || monthlySaving <= 0) {
+            return null;
+        }
+        return goalService.calculateMonthToReach(netWorth, monthlySaving, targetAmount);
+    }
+}

--- a/src/main/java/com/team/independence/goal/service/GoalService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalService.java
@@ -1,5 +1,6 @@
 package com.team.independence.goal.service;
 
+import com.team.independence.asset.dto.AssetNetWorthBreakdown;
 import com.team.independence.goal.dto.GoalCreateRequest;
 import com.team.independence.goal.dto.GoalDiagnosisRequest;
 import com.team.independence.goal.dto.GoalDiagnosisResponse;
@@ -10,4 +11,11 @@ public interface GoalService {
 
     /** 진단 결과를 목표로 저장한다. 이미 ACTIVE 목표가 있으면 GOAL_ALREADY_EXISTS로 거부한다. */
     GoalResponse createGoal(Long memberId, GoalCreateRequest request);
+
+    /**
+     * 매달 monthlySaving씩 저축할 때 예상 예산이 targetAmount 이상이 되는 최초 개월수.
+     * 진단과 동일한 복리 계산을 쓴다(예적금만 거치식 성장 + 월저축액 적립식 미래가치).
+     * 이미 도달했으면 0, 저축액이 0 이하거나 탐색 상한까지 못 미치면 null.
+     */
+    Long calculateMonthToReach(AssetNetWorthBreakdown netWorth, long monthlySaving, long targetAmount);
 }

--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -49,6 +49,8 @@ public class GoalServiceImpl implements GoalService {
     private static final long EXTEND_PERIOD_MAX_MONTHS = 240;
     /** 평수 축소 제안 탐색 상한(평) */
     private static final int REDUCE_SIZE_MAX_STEPS = 10;
+    /** 예상 달성 시점 탐색 상한(개월). 저축액이 미미해 사실상 도달 불가할 때 무한 루프를 막는 안전장치. */
+    private static final long MAX_FORECAST_MONTHS = 1200;
 
     private final RegionQueryService regionQueryService;
     private final AssetService assetService; // 자산 정보 조회
@@ -235,6 +237,34 @@ public class GoalServiceImpl implements GoalService {
                 .targetRentMiddleAmount(request.getTargetRentMiddleAmount())
                 .createdAt(LocalDateTime.now())
                 .build();
+    }
+
+    /**
+     * 목표 달성 상세 조회의 예상 달성 시점 계산에 쓴다.
+     * 진단의 기간 연장 제안(calculateExtendPeriodSuggestion)과 같은 방식으로,
+     * 저축액을 고정한 채 개월수를 늘려가며 예산이 목표 금액에 닿는 첫 시점을 찾는다.
+     * 화면에 필요한 개월수를 그대로 보여줘야 해서 진단의 240개월 상한 대신 안전장치 상한만 둔다.
+     */
+    @Override
+    public Long calculateMonthToReach(AssetNetWorthBreakdown netWorth, long monthlySaving, long targetAmount) {
+        long growingAssets = netWorth.getInterestBearingAssets(); // 이자로 불어나는 자산(예적금)
+        long fixedAssets = netWorth.getFlatRecognizedAssets();    // 원금 그대로 인정하는 자산
+
+        if (growingAssets + fixedAssets >= targetAmount) {
+            return 0L;
+        }
+        if (monthlySaving <= 0) {
+            return null;
+        }
+
+        for (long months = 1; months <= MAX_FORECAST_MONTHS; months++) {
+            long expectedBudget = calculateGrownAmount(growingAssets, months) + fixedAssets
+                    + calculateProjectedSavings(monthlySaving, months);
+            if (expectedBudget >= targetAmount) {
+                return months;
+            }
+        }
+        return null;
     }
 
     /** RentMedianService 호출용 요청 조립. sizeMin/sizeMax는 평 단위 그대로 넘기면 내부에서 ㎡로 환산한다. */

--- a/src/main/resources/mybatis/mapper/goal/GoalHousingMapper.xml
+++ b/src/main/resources/mybatis/mapper/goal/GoalHousingMapper.xml
@@ -4,6 +4,21 @@
 
 <mapper namespace="com.team.independence.goal.mapper.GoalHousingMapper">
 
+    <resultMap id="goalHousingMap" type="com.team.independence.goal.domain.GoalHousing">
+        <id     property="goalId"          column="goal_id"/>
+        <result property="regionCode"      column="region_code"/>
+        <result property="housingType"     column="housing_type"
+                javaType="com.team.independence.property.domain.HousingType"/>
+        <result property="dealType"        column="deal_type"
+                javaType="com.team.independence.property.domain.DealType"/>
+        <result property="areaMin"         column="area_min"/>
+        <result property="areaMax"         column="area_max"/>
+        <result property="depositMin"      column="deposit_min"/>
+        <result property="depositMax"      column="deposit_max"/>
+        <result property="monthlyRentMin"  column="monthly_rent_min"/>
+        <result property="monthlyRentMax"  column="monthly_rent_max"/>
+    </resultMap>
+
     <insert id="insert" parameterType="com.team.independence.goal.domain.GoalHousing">
         INSERT INTO goal_housing (
             goal_id, region_code, housing_type, deal_type,
@@ -15,5 +30,13 @@
             #{monthlyRentMin}, #{monthlyRentMax}
         )
     </insert>
+
+    <select id="findByGoalId" resultMap="goalHousingMap">
+        SELECT goal_id, region_code, housing_type, deal_type,
+               area_min, area_max, deposit_min, deposit_max,
+               monthly_rent_min, monthly_rent_max
+          FROM goal_housing
+         WHERE goal_id = #{goalId}
+    </select>
 
 </mapper>

--- a/src/main/resources/mybatis/mapper/goal/GoalMapper.xml
+++ b/src/main/resources/mybatis/mapper/goal/GoalMapper.xml
@@ -4,6 +4,21 @@
 
 <mapper namespace="com.team.independence.goal.mapper.GoalMapper">
 
+    <resultMap id="goalMap" type="com.team.independence.goal.domain.Goal">
+        <id     property="id"                        column="id"/>
+        <result property="memberId"                  column="member_id"/>
+        <result property="goalType"                  column="goal_type"/>
+        <result property="targetAmount"              column="target_amount"/>
+        <result property="targetRentMiddleAmount"    column="target_rent_middle_amount"/>
+        <result property="targetDate"                column="target_date"/>
+        <result property="monthlySaving"             column="monthly_saving"/>
+        <result property="status"                    column="status"/>
+        <result property="marketAlertDismissedAt"    column="market_alert_dismissed_at"/>
+        <result property="marketAlertDismissedPrice" column="market_alert_dismissed_price"/>
+        <result property="createdAt"                 column="created_at"/>
+        <result property="updatedAt"                 column="updated_at"/>
+    </resultMap>
+
     <insert id="insert" parameterType="com.team.independence.goal.domain.Goal"
             useGeneratedKeys="true" keyProperty="id">
         INSERT INTO goal (
@@ -19,6 +34,15 @@
         SELECT EXISTS(
             SELECT 1 FROM goal WHERE member_id = #{memberId} AND status = 'ACTIVE'
         )
+    </select>
+
+    <select id="findById" resultMap="goalMap">
+        SELECT id, member_id, goal_type, target_amount, target_rent_middle_amount,
+               target_date, monthly_saving, status,
+               market_alert_dismissed_at, market_alert_dismissed_price,
+               created_at, updated_at
+          FROM goal
+         WHERE id = #{id}
     </select>
 
 </mapper>

--- a/src/main/resources/mybatis/mapper/goal/SavingRecordMapper.xml
+++ b/src/main/resources/mybatis/mapper/goal/SavingRecordMapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.team.independence.goal.mapper.SavingRecordMapper">
+
+    <resultMap id="savingRecordMap" type="com.team.independence.goal.domain.SavingRecord">
+        <id     property="id"            column="id"/>
+        <result property="goalId"        column="goal_id"/>
+        <result property="recordYm"      column="record_ym"/>
+        <result property="targetSaving"  column="target_saving"/>
+        <result property="actualSaving"  column="actual_saving"/>
+        <result property="isModified"    column="is_modified"/>
+        <result property="createdAt"     column="created_at"/>
+        <result property="updatedAt"     column="updated_at"/>
+    </resultMap>
+
+    <!-- record_ym DESC 정렬은 uk_saving_goal_ym (goal_id, record_ym) 인덱스를 그대로 탄다. -->
+    <select id="findRecentByGoalId" resultMap="savingRecordMap">
+        SELECT id, goal_id, record_ym, target_saving, actual_saving,
+               is_modified, created_at, updated_at
+          FROM saving_record
+         WHERE goal_id = #{goalId}
+         ORDER BY record_ym DESC
+         LIMIT #{limit}
+    </select>
+
+</mapper>

--- a/src/test/java/com/team/independence/goal/mapper/GoalDetailMapperIntegrationTest.java
+++ b/src/test/java/com/team/independence/goal/mapper/GoalDetailMapperIntegrationTest.java
@@ -1,0 +1,250 @@
+package com.team.independence.goal.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.team.independence.config.RootConfig;
+import com.team.independence.goal.domain.Goal;
+import com.team.independence.goal.domain.GoalHousing;
+import com.team.independence.goal.domain.SavingRecord;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import java.time.LocalDate;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * 목표 상세 조회 매퍼의 XML 매핑 통합 테스트.
+ *
+ * <p>GoalDetailServiceImplTest는 가짜 매퍼를 끼워 자바 로직만 본다. 그래서 XML의
+ * SQL과 resultMap은 한 줄도 검증되지 않는다. 이 테스트는 반대로 실제 MySQL에 붙어
+ * 컬럼이 도메인 필드와 제대로 물리는지만 본다. 특히 컴파일로 잡히지 않는 것들 —
+ * enum 변환(housing_type/deal_type), LocalDate, Boolean, 정렬과 LIMIT.
+ *
+ * <p><b>테스트가 만든 행은 끝나고 모두 지운다.</b> 다른 회원의 목표는 건드리지 않는다.
+ *
+ * <p>실제 DB가 필요해 CI에서는 돌릴 수 없다. 로컬에서 확인할 때만
+ * 아래 @Disabled를 잠시 주석 처리하고 실행한다.
+ *
+ * <p>사전 조건: member와 region에 행이 하나라도 있어야 한다(FK). 없으면 건너뛴다.
+ */
+@Disabled("실제 DB가 필요해 로컬에서만 실행")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = RootConfig.class)
+class GoalDetailMapperIntegrationTest {
+
+    private static final long TARGET_AMOUNT = 300_000_000L;
+    private static final long MONTHLY_SAVING = 1_500_000L;
+    private static final LocalDate TARGET_DATE = LocalDate.of(2027, 12, 1);
+
+    @Autowired
+    private GoalMapper goalMapper;
+
+    @Autowired
+    private GoalHousingMapper goalHousingMapper;
+
+    @Autowired
+    private SavingRecordMapper savingRecordMapper;
+
+    @Autowired
+    private DataSource dataSource;
+
+    private JdbcTemplate jdbc;
+
+    /** 테스트가 만든 목표. FK 때문에 자식 행부터 지워야 한다. */
+    private Long goalId;
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        jdbc = new JdbcTemplate(dataSource);
+
+        memberId = firstOrNull("SELECT id FROM member ORDER BY id LIMIT 1", Long.class);
+        String regionCode = firstOrNull("SELECT code FROM region ORDER BY code LIMIT 1", String.class);
+        assumeTrue(memberId != null && regionCode != null,
+                "member 또는 region에 데이터가 없어 건너뜁니다. sql/full_schema.sql과 초기 데이터를 넣어주세요.");
+
+        Goal goal = Goal.builder()
+                .memberId(memberId)
+                .goalType("HOUSING")
+                .targetAmount(TARGET_AMOUNT)
+                .targetRentMiddleAmount(280_000_000L)
+                .targetDate(TARGET_DATE)
+                .monthlySaving(MONTHLY_SAVING)
+                .status("ACTIVE")
+                .build();
+        goalMapper.insert(goal);
+        goalId = goal.getId();
+
+        goalHousingMapper.insert(GoalHousing.builder()
+                .goalId(goalId)
+                .regionCode(regionCode)
+                .housingType(HousingType.OFFICETEL)
+                .dealType(DealType.WOLSE)
+                .areaMin(15)
+                .areaMax(25)
+                .depositMin(50_000_000L)
+                .depositMax(100_000_000L)
+                .monthlyRentMin(300_000L)
+                .monthlyRentMax(700_000L)
+                .build());
+
+        // 연월을 일부러 뒤섞어 넣어 정렬이 SQL에서 이뤄지는지 본다.
+        insertSavingRecord("202605", 1_450_000L, false);
+        insertSavingRecord("202607", 2_000_000L, true);
+        insertSavingRecord("202604", 1_000_000L, false);
+        insertSavingRecord("202606", 1_800_000L, false);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (goalId == null) {
+            return;
+        }
+        jdbc.update("DELETE FROM saving_record WHERE goal_id = ?", goalId);
+        jdbc.update("DELETE FROM goal_housing  WHERE goal_id = ?", goalId);
+        jdbc.update("DELETE FROM goal          WHERE id      = ?", goalId);
+    }
+
+    // ------------------------------------------------------------------
+    // goal
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("목표의 모든 컬럼이 도메인 필드에 담긴다")
+    void 목표_컬럼_매핑() {
+        Goal found = goalMapper.findById(goalId);
+
+        assertNotNull(found);
+        assertEquals(goalId, found.getId());
+        assertEquals(memberId, found.getMemberId());
+        assertEquals("HOUSING", found.getGoalType());
+        assertEquals(TARGET_AMOUNT, found.getTargetAmount().longValue());
+        assertEquals(280_000_000L, found.getTargetRentMiddleAmount().longValue());
+        assertEquals(TARGET_DATE, found.getTargetDate());
+        assertEquals(MONTHLY_SAVING, found.getMonthlySaving().longValue());
+        assertEquals("ACTIVE", found.getStatus());
+        // 저장 시 DEFAULT가 채우는 값이라 조회로만 확인된다.
+        assertNotNull(found.getCreatedAt());
+        assertNotNull(found.getUpdatedAt());
+    }
+
+    @Test
+    @DisplayName("시세 알림 관련 컬럼은 NULL 그대로 내려온다")
+    void 목표_널_컬럼() {
+        Goal found = goalMapper.findById(goalId);
+
+        assertNull(found.getMarketAlertDismissedAt());
+        assertNull(found.getMarketAlertDismissedPrice());
+    }
+
+    @Test
+    @DisplayName("없는 목표를 찾으면 null")
+    void 없는_목표는_널() {
+        assertNull(goalMapper.findById(-1L));
+    }
+
+    // ------------------------------------------------------------------
+    // goal_housing
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("주거 조건의 문자열 컬럼이 enum으로 변환된다")
+    void 주거조건_enum_매핑() {
+        GoalHousing found = goalHousingMapper.findByGoalId(goalId);
+
+        assertNotNull(found);
+        assertEquals(HousingType.OFFICETEL, found.getHousingType());
+        assertEquals(DealType.WOLSE, found.getDealType());
+    }
+
+    @Test
+    @DisplayName("주거 조건의 범위 컬럼이 모두 담긴다")
+    void 주거조건_범위_매핑() {
+        GoalHousing found = goalHousingMapper.findByGoalId(goalId);
+
+        assertEquals(15, found.getAreaMin().intValue());
+        assertEquals(25, found.getAreaMax().intValue());
+        assertEquals(50_000_000L, found.getDepositMin().longValue());
+        assertEquals(100_000_000L, found.getDepositMax().longValue());
+        assertEquals(300_000L, found.getMonthlyRentMin().longValue());
+        assertEquals(700_000L, found.getMonthlyRentMax().longValue());
+    }
+
+    @Test
+    @DisplayName("주거 조건이 없는 목표면 null")
+    void 없는_주거조건은_널() {
+        assertNull(goalHousingMapper.findByGoalId(-1L));
+    }
+
+    // ------------------------------------------------------------------
+    // saving_record
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("저축 기록은 최근 연월부터 내려오고 LIMIT이 걸린다")
+    void 저축기록_정렬과_제한() {
+        List<SavingRecord> records = savingRecordMapper.findRecentByGoalId(goalId, 3);
+
+        assertEquals(3, records.size());
+        assertEquals("202607", records.get(0).getRecordYm());
+        assertEquals("202606", records.get(1).getRecordYm());
+        assertEquals("202605", records.get(2).getRecordYm());
+    }
+
+    @Test
+    @DisplayName("저축 기록의 금액과 수정 여부가 담긴다")
+    void 저축기록_컬럼_매핑() {
+        SavingRecord latest = savingRecordMapper.findRecentByGoalId(goalId, 1).get(0);
+
+        assertEquals(goalId, latest.getGoalId());
+        assertEquals(2_000_000L, latest.getActualSaving().longValue());
+        assertEquals(MONTHLY_SAVING, latest.getTargetSaving().longValue());
+        assertTrue(latest.getIsModified());
+        assertNotNull(latest.getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("기록이 LIMIT보다 적으면 있는 만큼만 내려온다")
+    void 기록이_적으면_있는만큼() {
+        jdbc.update("DELETE FROM saving_record WHERE goal_id = ? AND record_ym <> '202607'", goalId);
+
+        List<SavingRecord> records = savingRecordMapper.findRecentByGoalId(goalId, 3);
+
+        assertEquals(1, records.size());
+        assertEquals("202607", records.get(0).getRecordYm());
+    }
+
+    @Test
+    @DisplayName("기록이 없는 목표면 빈 목록")
+    void 기록이_없으면_빈_목록() {
+        assertTrue(savingRecordMapper.findRecentByGoalId(-1L, 3).isEmpty());
+    }
+
+    // ------------------------------------------------------------------
+    // helper
+    // ------------------------------------------------------------------
+
+    private void insertSavingRecord(String recordYm, long actualSaving, boolean isModified) {
+        jdbc.update("INSERT INTO saving_record (goal_id, record_ym, target_saving, actual_saving, is_modified)"
+                + " VALUES (?, ?, ?, ?, ?)", goalId, recordYm, MONTHLY_SAVING, actualSaving, isModified);
+    }
+
+    private <T> T firstOrNull(String sql, Class<T> type) {
+        List<T> found = jdbc.queryForList(sql, type);
+        return found.isEmpty() ? null : found.get(0);
+    }
+}

--- a/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
@@ -1,0 +1,495 @@
+package com.team.independence.goal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.team.independence.asset.dto.AssetLinkRequest;
+import com.team.independence.asset.dto.AssetLinkResponse;
+import com.team.independence.asset.dto.AssetNetWorthBreakdown;
+import com.team.independence.asset.dto.LinkedOrganizationResponse;
+import com.team.independence.asset.dto.UnlinkOrganizationResponse;
+import com.team.independence.asset.service.AssetService;
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.goal.domain.Goal;
+import com.team.independence.goal.domain.GoalHousing;
+import com.team.independence.goal.domain.SavingBasis;
+import com.team.independence.goal.domain.SavingRecord;
+import com.team.independence.goal.dto.GoalDetailResponse;
+import com.team.independence.goal.dto.GoalDetailResponse.Forecast;
+import com.team.independence.goal.mapper.GoalHousingMapper;
+import com.team.independence.goal.mapper.GoalMapper;
+import com.team.independence.goal.mapper.SavingRecordMapper;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 목표 상세 조회 조립 로직 테스트.
+ *
+ * <p>DB 없이 돈다. Mapper와 AssetService 자리에 직접 만든 가짜 구현을 끼워 넣어
+ * 조회 결과를 마음대로 정해주고, 서비스가 그걸로 무엇을 만드는지만 본다.
+ * pom.xml에 Mockito가 없어 공용 파일을 건드리지 않으려고 이렇게 했다.
+ *
+ * <p>단 GoalService만은 진짜 구현을 쓴다. 예상 달성 시점 계산을 가짜로 바꾸면
+ * forecasts 검증이 의미를 잃기 때문이다.
+ */
+class GoalDetailServiceImplTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long GOAL_ID = 100L;
+    private static final Long FIXED_SAVING = 1_500_000L;
+
+    private FakeGoalMapper goalMapper;
+    private FakeGoalHousingMapper goalHousingMapper;
+    private FakeSavingRecordMapper savingRecordMapper;
+    private FakeAssetService assetService;
+    private GoalDetailServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        goalMapper = new FakeGoalMapper();
+        goalHousingMapper = new FakeGoalHousingMapper();
+        savingRecordMapper = new FakeSavingRecordMapper();
+        assetService = new FakeAssetService();
+        service = new GoalDetailServiceImpl(
+                goalMapper, goalHousingMapper, savingRecordMapper, assetService,
+                new GoalServiceImpl(null, null, null, null, null));
+    }
+
+    // ------------------------------------------------------------------
+    // 소유권
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("목표가 없으면 GOAL_NOT_FOUND")
+    void 목표가_없으면_404() {
+        goalMapper.goal = null;
+
+        BusinessException e = assertThrows(BusinessException.class, this::call);
+        assertEquals(ErrorCode.GOAL_NOT_FOUND, e.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("다른 회원의 목표면 GOAL_FORBIDDEN")
+    void 남의_목표면_403() {
+        goalMapper.goal.setMemberId(999L);
+
+        BusinessException e = assertThrows(BusinessException.class, this::call);
+        assertEquals(ErrorCode.GOAL_FORBIDDEN, e.getErrorCode());
+    }
+
+    // ------------------------------------------------------------------
+    // 목표 정보
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("목표 시점은 연월만 내려간다")
+    void 목표시점은_연월() {
+        goalMapper.goal.setTargetDate(LocalDate.of(2027, 12, 1));
+
+        assertEquals(YearMonth.of(2027, 12), call().getTargetDate());
+    }
+
+    @Test
+    @DisplayName("주거 조건은 goal_housing을 그대로 옮긴다")
+    void 주거조건을_그대로_옮긴다() {
+        GoalDetailResponse.Housing housing = call().getHousing();
+
+        assertEquals("11680", housing.getRegionCode());
+        assertEquals(HousingType.APT, housing.getHousingType());
+        assertEquals(DealType.JEONSE, housing.getDealType());
+        assertEquals(20, housing.getAreaMin().intValue());
+        assertEquals(30, housing.getAreaMax().intValue());
+    }
+
+    // ------------------------------------------------------------------
+    // 달성 현황
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("현재 자금은 이자 성장 자산과 원금 인정 자산의 합")
+    void 현재자금은_순자산_합계() {
+        assetService.growingAssets = 30_000_000L;
+        assetService.fixedAssets = 20_000_000L;
+
+        assertEquals(50_000_000L, call().getProgress().getCurrentAmount().longValue());
+    }
+
+    @Test
+    @DisplayName("남은 금액과 달성률을 목표 금액 기준으로 계산한다")
+    void 남은금액과_달성률() {
+        goalMapper.goal.setTargetAmount(200_000_000L);
+        assetService.growingAssets = 50_000_000L;
+        assetService.fixedAssets = 0L;
+
+        GoalDetailResponse.Progress progress = call().getProgress();
+
+        assertEquals(150_000_000L, progress.getRemainingAmount().longValue());
+        assertEquals(25.0, progress.getAchievementRate(), 0.0001);
+    }
+
+    @Test
+    @DisplayName("목표를 넘겨도 남은 금액은 0, 달성률은 100을 넘지 않는다")
+    void 초과달성해도_100을_넘지_않는다() {
+        goalMapper.goal.setTargetAmount(100_000_000L);
+        assetService.growingAssets = 300_000_000L;
+        assetService.fixedAssets = 0L;
+
+        GoalDetailResponse.Progress progress = call().getProgress();
+
+        assertEquals(0L, progress.getRemainingAmount().longValue());
+        assertEquals(100.0, progress.getAchievementRate(), 0.0001);
+    }
+
+    @Test
+    @DisplayName("순자산이 마이너스여도 달성률은 0 밑으로 내려가지 않는다")
+    void 순자산이_마이너스여도_0() {
+        goalMapper.goal.setTargetAmount(100_000_000L);
+        assetService.growingAssets = 0L;
+        assetService.fixedAssets = -5_000_000L; // 대출이 자산보다 많은 경우
+
+        assertEquals(0.0, call().getProgress().getAchievementRate(), 0.0001);
+    }
+
+    @Test
+    @DisplayName("달성률은 소수 둘째 자리까지만 내려간다")
+    void 달성률은_소수_둘째자리() {
+        goalMapper.goal.setTargetAmount(300_000_000L);
+        assetService.growingAssets = 100_000_000L;
+        assetService.fixedAssets = 0L;
+
+        // 33.3333...% -> 33.33
+        assertEquals(33.33, call().getProgress().getAchievementRate(), 0.0001);
+    }
+
+    // ------------------------------------------------------------------
+    // 저축 현황 (명세의 저축 기록 건수별 분기)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("저축 기록이 없으면 최근 저축액은 둘 다 null이고 forecasts는 FIXED뿐")
+    void 기록_0건() {
+        savingRecordMapper.records = Collections.emptyList();
+
+        GoalDetailResponse response = call();
+
+        assertEquals(FIXED_SAVING, response.getSavingStatus().getFixedSaving());
+        assertNull(response.getSavingStatus().getLatestSaving());
+        assertNull(response.getSavingStatus().getRecentAverageSaving());
+        assertEquals(1, response.getForecasts().size());
+        assertEquals(SavingBasis.FIXED, response.getForecasts().get(0).getBasis());
+    }
+
+    @Test
+    @DisplayName("기록이 3건 미만이면 평균은 내지 않고 RECENT_AVERAGE도 빠진다")
+    void 기록_2건() {
+        savingRecordMapper.records = Arrays.asList(record("202607", 2_000_000L), record("202606", 1_800_000L));
+
+        GoalDetailResponse response = call();
+
+        assertEquals(2_000_000L, response.getSavingStatus().getLatestSaving().longValue());
+        assertNull(response.getSavingStatus().getRecentAverageSaving());
+        assertFalse(hasBasis(response, SavingBasis.RECENT_AVERAGE));
+        assertTrue(hasBasis(response, SavingBasis.LATEST));
+    }
+
+    @Test
+    @DisplayName("기록이 3건이면 평균을 내고 forecasts도 세 개가 된다")
+    void 기록_3건() {
+        savingRecordMapper.records = Arrays.asList(
+                record("202607", 2_000_000L),
+                record("202606", 1_800_000L),
+                record("202605", 1_450_000L));
+
+        GoalDetailResponse response = call();
+
+        assertEquals(2_000_000L, response.getSavingStatus().getLatestSaving().longValue());
+        assertEquals(1_750_000L, response.getSavingStatus().getRecentAverageSaving().longValue());
+        assertEquals(3, response.getForecasts().size());
+    }
+
+    @Test
+    @DisplayName("가장 최근 달은 조회 결과의 첫 번째 행이다")
+    void 최근달은_첫번째_행() {
+        savingRecordMapper.records = Arrays.asList(record("202607", 3_000_000L), record("202606", 1_000_000L));
+
+        assertEquals(3_000_000L, call().getSavingStatus().getLatestSaving().longValue());
+    }
+
+    // ------------------------------------------------------------------
+    // 예상 달성 시점
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("forecasts는 FIXED, RECENT_AVERAGE, LATEST 순서로 내려간다")
+    void forecasts_순서() {
+        savingRecordMapper.records = threeRecords();
+
+        List<Forecast> forecasts = call().getForecasts();
+
+        assertEquals(SavingBasis.FIXED, forecasts.get(0).getBasis());
+        assertEquals(SavingBasis.RECENT_AVERAGE, forecasts.get(1).getBasis());
+        assertEquals(SavingBasis.LATEST, forecasts.get(2).getBasis());
+    }
+
+    @Test
+    @DisplayName("고정 기준의 monthsDiff는 항상 0")
+    void 고정기준의_차이는_0() {
+        savingRecordMapper.records = threeRecords();
+
+        assertEquals(0, findBasis(call(), SavingBasis.FIXED).getMonthsDiff().intValue());
+    }
+
+    @Test
+    @DisplayName("더 많이 저축하면 예상 시점이 앞당겨지고 monthsDiff가 양수가 된다")
+    void 더_저축하면_앞당겨진다() {
+        savingRecordMapper.records = threeRecords(); // 평균 175만 > 고정 150만
+
+        GoalDetailResponse response = call();
+        Forecast fixed = findBasis(response, SavingBasis.FIXED);
+        Forecast average = findBasis(response, SavingBasis.RECENT_AVERAGE);
+
+        assertTrue(average.getMonthsDiff() > 0, "앞당겨졌으면 양수여야 한다: " + average.getMonthsDiff());
+        assertTrue(average.getExpectedDate().isBefore(fixed.getExpectedDate()));
+    }
+
+    @Test
+    @DisplayName("덜 저축하면 monthsDiff가 음수가 된다")
+    void 덜_저축하면_지연된다() {
+        savingRecordMapper.records = Arrays.asList(
+                record("202607", 500_000L),
+                record("202606", 500_000L),
+                record("202605", 500_000L));
+
+        assertTrue(findBasis(call(), SavingBasis.RECENT_AVERAGE).getMonthsDiff() < 0);
+    }
+
+    @Test
+    @DisplayName("이미 달성했으면 예상 시점은 없고 차이는 0")
+    void 이미_달성했으면_시점이_없다() {
+        goalMapper.goal.setTargetAmount(100_000_000L);
+        assetService.growingAssets = 200_000_000L;
+        assetService.fixedAssets = 0L;
+        savingRecordMapper.records = threeRecords();
+
+        for (Forecast forecast : call().getForecasts()) {
+            assertNull(forecast.getExpectedDate(), forecast.getBasis() + "은 시점이 없어야 한다");
+            assertEquals(0, forecast.getMonthsDiff().intValue());
+        }
+    }
+
+    @Test
+    @DisplayName("고정 저축액이 0이면 FIXED가 빠지고 나머지는 비교 기준이 없어 monthsDiff가 null")
+    void 고정저축액이_0이면_비교불가() {
+        goalMapper.goal.setMonthlySaving(0L);
+        savingRecordMapper.records = threeRecords();
+
+        GoalDetailResponse response = call();
+
+        assertFalse(hasBasis(response, SavingBasis.FIXED));
+        assertEquals(2, response.getForecasts().size());
+        for (Forecast forecast : response.getForecasts()) {
+            assertNotNull(forecast.getExpectedDate());
+            assertNull(forecast.getMonthsDiff(), forecast.getBasis() + "은 비교 기준이 없다");
+        }
+    }
+
+    @Test
+    @DisplayName("실제 저축액이 0인 달만 있으면 그 기준은 목록에서 빠진다")
+    void 저축액_0인_기준은_제외() {
+        savingRecordMapper.records = Arrays.asList(
+                record("202607", 0L), record("202606", 0L), record("202605", 0L));
+
+        GoalDetailResponse response = call();
+
+        assertTrue(hasBasis(response, SavingBasis.FIXED));
+        assertFalse(hasBasis(response, SavingBasis.RECENT_AVERAGE));
+        assertFalse(hasBasis(response, SavingBasis.LATEST));
+    }
+
+    @Test
+    @DisplayName("예상 시점은 이번 달을 기준으로 앞으로 간다")
+    void 예상시점은_이번달_기준() {
+        savingRecordMapper.records = Collections.emptyList();
+
+        YearMonth expected = findBasis(call(), SavingBasis.FIXED).getExpectedDate();
+
+        assertTrue(expected.isAfter(YearMonth.now()), "미래여야 한다: " + expected);
+    }
+
+    // ------------------------------------------------------------------
+    // 조회 횟수
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("자산과 저축 기록은 각각 한 번씩만 조회한다")
+    void 조회는_한_번씩만() {
+        savingRecordMapper.records = threeRecords();
+
+        call();
+
+        assertEquals(1, assetService.netWorthCalls, "forecasts 세 개를 만들어도 자산 조회는 1회");
+        assertEquals(1, savingRecordMapper.calls);
+    }
+
+    // ------------------------------------------------------------------
+    // helper
+    // ------------------------------------------------------------------
+
+    private GoalDetailResponse call() {
+        return service.getGoalDetail(MEMBER_ID, GOAL_ID);
+    }
+
+    private boolean hasBasis(GoalDetailResponse response, SavingBasis basis) {
+        return response.getForecasts().stream().anyMatch(f -> f.getBasis() == basis);
+    }
+
+    private Forecast findBasis(GoalDetailResponse response, SavingBasis basis) {
+        return response.getForecasts().stream()
+                .filter(f -> f.getBasis() == basis)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(basis + " 기준이 없다"));
+    }
+
+    /** 평균 175만원이 되는 3개월치 기록 */
+    private List<SavingRecord> threeRecords() {
+        return Arrays.asList(
+                record("202607", 2_000_000L),
+                record("202606", 1_800_000L),
+                record("202605", 1_450_000L));
+    }
+
+    private SavingRecord record(String recordYm, long actualSaving) {
+        return SavingRecord.builder()
+                .goalId(GOAL_ID)
+                .recordYm(recordYm)
+                .targetSaving(FIXED_SAVING)
+                .actualSaving(actualSaving)
+                .isModified(false)
+                .build();
+    }
+
+    // ------------------------------------------------------------------
+    // fakes
+    // ------------------------------------------------------------------
+
+    private static class FakeGoalMapper implements GoalMapper {
+
+        private Goal goal = defaultGoal();
+
+        private static Goal defaultGoal() {
+            return Goal.builder()
+                    .id(GOAL_ID)
+                    .memberId(MEMBER_ID)
+                    .goalType("HOUSING")
+                    .targetAmount(300_000_000L)
+                    .targetRentMiddleAmount(280_000_000L)
+                    .targetDate(LocalDate.of(2027, 12, 1))
+                    .monthlySaving(FIXED_SAVING)
+                    .status("ACTIVE")
+                    .build();
+        }
+
+        @Override
+        public Goal findById(Long id) {
+            return goal;
+        }
+
+        @Override
+        public void insert(Goal goal) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean existsActiveByMemberId(Long memberId) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class FakeGoalHousingMapper implements GoalHousingMapper {
+
+        private GoalHousing housing = GoalHousing.builder()
+                .goalId(GOAL_ID)
+                .regionCode("11680")
+                .housingType(HousingType.APT)
+                .dealType(DealType.JEONSE)
+                .areaMin(20)
+                .areaMax(30)
+                .depositMin(200_000_000L)
+                .depositMax(300_000_000L)
+                .monthlyRentMin(0L)
+                .monthlyRentMax(0L)
+                .build();
+
+        @Override
+        public GoalHousing findByGoalId(Long goalId) {
+            return housing;
+        }
+
+        @Override
+        public void insert(GoalHousing goalHousing) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class FakeSavingRecordMapper implements SavingRecordMapper {
+
+        private List<SavingRecord> records = new ArrayList<>();
+        private int calls = 0;
+
+        @Override
+        public List<SavingRecord> findRecentByGoalId(Long goalId, int limit) {
+            calls++;
+            return records.size() > limit ? records.subList(0, limit) : records;
+        }
+    }
+
+    private static class FakeAssetService implements AssetService {
+
+        private long growingAssets = 100_000_000L;
+        private long fixedAssets = 20_000_000L;
+        private int netWorthCalls = 0;
+
+        @Override
+        public AssetNetWorthBreakdown getNetWorthBreakdown(Long memberId) {
+            netWorthCalls++;
+            return AssetNetWorthBreakdown.builder()
+                    .interestBearingAssets(growingAssets)
+                    .flatRecognizedAssets(fixedAssets)
+                    .build();
+        }
+
+        @Override
+        public void validateConnectedAccountExists(Long memberId) {
+            // 연동돼 있다고 본다.
+        }
+
+        @Override
+        public AssetLinkResponse linkAccount(Long memberId, AssetLinkRequest request) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<LinkedOrganizationResponse> getConnections(Long memberId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public UnlinkOrganizationResponse unlinkOrganization(Long memberId, String organizationCode) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplTest.java
@@ -1,0 +1,174 @@
+package com.team.independence.goal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.team.independence.asset.dto.AssetNetWorthBreakdown;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 목표 금액 도달 개월수 계산 테스트.
+ *
+ * <p>calculateMonthToReach는 주입받은 의존성을 하나도 쓰지 않는 순수 계산이라
+ * 생성자에 null을 넘겨 만든다. DB도 스프링 컨텍스트도 필요 없다.
+ */
+class GoalServiceImplTest {
+
+    /** 연 5% 복리를 월 단위로 환산한 이자율. 서비스와 같은 식으로 기대값을 만든다. */
+    private static final double MONTHLY_RATE = Math.pow(1.05, 1.0 / 12) - 1;
+
+    private GoalServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new GoalServiceImpl(null, null, null, null, null);
+    }
+
+    // ------------------------------------------------------------------
+    // 핵심 성질: 진단이 만든 목표 금액을 그대로 되짚는다
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("저축액 S로 M개월 굴려 나온 금액을 목표로 주면 정확히 M개월이 나온다")
+    void 진단이_만든_목표금액을_그대로_되짚는다() {
+        long growingAssets = 30_000_000L;
+        long fixedAssets = 20_000_000L;
+        long monthlySaving = 1_500_000L;
+        long months = 17;
+
+        // 목표 저장 시 target_amount에 들어가는 값과 같은 방식으로 만든다.
+        long targetAmount = grown(growingAssets, months) + fixedAssets
+                + projectedSavings(monthlySaving, months);
+
+        Long actual = service.calculateMonthToReach(
+                netWorth(growingAssets, fixedAssets), monthlySaving, targetAmount);
+
+        assertEquals(months, actual.longValue());
+    }
+
+    @Test
+    @DisplayName("목표 금액이 1원만 더 커도 한 달이 더 걸린다")
+    void 목표가_조금이라도_크면_한달이_더_걸린다() {
+        long growingAssets = 30_000_000L;
+        long fixedAssets = 20_000_000L;
+        long monthlySaving = 1_500_000L;
+        long months = 17;
+
+        long exactAmount = grown(growingAssets, months) + fixedAssets
+                + projectedSavings(monthlySaving, months);
+
+        Long actual = service.calculateMonthToReach(
+                netWorth(growingAssets, fixedAssets), monthlySaving, exactAmount + 1);
+
+        assertEquals(months + 1, actual.longValue());
+    }
+
+    // ------------------------------------------------------------------
+    // 경계값
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("이미 목표 이상을 모았으면 0개월")
+    void 이미_달성했으면_0개월() {
+        Long actual = service.calculateMonthToReach(
+                netWorth(50_000_000L, 50_000_000L), 1_000_000L, 100_000_000L);
+
+        assertEquals(0L, actual.longValue());
+    }
+
+    @Test
+    @DisplayName("목표와 자산이 정확히 같아도 달성으로 본다")
+    void 목표와_자산이_같으면_달성() {
+        Long actual = service.calculateMonthToReach(
+                netWorth(40_000_000L, 60_000_000L), 1_000_000L, 100_000_000L);
+
+        assertEquals(0L, actual.longValue());
+    }
+
+    @Test
+    @DisplayName("저축액이 0이면 계산할 수 없어 null")
+    void 저축액_0이면_null() {
+        assertNull(service.calculateMonthToReach(
+                netWorth(10_000_000L, 0L), 0L, 300_000_000L));
+    }
+
+    @Test
+    @DisplayName("저축액이 음수여도 null")
+    void 저축액_음수면_null() {
+        assertNull(service.calculateMonthToReach(
+                netWorth(10_000_000L, 0L), -100_000L, 300_000_000L));
+    }
+
+    @Test
+    @DisplayName("자산이 0이어도 저축액이 있으면 언젠가는 도달한다")
+    void 자산이_없어도_저축으로_도달한다() {
+        Long actual = service.calculateMonthToReach(
+                netWorth(0L, 0L), 1_000_000L, 12_000_000L);
+
+        assertNotNull(actual);
+        // 이자가 붙으므로 단순 나눗셈(12개월)보다 빠르거나 같다.
+        assertTrue(actual <= 12, "이자를 감안하면 12개월 이내여야 한다: " + actual);
+    }
+
+    @Test
+    @DisplayName("탐색 상한을 넘길 만큼 저축액이 미미하면 null")
+    void 사실상_도달_불가하면_null() {
+        assertNull(service.calculateMonthToReach(
+                netWorth(0L, 0L), 1L, 1_000_000_000_000L));
+    }
+
+    // ------------------------------------------------------------------
+    // 단조성
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("저축액을 늘리면 도달 개월수가 줄어들거나 같다")
+    void 저축액이_클수록_빨리_도달한다() {
+        AssetNetWorthBreakdown netWorth = netWorth(10_000_000L, 5_000_000L);
+        long targetAmount = 200_000_000L;
+
+        long slow = service.calculateMonthToReach(netWorth, 1_000_000L, targetAmount);
+        long normal = service.calculateMonthToReach(netWorth, 2_000_000L, targetAmount);
+        long fast = service.calculateMonthToReach(netWorth, 3_000_000L, targetAmount);
+
+        assertTrue(normal <= slow, "저축액을 올렸는데 더 오래 걸린다: " + slow + " -> " + normal);
+        assertTrue(fast <= normal, "저축액을 올렸는데 더 오래 걸린다: " + normal + " -> " + fast);
+    }
+
+    @Test
+    @DisplayName("이자 덕에 단순 나눗셈보다 빠르게 도달한다")
+    void 이자가_붙어_단순계산보다_빠르다() {
+        // 예적금 1억이 이자로 불어나므로, 남은 1억을 월 100만원으로 나눈 100개월보다 짧아야 한다.
+        Long actual = service.calculateMonthToReach(
+                netWorth(100_000_000L, 0L), 1_000_000L, 200_000_000L);
+
+        assertNotNull(actual);
+        assertTrue(actual < 100, "이자를 감안하면 100개월 미만이어야 한다: " + actual);
+    }
+
+    // ------------------------------------------------------------------
+    // helper
+    // ------------------------------------------------------------------
+
+    private AssetNetWorthBreakdown netWorth(long growingAssets, long fixedAssets) {
+        return AssetNetWorthBreakdown.builder()
+                .interestBearingAssets(growingAssets)
+                .flatRecognizedAssets(fixedAssets)
+                .build();
+    }
+
+    /** 거치식 복리 (서비스의 calculateGrownAmount와 같은 식) */
+    private long grown(long principal, long months) {
+        return Math.round(principal * Math.pow(1 + MONTHLY_RATE, months));
+    }
+
+    /** 적립식 미래가치 (서비스의 calculateProjectedSavings와 같은 식) */
+    private long projectedSavings(long monthlySaving, long months) {
+        double factor = (Math.pow(1 + MONTHLY_RATE, months) - 1) / MONTHLY_RATE;
+        return Math.round(monthlySaving * factor);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #26 

close #26 

## 📝 작업 내용

목표 상세 화면 데이터를 한 번에 내려주는 **`GET /api/v1/goals/{goalId}/detail`** 을 추가했습니다.
목표 정보 · 달성 현황 · 저축 현황 · 저축 기준별 예상 달성 시점 네 덩어리를 반환합니다.

### 메인 로직 (`GoalDetailServiceImpl.getGoalDetail`)

**1) 목표를 찾고 소유자인지 확인** — `findOwnedGoal()`

`goalMapper.findById(goalId)` 로 목표를 가져와, 없으면 `GOAL_NOT_FOUND`(404), `goal.memberId`가 요청자와 다르면 `GOAL_FORBIDDEN`(403, 이번에 추가한 `GOAL_008`)을 던집니다. 주거 희망 조건은 `goalHousingMapper.findByGoalId()` 로 따로 가져옵니다.

**2) 현재 자금(순자산) 계산**

`assetService.getNetWorthBreakdown(memberId)` 를 호출해 `interestBearingAssets`(예적금) + `flatRecognizedAssets`(현금성 + 투자 인정액 + 수동자산 − 대출) 을 더합니다.
**목표 진단·저장이 쓰는 것과 같은 기준**이라 진단 때 본 금액과 상세 화면 금액이 어긋나지 않습니다. (자산 요약 API의 `total_assets − loan_balance` 와는 값이 다릅니다 — 청약 제외, 투자자산 70% 인정률 적용)

`remainingAmount`는 `max(0, targetAmount − currentAmount)`, `achievementRate`는 0~100으로 clamp 후 소수 둘째 자리까지 (또래 비교 집계와 같은 규칙).

**3) 저축 현황 집계** — `buildSavingStatus()`

`savingRecordMapper.findRecentByGoalId(goalId, 3)` **한 번**으로 최근 3건을 `record_ym DESC` 로 받아, 첫 번째 행을 `latestSaving`, 3건이 다 있을 때만 평균을 내 `recentAverageSaving`으로 씁니다. 3건이 안 되면 평균은 신뢰할 수 없다고 보고 `null`로 둡니다.

**4) 예상 달성 시점** — `buildForecasts()` → `GoalServiceImpl.calculateMonthToReach()`

여기가 이번 PR의 핵심입니다. **단순 나눗셈(`남은 금액 ÷ 월 저축액`)이 아니라 진단과 똑같은 복리 계산을 씁니다.**

```
n = 1, 2, 3... 늘려가며
  예산(n) = 예적금을 n개월 굴린 값 + 원금인정자산 + 월저축액의 적립식 미래가치(n)
  예산(n) >= goal.target_amount 가 되는 첫 n
expectedDate = 이번 달 + n
```

`calculateMonthToReach()`는 `GoalServiceImpl`에 있는 기존 `calculateGrownAmount()`(거치식 복리) / `calculateProjectedSavings()`(적립식 미래가치)를 그대로 호출합니다. 계산식을 복사하거나 다른 클래스로 옮기지 않아서, 진단 로직이 바뀌면 상세 조회도 자동으로 따라갑니다.

**왜 이렇게 했나요?**
`goal.target_amount`는 저장 시점에 `예적금 굴린 값 + 원금인정자산 + 적립식 미래가치(설정 저축액, M개월)` 로 만들어진 값(진단의 `totalBudget`)입니다. 같은 식에 **월 저축액만 바꿔 넣고** 되짚으므로, 고정 저축액 기준 `expectedDate`는 사용자가 설정한 `targetDate`를 그대로 재현합니다. 단순 나눗셈을 쓰면 이자가 빠져 진단 결과와 어긋납니다.

`monthsDiff`는 FIXED 기준 개월수와의 차이(양수 = 단축)입니다. 저축액이 0 이하인 기준은 계산이 불가해 목록에서 빼고, 이미 달성했으면 `expectedDate: null` · `monthsDiff: 0`으로 내려갑니다.

---

### 구현 내용

커밋 단위로 정리했습니다.

**1. 에러코드 추가** (`ErrorCode`)
타인의 목표 접근을 막는 `GOAL_FORBIDDEN`(`GOAL_008`, 403). GOAL_002~007은 진단·저장이 이미 쓰고 있어 008을 할당했습니다.

**2. 목표 금액 도달 개월수 계산** (`GoalService` / `GoalServiceImpl`)
`calculateMonthToReach(netWorth, monthlySaving, targetAmount)` 를 인터페이스에 추가했습니다. 위에 설명한 복리 탐색이고, 기존 private 계산 메서드를 그대로 호출합니다. `netWorth`를 파라미터로 받아 상세 조회가 자산을 한 번만 조회하고 3개 기준에 재사용할 수 있게 했습니다.

**3. 도메인 정비** (`goal/domain`)
- `Goal` / `GoalHousing` 이 `@Getter @Builder` 만 있어 MyBatis가 조회 결과를 채울 수 없었습니다. `@Setter @NoArgsConstructor @AllArgsConstructor` 추가 (기존 insert 경로 영향 없음)
- `SavingRecord` 도메인 신설 — `saving_record` 테이블 1:1 매핑
- `SavingBasis` enum 신설 — `FIXED` / `RECENT_AVERAGE` / `LATEST`

**4. 매퍼 조회 메서드** (`goal/mapper` + `mybatis/mapper/goal`)
- `GoalMapper.findById` — resultMap 신설 (기존엔 insert/exists만 있었음)
- `GoalHousingMapper.findByGoalId` — `housing_type` / `deal_type` 을 `javaType` 으로 enum 매핑
- `SavingRecordMapper.findRecentByGoalId(goalId, limit)` 신설 — `record_ym DESC` + `LIMIT`, `uk_saving_goal_ym` 인덱스 사용

**5. 응답 DTO** (`GoalDetailResponse`)
`Housing` / `Progress` / `SavingStatus` / `Forecast` 중첩 클래스 4개. 날짜는 `YearMonth`로 두어 `"2027-12"` 형태로 직렬화되고, 값 없음을 구분해야 해서 전부 래퍼 타입입니다.

**6. 서비스** (`GoalDetailService` / `GoalDetailServiceImpl`)
위 "메인 로직" 참고. 진단·저장과 책임이 달라 `GoalService`와 파일을 분리했고 읽기 전용이라 `@Transactional`은 없습니다.

**7. 엔드포인트** (`GoalController`)
`GET /{goalId}/detail` 추가. 명세대로 `@LoginMember` 를 씁니다 — 기존 진단·저장의 `@RequestParam memberId` 는 프론트 호출부에 영향이 있어 이번 PR에서 건드리지 않았습니다.

**8. 테스트** — 아래 표 참고

### 테스트

| 파일 | 개수 | 비고 |
| --- | --- | --- |
| `GoalServiceImplTest` | 10 | 도달 개월수 계산. **저축액 S로 M개월 굴린 금액을 목표로 주면 정확히 M을 반환**하는지가 핵심 |
| `GoalDetailServiceImplTest` | 22 | 저축 기록 0/2/3건 분기, 달성률 clamp, forecasts 순서와 `monthsDiff` 부호 |
| `GoalDetailMapperIntegrationTest` | 10 | XML resultMap 매핑(enum 변환, 정렬, LIMIT). 로컬 DB 전용 `@Disabled` |

전체 79개 통과(통합 테스트는 skip). 로컬 Tomcat + MySQL로 실제 호출해 **FIXED의 `expectedDate`가 `targetDate`와 같은 달로 나오는 것**까지 확인했습니다.

<img width="1170" height="752" alt="image" src="https://github.com/user-attachments/assets/9ddeecbd-cdff-4349-87e9-64a53a7cadc5" />

### 알아두실 점

`saving_record`에 데이터를 쌓는 API나 배치가 아직 없습니다. 그래서 현재 실제 응답은 "저축 기록 0건" 분기를 타서 `forecasts`에 `FIXED` 하나만, `recentAverageSaving` / `latestSaving`은 `null`로 나갑니다. 적재 경로는 별도 이슈가 필요합니다.