### PR TITLE
feat: REST Long-Running Task 패턴을 적용하여 자산 동기화 비동기 처리 전환

### DIFF
--- a/src/main/java/com/team/independence/asset/controller/AssetController.java
+++ b/src/main/java/com/team/independence/asset/controller/AssetController.java
@@ -4,13 +4,19 @@ import com.team.independence.asset.dto.*;
 import com.team.independence.asset.service.AssetAccountListService;
 import com.team.independence.asset.service.AssetService;
 import com.team.independence.asset.service.AssetSummaryService;
+import com.team.independence.asset.service.AssetSyncJobStarter;
 import com.team.independence.asset.service.AssetSyncService;
 import com.team.independence.asset.service.InstitutionService;
 import com.team.independence.asset.service.ManualAssetService;
 import com.team.independence.common.annotation.LoginMember;
 import com.team.independence.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import java.net.URI;
 
 import java.util.List;
 
@@ -21,6 +27,7 @@ public class AssetController {
 
     private final AssetService assetService;
     private final AssetSyncService assetSyncService;
+    private final AssetSyncJobStarter assetSyncJobStarter;
     private final AssetSummaryService assetSummaryService;
     private final AssetAccountListService assetAccountListService;
     private final ManualAssetService manualAssetService;
@@ -46,8 +53,23 @@ public class AssetController {
     }
 
     @PostMapping("/sync")
-    public ApiResponse<AssetSyncResponse> syncAccounts(@RequestParam Long memberId) {
-        return ApiResponse.ok(assetSyncService.syncAccounts(memberId));
+    public ResponseEntity<ApiResponse<SyncJobResponse>> startSync(
+            @RequestParam Long memberId,
+            HttpServletRequest request) {
+        SyncJobResponse response = assetSyncJobStarter.start(memberId);
+        URI location = UriComponentsBuilder
+                .fromHttpUrl(request.getRequestURL().toString())
+                .path("/status/{jobId}")
+                .buildAndExpand(response.getJobId())
+                .toUri();
+        return ResponseEntity.accepted()
+                .location(location)
+                .body(ApiResponse.ok(response));
+    }
+
+    @GetMapping("/sync/status/{jobId}")
+    public ApiResponse<SyncJobStatusResponse> getSyncStatus(@PathVariable String jobId) {
+        return ApiResponse.ok(assetSyncService.getSyncStatus(jobId));
     }
 
     @GetMapping("/summary/{memberId}")

--- a/src/main/java/com/team/independence/asset/dto/SyncJobResponse.java
+++ b/src/main/java/com/team/independence/asset/dto/SyncJobResponse.java
@@ -1,0 +1,10 @@
+package com.team.independence.asset.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SyncJobResponse {
+    private String jobId;
+}

--- a/src/main/java/com/team/independence/asset/dto/SyncJobStatusResponse.java
+++ b/src/main/java/com/team/independence/asset/dto/SyncJobStatusResponse.java
@@ -1,0 +1,13 @@
+package com.team.independence.asset.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SyncJobStatusResponse {
+    private String jobId;
+    private String status;  // PENDING / SUCCESS / FAILED
+    private String errorMessage;  // FAILED 시에만 채워짐
+    private String resultUrl;  // SUCCESS 시에만 채워짐
+}

--- a/src/main/java/com/team/independence/asset/service/AssetSyncJobRunner.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncJobRunner.java
@@ -1,0 +1,28 @@
+package com.team.independence.asset.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AssetSyncJobRunner {
+
+    private final AssetSyncService assetSyncService;
+    private final AssetSyncJobStore jobStore;
+
+    @Async("assetSyncExecutor")
+    public void runAsync(Long memberId, String jobId) {
+        log.info("[비동기 동기화] 시작: memberId={}, jobId={}", memberId, jobId);
+        try {
+            assetSyncService.syncAccounts(memberId);
+            jobStore.markSuccess(jobId, "/api/v1/assets/summary/" + memberId);
+            log.info("[비동기 동기화] 완료: memberId={}, jobId={}", memberId, jobId);
+        } catch (Exception e) {
+            log.error("[비동기 동기화] 실패: memberId={}, jobId={}", memberId, jobId, e);
+            jobStore.markFailed(jobId, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/team/independence/asset/service/AssetSyncJobStarter.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncJobStarter.java
@@ -1,0 +1,19 @@
+package com.team.independence.asset.service;
+
+import com.team.independence.asset.dto.SyncJobResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AssetSyncJobStarter {
+
+    private final AssetSyncJobStore jobStore;
+    private final AssetSyncJobRunner jobRunner;
+
+    public SyncJobResponse start(Long memberId) {
+        String jobId = jobStore.createJob();
+        jobRunner.runAsync(memberId, jobId);
+        return SyncJobResponse.builder().jobId(jobId).build();
+    }
+}

--- a/src/main/java/com/team/independence/asset/service/AssetSyncJobStore.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncJobStore.java
@@ -1,0 +1,63 @@
+package com.team.independence.asset.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class AssetSyncJobStore {
+
+    private static final String KEY_STATUS = "asset:sync:job:%s:status";
+    private static final String KEY_ERROR = "asset:sync:job:%s:error";
+    private static final String KEY_RESULT = "asset:sync:job:%s:result";
+    private static final long TTL_MINUTES = 10;
+
+    private final StringRedisTemplate redisTemplate;
+
+    public String createJob() {
+        String jobId = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set(statusKey(jobId), "PENDING", TTL_MINUTES, TimeUnit.MINUTES);
+        return jobId;
+    }
+
+    public String getStatus(String jobId) {
+        return redisTemplate.opsForValue().get(statusKey(jobId));
+    }
+
+    public String getError(String jobId) {
+        return redisTemplate.opsForValue().get(errorKey(jobId));
+    }
+
+    public void markSuccess(String jobId, String resultUrl) {
+        redisTemplate.opsForValue().set(statusKey(jobId), "SUCCESS", TTL_MINUTES, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set(resultKey(jobId), resultUrl, TTL_MINUTES, TimeUnit.MINUTES);
+    }
+
+    public String getResultUrl(String jobId) {
+        return redisTemplate.opsForValue().get(resultKey(jobId));
+    }
+
+    public void markFailed(String jobId, String errorMessage) {
+        redisTemplate.opsForValue().set(statusKey(jobId), "FAILED", TTL_MINUTES, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set(
+                errorKey(jobId),
+                errorMessage != null ? errorMessage : "알 수 없는 오류",
+                TTL_MINUTES, TimeUnit.MINUTES);
+    }
+
+    private String statusKey(String jobId) {
+        return String.format(KEY_STATUS, jobId);
+    }
+
+    private String errorKey(String jobId) {
+        return String.format(KEY_ERROR, jobId);
+    }
+
+    private String resultKey(String jobId) {
+        return String.format(KEY_RESULT, jobId);
+    }
+}

--- a/src/main/java/com/team/independence/asset/service/AssetSyncService.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncService.java
@@ -1,8 +1,10 @@
 package com.team.independence.asset.service;
 
 import com.team.independence.asset.dto.AssetSyncResponse;
+import com.team.independence.asset.dto.SyncJobStatusResponse;
 
 public interface AssetSyncService {
     AssetSyncResponse syncAccounts(Long memberId);
     void syncAll();
+    SyncJobStatusResponse getSyncStatus(String jobId);
 }

--- a/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
@@ -8,6 +8,7 @@ import com.team.independence.asset.domain.ConnectedInstitution;
 import com.team.independence.asset.domain.LoanAccount;
 import com.team.independence.asset.dto.AssetSyncResponse;
 import com.team.independence.asset.dto.AssetSyncResponse.InstitutionSyncResult;
+import com.team.independence.asset.dto.SyncJobStatusResponse;
 import com.team.independence.asset.domain.AssetSummary;
 import com.team.independence.asset.mapper.AssetAccountMapper;
 import com.team.independence.asset.mapper.AssetSummaryMapper;
@@ -60,6 +61,7 @@ public class AssetSyncServiceImpl implements AssetSyncService {
     private static final String CURRENCY_KRW = "KRW";
     private static final String OVERDRAFT_FLAG = "1";
 
+    private final AssetSyncJobStore jobStore;
     private final ConnectedAccountMapper connectedAccountMapper;
     private final ConnectedInstitutionMapper connectedInstitutionMapper;
     private final InstitutionMapper institutionMapper;
@@ -71,6 +73,20 @@ public class AssetSyncServiceImpl implements AssetSyncService {
     private final AesEncryptor aesEncryptor;
     private final ObjectMapper objectMapper;
     private final SlackNotifier slackNotifier;
+
+    @Override
+    public SyncJobStatusResponse getSyncStatus(String jobId) {
+        String status = jobStore.getStatus(jobId);
+        if (status == null) {
+            throw new BusinessException(ErrorCode.ASSET_SYNC_JOB_NOT_FOUND);
+        }
+        return SyncJobStatusResponse.builder()
+                .jobId(jobId)
+                .status(status)
+                .errorMessage("FAILED".equals(status) ? jobStore.getError(jobId) : null)
+                .resultUrl("SUCCESS".equals(status) ? jobStore.getResultUrl(jobId) : null)
+                .build();
+    }
 
     @Override
     public void syncAll() {

--- a/src/main/java/com/team/independence/common/exception/ErrorCode.java
+++ b/src/main/java/com/team/independence/common/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     ASSET_ORGANIZATION_NOT_CONNECTED("ASSET_005", "연동되지 않은 기관입니다.", HttpStatus.NOT_FOUND),
     ASSET_SUMMARY_NOT_FOUND("ASSET_006", "자산 연동 정보가 없습니다. 먼저 금융기관을 연동해주세요.", HttpStatus.NOT_FOUND),
     ASSET_MANUAL_NOT_FOUND("ASSET_007", "수동 자산을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    ASSET_SYNC_JOB_NOT_FOUND("ASSET_008", "동기화 작업을 찾을 수 없거나 만료되었습니다.", HttpStatus.NOT_FOUND),
 
     // ===== 목표 GOAL_xxx =====
     GOAL_NOT_FOUND("GOAL_001", "목표를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/team/independence/config/RootConfig.java
+++ b/src/main/java/com/team/independence/config/RootConfig.java
@@ -20,11 +20,15 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Controller;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.concurrent.Executor;
 
 import javax.sql.DataSource;
 
@@ -52,6 +56,7 @@ import javax.sql.DataSource;
         })
 @MapperScan(basePackages = "com.team.independence", annotationClass = Mapper.class)
 @EnableTransactionManagement
+@EnableAsync
 public class RootConfig {
 
     @Value("${DB_URL:jdbc:mysql://localhost:3306/independence?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}")
@@ -145,6 +150,17 @@ public class RootConfig {
     @Bean
     public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory cf) {
         return new StringRedisTemplate(cf);
+    }
+
+    @Bean("assetSyncExecutor")
+    public Executor assetSyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("asset-sync-");
+        executor.initialize();
+        return executor;
     }
 
 }

--- a/src/test/java/com/team/independence/asset/service/AssetSyncServiceImplTest.java
+++ b/src/test/java/com/team/independence/asset/service/AssetSyncServiceImplTest.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class  AssetSyncServiceImplTest {
 
+    @Mock AssetSyncJobStore jobStore;
     @Mock ConnectedAccountMapper connectedAccountMapper;
     @Mock ConnectedInstitutionMapper connectedInstitutionMapper;
     @Mock InstitutionMapper institutionMapper;
@@ -75,6 +76,7 @@ class  AssetSyncServiceImplTest {
     @BeforeEach
     void setUp() {
         service = new AssetSyncServiceImpl(
+                jobStore,
                 connectedAccountMapper, connectedInstitutionMapper, institutionMapper,
                 assetAccountMapper, loanAccountMapper, assetSummaryMapper,
                 codefClient, codefTokenManager, aesEncryptor, objectMapper, slackNotifier);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #39 

## 📝작업 내용

 ## 개요

기존에는 자산 동기화(POST `/api/v1/assets/sync`)는 연동된 금융기관마다 CODEF API를 순차 호출하는 구조로, 응답까지 평균 25.87초 소요되었습니다. 25초 동안 HTTP 연결이 유지되는 동안 클라이언트는 아무 작업도 할 수 없고, 네트워크가 일시적으로 끊기면 서버는 계속 동기화를 진행하지만 클라이언트는 결과를 받을 방법이 없었습니다.

이를 해결하기 위해 REST Long-Running Task 패턴(RFC 9110)을 적용하여 동기화 요청을 즉시 수락하고 백그라운드에서 처리한 뒤 클라이언트가 폴링으로 결과를 확인하는 구조로 전환했습니다.

### 실측 응답 시간 (우리은행 계좌 2개 + 삼성증권 계좌 4개 + KB증권 계좌 5개)
  
  | 구분 | 기존 (동기) | 변경 후 (비동기) |
  |------|------------|----------------|
  | 1회차 | 25.10초 | 0.029초 |
  | 2회차 | 29.40초 | 0.031초 |
  | 3회차 | 23.11초 | 0.028초 |
  | 평균 | 25.87초 | 0.029초 |
  
  ---

  ## API 변경
  
  ### Before
  ```
  POST /api/v1/assets/sync?memberId=1
  → (25초 대기)
  ← 200 OK
     { "syncedCount": 3, "failedCount": 0, "institutions": [...] }
  ```
  
  ### After 
  ```
  POST /api/v1/assets/sync?memberId=1
  ← 202 Accepted
     Location: http://.../api/v1/assets/sync/status/900b55dd-...
     { "success": true, "data": { "jobId": "900b55dd-..." } }

  GET /api/v1/assets/sync/status/900b55dd-...
  ← 200 OK  (진행 중) 
     { "data": { "status": "PENDING", "errorMessage": null, "resultUrl": null } }

  GET /api/v1/assets/sync/status/900b55dd-...
  ← 200 OK  (완료)    
     { "data": { "status": "SUCCESS", "errorMessage": null, "resultUrl": "/api/v1/assets/summary/1" } }
  ```
  
  ### 프론트엔드 연동 패턴
  ```javascript
  // 1) 동기화 시작
  const { data } = await POST('/api/v1/assets/sync?memberId=1')
  const jobId = data.jobId
  
  // 2) 완료까지 폴링 (ex. 2초 간격)
  while (true) {
    const { data } = await GET(`/api/v1/assets/sync/status/${jobId}`)
    if (data.status === 'SUCCESS') {
      const result = await GET(data.resultUrl) // /api/v1/assets/summary/1
      break
    }
    if (data.status === 'FAILED') {
      alert(data.errorMessage)
      break
    }
    await sleep(2000)
  }
  ```

  ---

## REST Long-Running Task 패턴 적용 근거

[restfulapi.net — REST API Design for Long-Running Tasks](https://restfulapi.net/rest-api-design-for-long-running-tasks/) 에서 설명하는 표준 패턴을 그대로 적용했습니다.

  | 패턴 요소 | 구현 내용 |
  |----------|----------|
  | `202 Accepted` 즉시 응답 | `ResponseEntity.accepted()` |
  | `Location` 헤더로 폴링 URL 안내 | `request.getRequestURL()` 기반으로 동적 생성 |
  | 폴링 엔드포인트 | `GET /api/v1/assets/sync/status/{jobId}` |
  | 완료 시 결과 URL 제공 | `resultUrl: "/api/v1/assets/summary/{memberId}"` |
  | 실패 시 에러 메시지 제공 | `errorMessage` 필드 |
  
해당 패턴의 설명에 따르면 Location 헤더를 포함해야 하는 이유는 클라이언트가 `jobId`를 받은 후 폴링 URL을 직접 조립하지 않아도 되도록 서버가 명시적으로 알려주기 때문이라고 합니다. 그럼 클라이언트는 URL 구조를 알 필요 없이 `Location` 헤더 값을 그대로 사용하면 됩니다.

또한 resultUrl을 제공하면 완료 후 클라이언트가 어디서 결과를 가져올지 서버가 알려주면, API 경로가 바뀌어도 클라이언트 코드를 수정하지 않아도 됩니다.

  ---
  
## 기술 선택 근거
  
### `@Async`, `ThreadPoolTaskExecutor`를 선택한 이유
  
1. `WebClient` 미선택
`WebClient`는 리액티브(Reactive) 환경에서 쓰는 논블로킹 HTTP 클라이언트로, 우리 서비스는 Spring MVC(서블릿 기반) 구조이므로 `WebClient`를 써도 결국 `.block()`으로 결과를 기다려야 했습니다. 결국 RestTemplate과 동작 방식이 같고 의존성만 늘어나므로 도입 이유가 없다고 판단했습니다.

2. Kafka / RabbitMQ 미선택
메시지 큐는 서비스 간 비동기 통신, 대용량 이벤트 처리에 적합하다고 합니다. 단일 모놀리식 서버에서 하나의 비동기 작업을 처리하는 용도로 도입하는 것은 과도한 복잡성을 추가하는 것이고 브로커 운영, 토픽 관리, 컨슈머 설정 등 부수적인 비용이 실제 이점보다 훨씬 크기 때문에 메시지 큐 도입을 배제했습니다.

#### `@Async`, `ThreadPoolTaskExecutor` 선택
일단 Spring이 기본 제공하는 기능이므로 추가 의존성이 없습니다. 스레드 풀을 명시적으로 등록(`assetSyncExecutor`)하여 스레드 수를 제어하고 다른 비동기 작업과 격리할 수 있습니다. 그리고 Spring 기본 실행기(`SimpleAsyncTaskExecutor`)는 요청마다 새 스레드를 생성하므로 명시적 풀 등록이 필요했습니다.

  ```java
  executor.setCorePoolSize(2);  // 상시 대기 스레드: 동시 동기화 2건은 즉시 처리
  executor.setMaxPoolSize(5);  // 최대: 동시 요청이 몰려도 최대 5건까지 처리
  executor.setQueueCapacity(10);  // 대기열: 풀이 가득 차도 10건까지 대기
  ```
  
  ---

  ## @Async 자기 호출(Self-Invocation) 문제와 해결
  
  ### 문제  
  
  `@Async`를 같은 클래스 안에서 `this.`로 호출하면 동작하지 않는 문제가 있었습니다.
  
  ```java   
  // ❌ 동작하지 않는 구조
  @Service
  public class AssetSyncServiceImpl implements AssetSyncService {
  
      public SyncJobResponse startSync(Long memberId) {
          String jobId = jobStore.createJob();
          this.doSyncAsync(memberId, jobId);  // 자기 호출
          return SyncJobResponse.builder().jobId(jobId).build();
      }
  
      @Async("assetSyncExecutor")  // 무시됨
      public void doSyncAsync(Long memberId, String jobId) {
          syncAccounts(memberId);
      }
  }
  ```

  Spring의 `@Async`는 AOP 프록시를 통해 동작하는데 `this.doSyncAsync()`는 프록시를 거치지 않고
  원본 객체의 메서드를 직접 호출합니다. 프록시가 개입하지 않으니 `@Async`를 감지할 수 없고, 아래 스크린샷과 같이 일반 동기 메서드 호출과 동일하게 실행됩니다.

<img width="1428" height="94" alt="@Async 자기 호출 문제" src="https://github.com/user-attachments/assets/2c773861-72bd-454e-9a56-d5c94fb1e91f" />

  ### 해결: 세 빈으로 분리
  
  따라서 호출 경계를 빈 경계와 일치시켜 프록시가 반드시 개입하도록 구조를 분리했습니다.
  
  ```
  [AssetController]
      
      ↓

  [AssetSyncJobStarter] 컨트롤러 진입점. jobId 생성 후 Runner에게 위임하고 즉시 리턴
      
      ↓ 다른 빈 호출 → 프록시 통과

  [AssetSyncJobRunner] @Async 적용. 프록시가 이 경계에서 스레드를 분기시킴
      
       ↓ 다른 빈 호출 → 프록시 통과

  [AssetSyncServiceImpl] 기존 @Transactional 로직 그대로 유지
  ```
  
  `jobRunner.runAsync()`를 호출하는 순간 `AssetSyncJobRunner`의 프록시가 개입하여 `assetSyncExecutor` 스레드 풀에 작업을 넘기고 즉시 리턴합니다. `AssetSyncJobStarter.start()`는 `jobId`를 반환하고 컨트롤러는 202 응답을 즉시 보냅니다.

<img width="1337" height="402" alt="스크린샷 2026-08-04 오후 3 34 56" src="https://github.com/user-attachments/assets/66d9af75-c12a-42ec-9912-ff5c5c8ab08e" />


<img width="1426" height="100" alt="3개의 빈으로 분리" src="https://github.com/user-attachments/assets/cfb551f1-97a3-4ed1-96b7-9bba5443072c" />


  `AssetSyncJobRunner`가 `AssetSyncService`를 Spring 프록시를 통해 호출하므로 `syncAccounts()`의 `@Transactional`도 정상 적용됩니다.

  ---
  
  ## Redis 작업 상태 설계

  ```
  asset:sync:job:{jobId}:status  →  "PENDING" / "SUCCESS" / "FAILED"  (TTL 10분)
  asset:sync:job:{jobId}:error  →  에러 메시지 (FAILED일 때만)        (TTL 10분)
  asset:sync:job:{jobId}:result  →  결과 조회 URL (SUCCESS일 때만)     (TTL 10분)
  ```
  
  TTL을 10분으로 설정한 이유는 동기화 완료 후 클라이언트가 상태를 확인하기까지 충분한 시간을 보장하면서, 완료된 작업 상태가 Redis에 무기한 누적되는 것을 방지하기 위함입니다. 추후 논의를 통해 변경해도 무방합니다. 그리고`jobId`가 Redis에 없으면 만료되었거나 존재하지 않는 작업으로 판단하여 `ASSET_SYNC_JOB_NOT_FOUND (404)`를 반환하도록 처리했습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?