### PR TITLE
fix: CORS preflight(OPTIONS) 요청에 대한 401 응답 문제 해결

### DIFF
--- a/src/main/java/com/team/independence/config/WebAppInitializer.java
+++ b/src/main/java/com/team/independence/config/WebAppInitializer.java
@@ -1,6 +1,9 @@
 package com.team.independence.config;
 
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
 
 import javax.servlet.Filter;
@@ -37,13 +40,24 @@ public class WebAppInitializer extends AbstractAnnotationConfigDispatcherServlet
         return new String[]{ "/" };
     }
 
-    /** UTF-8 인코딩 필터 */
     @Override
     protected Filter[] getServletFilters() {
+        CorsConfiguration corsConfig = new CorsConfiguration();
+        corsConfig.addAllowedOrigin("http://localhost:5173");
+        corsConfig.addAllowedOrigin("https://www.nagasseum.com");
+        corsConfig.addAllowedMethod("*");
+        corsConfig.addAllowedHeader("*");
+        corsConfig.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", corsConfig);
+
         CharacterEncodingFilter encodingFilter = new CharacterEncodingFilter();
         encodingFilter.setEncoding("UTF-8");
         encodingFilter.setForceEncoding(true);
-        return new Filter[]{ encodingFilter };
+
+        // CorsFilter가 CharacterEncodingFilter보다 먼저 실행되어야 preflight를 MVC 전에 처리함
+        return new Filter[]{ new CorsFilter(source), encodingFilter };
     }
 
     /**

--- a/src/main/java/com/team/independence/config/WebConfig.java
+++ b/src/main/java/com/team/independence/config/WebConfig.java
@@ -13,7 +13,6 @@ import org.springframework.http.converter.json.MappingJackson2HttpMessageConvert
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -45,15 +44,6 @@ public class WebConfig implements WebMvcConfigurer {
         this.authInterceptor = authInterceptor;
         this.objectMapper = objectMapper;
         this.loginMemberArgumentResolver = loginMemberArgumentResolver;
-    }
-
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/**")
-                .allowedOrigins("http://localhost:5173", "https://www.nagasseum.com")
-                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
-                .allowedHeaders("*")
-                .allowCredentials(true);
     }
 
     @Override


### PR DESCRIPTION
## #️⃣연관된 이슈

- #41 

## 📝작업 내용

### 요약

- `addCorsMappings()`(MVC 내부 처리)를 `CorsFilter`(서블릿 필터 레벨)로 교체
- preflight OPTIONS 요청이 `ProdAuthInterceptor`에 도달하기 전에 처리되어 401 차단 해소

### 원인

Spring MVC 5.3.x의 `AbstractHandlerMapping.getCorsHandlerExecutionChain()`은  
preflight용 `PreFlightHandler`를 생성할 때 사용자 인터셉터를 그대로 포함합니다.  
`ProdAuthInterceptor`가 OPTIONS 요청에도 실행되어 Authorization 헤더 없음 → 401.

### 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `WebAppInitializer.java` | `CorsFilter` 등록 (`CharacterEncodingFilter` 앞) |
| `WebConfig.java` | `addCorsMappings()` 제거 |

### 요청 흐름 (변경 후)

```
OPTIONS(preflight)
  └→ CorsFilter → 200 응답, 종료 (MVC 진입 없음)

실제 요청
  └→ CorsFilter (통과)
       └→ DispatcherServlet
            └→ ProdAuthInterceptor (JWT 검증)
                 └→ Controller
```