### PR TITLE
feat: 홈 화면 목표 달성 요약, 매물 시세 변화 API 구현

### DIFF
--- a/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
@@ -110,7 +110,7 @@ public class AssetSyncServiceImpl implements AssetSyncService {
                 sb.append("• memberId=").append(f.memberId)
                   .append(" / ").append(f.reason).append("\n");
             }
-            slackNotifier.sendBatchFailureSummary(sb.toString().trim());
+            slackNotifier.sendBatchFailureSummary("asset-sync", sb.toString().trim());
         }
 
         log.info("[배치] 자산 동기화 완료 — 성공: {}, 실패: {}",

--- a/src/main/java/com/team/independence/external/slack/SlackNotifier.java
+++ b/src/main/java/com/team/independence/external/slack/SlackNotifier.java
@@ -17,7 +17,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class SlackNotifier {
 
-    private static final String DEDUP_KEY_PREFIX = "slack:asset-sync:fail:";
+    private static final String DEDUP_KEY_PREFIX = "slack:batch-fail:";
     private static final Duration DEDUP_TTL = Duration.ofMinutes(30);
 
     @Value("${slack.webhook.url:}")
@@ -26,13 +26,14 @@ public class SlackNotifier {
     private final RestTemplate restTemplate;
     private final StringRedisTemplate redisTemplate;
 
-    public void sendBatchFailureSummary(String message) {
+    /** batchName별로 dedup key를 나눠, 서로 다른 배치의 실패 알림이 30분 내 겹쳐도 한쪽이 다른 쪽을 억제하지 않게 한다. */
+    public void sendBatchFailureSummary(String batchName, String message) {
         if (webhookUrl == null || webhookUrl.isBlank()) {
             log.warn("[Slack] webhook URL이 설정되지 않아 알림을 건너뜁니다.");
             return;
         }
 
-        String dedupKey = DEDUP_KEY_PREFIX + LocalDate.now();
+        String dedupKey = DEDUP_KEY_PREFIX + batchName + ":" + LocalDate.now();
         if (Boolean.TRUE.equals(redisTemplate.hasKey(dedupKey))) {
             log.info("[Slack] 중복 알림 억제 (30분 내 이미 전송): key={}", dedupKey);
             return;

--- a/src/main/java/com/team/independence/goal/controller/GoalController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalController.java
@@ -9,6 +9,7 @@ import com.team.independence.goal.dto.GoalDiagnosisResponse;
 import com.team.independence.goal.dto.GoalMarketTrendResponse;
 import com.team.independence.goal.dto.GoalForecastResponse;
 import com.team.independence.goal.dto.GoalResponse;
+import com.team.independence.goal.dto.GoalSummaryResponse;
 import com.team.independence.goal.service.GoalDetailService;
 import com.team.independence.goal.service.GoalService;
 import javax.validation.Valid;
@@ -61,5 +62,10 @@ public class GoalController {
     @GetMapping("/market-trend")
     public ApiResponse<GoalMarketTrendResponse> getMarketTrend(@RequestParam Long memberId) {
         return ApiResponse.ok(goalService.getMarketTrend(memberId));
+    }
+
+    @GetMapping("/summary")
+    public ApiResponse<GoalSummaryResponse> getSummary(@LoginMember Long memberId) {
+        return ApiResponse.ok(goalService.getSummary(memberId));
     }
 }

--- a/src/main/java/com/team/independence/goal/controller/GoalController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalController.java
@@ -6,6 +6,7 @@ import com.team.independence.goal.dto.GoalCreateRequest;
 import com.team.independence.goal.dto.GoalDetailResponse;
 import com.team.independence.goal.dto.GoalDiagnosisRequest;
 import com.team.independence.goal.dto.GoalDiagnosisResponse;
+import com.team.independence.goal.dto.GoalMarketTrendResponse;
 import com.team.independence.goal.dto.GoalForecastResponse;
 import com.team.independence.goal.dto.GoalResponse;
 import com.team.independence.goal.service.GoalDetailService;
@@ -55,5 +56,10 @@ public class GoalController {
             @PathVariable Long goalId,
             @RequestParam Long monthlySaving) {
         return ApiResponse.ok(goalService.simulateMonthlySaving(memberId, goalId, monthlySaving));
+    }
+
+    @GetMapping("/market-trend")
+    public ApiResponse<GoalMarketTrendResponse> getMarketTrend(@RequestParam Long memberId) {
+        return ApiResponse.ok(goalService.getMarketTrend(memberId));
     }
 }

--- a/src/main/java/com/team/independence/goal/dto/GoalMarketTrendResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalMarketTrendResponse.java
@@ -1,0 +1,45 @@
+package com.team.independence.goal.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import java.time.YearMonth;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 홈 화면 「매물 시세 변화」 카드용 데이터.
+ *
+ * <p>표시용 가공(평수 라벨 조합, 연월 문자열 포맷, 금액 단위 변환 등)은 하지 않고 raw 값만 내려준다.
+ * FE가 화면에 맞게 포맷한다.
+ */
+@Getter
+@Builder
+public class GoalMarketTrendResponse {
+
+    private String regionName;
+    private HousingType housingType;
+    private DealType dealType;
+    private Integer areaMin;
+    private Integer areaMax;
+
+    /** 실거래 집계 기준 최신 연월 */
+    private YearMonth updatedYm;
+
+    /** currentMiddleAmount - initialMiddleAmount (부호 포함) */
+    private Long changeAmount;
+
+    /** 내 목표 금액 (설정 시점에 고정, 불변) */
+    private Long targetAmount;
+
+    /** 목표 설정 당시 실거래 중앙값 */
+    private Long initialMiddleAmount;
+
+    /** 현재 실거래 중앙값 */
+    private Long currentMiddleAmount;
+
+    /** 목표를 유지할 때의 도달 예상 시점. 재계산하지 않고 goal.target_date를 그대로 반환한다(홈 화면에 노출되는 목표 시점과 동일 값 유지). */
+    private YearMonth maintainEta;
+
+    /** 목표 금액 대신 현재 시세(currentMiddleAmount)를 반영했을 때의 예상 도달 시점. 상한 내 도달 불가면 null */
+    private YearMonth reflectEta;
+}

--- a/src/main/java/com/team/independence/goal/dto/GoalSummaryResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalSummaryResponse.java
@@ -1,0 +1,51 @@
+package com.team.independence.goal.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import java.time.YearMonth;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 홈 화면 「목표 달성 요약」 카드 응답.
+ * 표시용 가공(금액 단위 변환, 연월 문자열 포맷 등)은 하지 않고 raw 값만 내려준다. FE가 화면에 맞게 포맷한다.
+ */
+@Getter
+@Builder
+public class GoalSummaryResponse {
+
+    private Long goalId;
+    private String goalType;
+
+    private Housing housing;
+    private Long targetAmount;
+    /** 목표 시점 */
+    private YearMonth targetDate;
+
+    private Progress progress;
+
+    /** 희망 주거 조건 (goal_housing) */
+    @Getter
+    @Builder
+    public static class Housing {
+        private String regionName;
+        private HousingType housingType;
+        private DealType dealType;
+        private Integer areaMin;
+        private Integer areaMax;
+    }
+
+    /** 목표 달성 현황 */
+    @Getter
+    @Builder
+    public static class Progress {
+        /** 현재 자금(순자산) */
+        private Long currentAmount;
+        /** 남은 금액 = 목표 − 현재, 최소 0 */
+        private Long remainingAmount;
+        /** 달성률(%), 0~100으로 clamp */
+        private Double achievementRate;
+        /** 목표 시점(target_date)까지 남은 개월수. 재계산하지 않고 저장된 target_date 기준. 이미 지났으면 0 */
+        private Long remainingMonths;
+    }
+}

--- a/src/main/java/com/team/independence/goal/mapper/GoalMapper.java
+++ b/src/main/java/com/team/independence/goal/mapper/GoalMapper.java
@@ -1,6 +1,7 @@
 package com.team.independence.goal.mapper;
 
 import com.team.independence.goal.domain.Goal;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -11,6 +12,12 @@ public interface GoalMapper {
     /** 회원에게 ACTIVE 목표가 이미 있는지 확인한다(동시 ACTIVE 목표는 1개만 허용). */
     boolean existsActiveByMemberId(@Param("memberId") Long memberId);
 
-    /** 목표 단건 조회. 소유권 검증은 호출부에서 memberId를 비교해 수행한다. */
-    Goal findById(@Param("id") Long id);
+    /** 회원의 ACTIVE 목표를 조회한다. 없으면 null. */
+    Goal findActiveByMemberId(@Param("memberId") Long memberId);
+
+    /** id로 목표를 조회한다. 없으면 null. */
+    Goal findById(@Param("goalId") Long goalId);
+
+    /** ACTIVE 상태인 모든 목표의 id 목록. 목표 시세 변화 배치 대상 조회용. */
+    List<Long> findAllActiveGoalIds();
 }

--- a/src/main/java/com/team/independence/goal/service/GoalMarketTrendBatchService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalMarketTrendBatchService.java
@@ -1,0 +1,10 @@
+package com.team.independence.goal.service;
+
+public interface GoalMarketTrendBatchService {
+
+    /**
+     * ACTIVE 상태인 모든 목표의 「매물 시세 변화」 카드 데이터를 다시 계산해 Redis 캐시를 갱신한다.
+     * 개별 목표 실패는 서로 격리되며(한 목표 실패가 배치 전체를 죽이지 않음), 실패가 있으면 요약 알림 1건을 보낸다.
+     */
+    void refreshAll();
+}

--- a/src/main/java/com/team/independence/goal/service/GoalMarketTrendBatchServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalMarketTrendBatchServiceImpl.java
@@ -1,0 +1,67 @@
+package com.team.independence.goal.service;
+
+import com.team.independence.external.slack.SlackNotifier;
+import com.team.independence.goal.mapper.GoalMapper;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 목표 시세 변화 배치 구현.
+ *
+ * <p>목표별로 실거래 재조회 + 자산 조회가 필요해 SQL 한 방으로 끝낼 수 없다(goal_snapshot과 다름).
+ * 회원 단위로 순회하며 개별 실패를 격리하는 자산 동기화 배치({@code AssetSyncServiceImpl})와 동일한 패턴을 쓴다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoalMarketTrendBatchServiceImpl implements GoalMarketTrendBatchService {
+
+    private static final String BATCH_NAME = "goal-market-trend";
+
+    private final GoalMapper goalMapper;
+    private final GoalService goalService;
+    private final SlackNotifier slackNotifier;
+
+    // 활성 상태인 모든 목표의 시세 변화 데이터를 갱신
+    @Override
+    public void refreshAll() {
+        List<Long> goalIds = goalMapper.findAllActiveGoalIds();
+        log.info("[배치] 목표 시세 변화 갱신 대상 목표 수: {}", goalIds.size());
+
+        List<RefreshFailure> failures = new ArrayList<>();
+        for (Long goalId : goalIds) {
+            try {
+                goalService.refreshMarketTrend(goalId);
+            } catch (Exception e) {
+                log.error("[배치] 목표 시세 변화 갱신 실패: goalId={}", goalId, e);
+                failures.add(new RefreshFailure(goalId, e));
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            StringBuilder sb = new StringBuilder("[목표 시세 변화 배치 실패] ")
+                    .append(failures.size()).append("건\n");
+            for (RefreshFailure f : failures) {
+                sb.append("• goalId=").append(f.goalId)
+                  .append(" / ").append(f.reason).append("\n");
+            }
+            slackNotifier.sendBatchFailureSummary(BATCH_NAME, sb.toString().trim());
+        }
+
+        log.info("[배치] 목표 시세 변화 갱신 완료 — 성공: {}, 실패: {}",
+                goalIds.size() - failures.size(), failures.size());
+    }
+
+    private static class RefreshFailure {
+        final Long goalId;
+        final String reason;
+
+        RefreshFailure(Long goalId, Throwable e) {
+            this.goalId = goalId;
+            this.reason = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+        }
+    }
+}

--- a/src/main/java/com/team/independence/goal/service/GoalMarketTrendCacheStore.java
+++ b/src/main/java/com/team/independence/goal/service/GoalMarketTrendCacheStore.java
@@ -1,0 +1,61 @@
+package com.team.independence.goal.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.independence.goal.dto.GoalMarketTrendResponse;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 홈 화면 「매물 시세 변화」 카드 데이터를 Redis에 캐싱한다.
+ * Key: goal:market-trend:{goalId}  Value: GoalMarketTrendResponse의 JSON  TTL: 35일
+ *
+ * <p>매월 1일 배치({@link GoalMarketTrendBatchService})가 값을 덮어써 갱신하는 게 기본 흐름이고,
+ * TTL은 배치가 실패했을 때 데이터가 무한정 오래된 값으로 남지 않게 하는 안전장치다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GoalMarketTrendCacheStore {
+
+    private static final String KEY_PREFIX = "goal:market-trend:";
+    private static final Duration TTL = Duration.ofDays(35); // 35일 후 자동 삭제
+
+    // Redis에 문자열 형식의 Key, Value를 저장/조회할 때 사용
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    // 목표 ID에 해당하는 시세 변화 캐시를 Redis에서 조회
+    public Optional<GoalMarketTrendResponse> find(Long goalId) {
+        String json = redisTemplate.opsForValue().get(key(goalId));
+        if (json == null) {
+            return Optional.empty();
+        }
+
+        // JSON을 GoalMarketTrendResponse 객체로 변환
+        try {
+            return Optional.of(objectMapper.readValue(json, GoalMarketTrendResponse.class));
+        } catch (JsonProcessingException e) {
+            log.warn("[목표 시세 캐시] 역직렬화 실패, 캐시 미스로 처리: goalId={}", goalId, e);
+            return Optional.empty();
+        }
+    }
+
+    // 시세 변화 응답 객체를 Redis에 저장
+    public void save(Long goalId, GoalMarketTrendResponse response) {
+        try {
+            String json = objectMapper.writeValueAsString(response);
+            redisTemplate.opsForValue().set(key(goalId), json, TTL);
+        } catch (JsonProcessingException e) {
+            log.warn("[목표 시세 캐시] 직렬화 실패, 캐싱 건너뜀: goalId={}", goalId, e);
+        }
+    }
+
+    private String key(Long goalId) {
+        return KEY_PREFIX + goalId;
+    }
+}

--- a/src/main/java/com/team/independence/goal/service/GoalService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalService.java
@@ -8,6 +8,7 @@ import com.team.independence.goal.dto.GoalDiagnosisResponse;
 import com.team.independence.goal.dto.GoalMarketTrendResponse;
 import com.team.independence.goal.dto.GoalForecastResponse;
 import com.team.independence.goal.dto.GoalResponse;
+import com.team.independence.goal.dto.GoalSummaryResponse;
 
 public interface GoalService {
     GoalDiagnosisResponse diagnose(Long memberId, GoalDiagnosisRequest request);
@@ -42,4 +43,10 @@ public interface GoalService {
 
     /** 목표 시세 변화 데이터를 다시 계산해 캐시에 덮어쓴다. 배치와 캐시 미스 fallback이 공유하는 진입점. */
     GoalMarketTrendResponse refreshMarketTrend(Long goalId);
+
+    /**
+     * 홈 화면 「목표 달성 요약」 카드 데이터. 목표 조건, 목표 금액/시점, 현재 진행 상황(현재 자금/잔여 금액/
+     * 달성률/예상 잔여 개월)을 한 번에 조회한다. 회원의 활성 목표가 없으면 GOAL_NOT_FOUND.
+     */
+    GoalSummaryResponse getSummary(Long memberId);
 }

--- a/src/main/java/com/team/independence/goal/service/GoalService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalService.java
@@ -5,6 +5,7 @@ import com.team.independence.goal.domain.Goal;
 import com.team.independence.goal.dto.GoalCreateRequest;
 import com.team.independence.goal.dto.GoalDiagnosisRequest;
 import com.team.independence.goal.dto.GoalDiagnosisResponse;
+import com.team.independence.goal.dto.GoalMarketTrendResponse;
 import com.team.independence.goal.dto.GoalForecastResponse;
 import com.team.independence.goal.dto.GoalResponse;
 
@@ -32,4 +33,13 @@ public interface GoalService {
      * 저축액이 0 이하면 GOAL_INVALID_INPUT, 진행 중이 아닌 목표면 GOAL_NOT_ACTIVE.
      */
     GoalForecastResponse simulateMonthlySaving(Long memberId, Long goalId, Long monthlySaving);
+
+    /**
+     * 홈 화면 「매물 시세 변화」 카드 데이터. Redis 캐시를 우선 조회하고, 캐시 미스일 때만
+     * {@link #refreshMarketTrend}로 즉시 계산한다(정상적으로는 매월 1일 배치가 캐시를 채워둔다).
+     */
+    GoalMarketTrendResponse getMarketTrend(Long memberId);
+
+    /** 목표 시세 변화 데이터를 다시 계산해 캐시에 덮어쓴다. 배치와 캐시 미스 fallback이 공유하는 진입점. */
+    GoalMarketTrendResponse refreshMarketTrend(Long goalId);
 }

--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -13,6 +13,7 @@ import com.team.independence.goal.dto.GoalDiagnosisResponse;
 import com.team.independence.goal.dto.GoalForecastResponse;
 import com.team.independence.goal.dto.GoalMarketTrendResponse;
 import com.team.independence.goal.dto.GoalResponse;
+import com.team.independence.goal.dto.GoalSummaryResponse;
 import com.team.independence.goal.mapper.GoalHousingMapper;
 import com.team.independence.goal.mapper.GoalMapper;
 import com.team.independence.property.domain.DealType;
@@ -410,6 +411,65 @@ public class GoalServiceImpl implements GoalService {
             return null;
         }
         return calculateMonthToReach(netWorth, fixedSaving, targetAmount);
+    }
+
+    // 홈 화면 「목표 달성 요약」 카드 데이터 조회
+    @Override
+    @Transactional(readOnly = true)
+    public GoalSummaryResponse getSummary(Long memberId) {
+        // 회원 활성 목표 조회
+        Goal goal = goalMapper.findActiveByMemberId(memberId);
+        if (goal == null) {
+            throw new BusinessException(ErrorCode.GOAL_NOT_FOUND);
+        }
+
+        // 회원 목표 주거 조건 조회
+        GoalHousing goalHousing = goalHousingMapper.findByGoalId(goal.getId());
+        if (goalHousing == null) {
+            throw new BusinessException(ErrorCode.GOAL_NOT_FOUND);
+        }
+        String regionName = regionQueryService.resolveRegionName(goalHousing.getRegionCode());
+
+        // 연동 계좌 있는지 확인
+        assetService.validateConnectedAccountExists(memberId);
+        // 현재 순자산 구성 조회
+        AssetNetWorthBreakdown netWorth = assetService.getNetWorthBreakdown(memberId);
+        long currentAmount = netWorth.getInterestBearingAssets() + netWorth.getFlatRecognizedAssets();
+
+        long targetAmount = goal.getTargetAmount();
+        long remainingAmount = Math.max(0, targetAmount - currentAmount); // 남은 금액
+        Double achievementRate = calculateAchievementRate(currentAmount, targetAmount); // 달성률
+        Long remainingMonths = monthsUntil(YearMonth.from(goal.getTargetDate())); // 목표 시점
+
+        return GoalSummaryResponse.builder()
+                .goalId(goal.getId())
+                .goalType(goal.getGoalType())
+                .housing(GoalSummaryResponse.Housing.builder()
+                        .regionName(regionName)
+                        .housingType(goalHousing.getHousingType())
+                        .dealType(goalHousing.getDealType())
+                        .areaMin(goalHousing.getAreaMin())
+                        .areaMax(goalHousing.getAreaMax())
+                        .build())
+                .targetAmount(targetAmount)
+                .targetDate(YearMonth.from(goal.getTargetDate()))
+                .progress(GoalSummaryResponse.Progress.builder()
+                        .currentAmount(currentAmount)
+                        .remainingAmount(remainingAmount)
+                        .achievementRate(achievementRate)
+                        .remainingMonths(remainingMonths)
+                        .build())
+                .build();
+    }
+
+    /** 달성률(%). 0~100으로 자른다 — GoalDetailServiceImpl과 동일 규칙. */
+    private Double calculateAchievementRate(long currentAmount, long targetAmount) {
+        if (targetAmount <= 0) {
+            return 0.0;
+        }
+        double rate = currentAmount * 100.0 / targetAmount;
+        double clamped = Math.min(100.0, Math.max(0.0, rate));
+        return Math.round(clamped * 100) / 100.0;
     }
 
     /** RentMedianService 호출용 요청 조립. sizeMin/sizeMax는 평 단위 그대로 넘기면 내부에서 ㎡로 환산한다. */

--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -11,6 +11,7 @@ import com.team.independence.goal.dto.GoalCreateRequest;
 import com.team.independence.goal.dto.GoalDiagnosisRequest;
 import com.team.independence.goal.dto.GoalDiagnosisResponse;
 import com.team.independence.goal.dto.GoalForecastResponse;
+import com.team.independence.goal.dto.GoalMarketTrendResponse;
 import com.team.independence.goal.dto.GoalResponse;
 import com.team.independence.goal.mapper.GoalHousingMapper;
 import com.team.independence.goal.mapper.GoalMapper;
@@ -22,6 +23,7 @@ import com.team.independence.property.service.RegionQueryService;
 import com.team.independence.property.service.RentMedianService;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,11 +56,15 @@ public class GoalServiceImpl implements GoalService {
     /** 예상 달성 시점 탐색 상한(개월). 저축액이 미미해 사실상 도달 불가할 때 무한 루프를 막는 안전장치. */
     private static final long MAX_FORECAST_MONTHS = 1200;
 
+    /** RentMedianResponse.baseEndYm("YYYYMM") 파싱용 */
+    private static final DateTimeFormatter YM_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
+
     private final RegionQueryService regionQueryService;
     private final AssetService assetService; // 자산 정보 조회
     private final RentMedianService rentMedianService; // 조건에 맞는 실거래 4분위값 조회
     private final GoalMapper goalMapper;
     private final GoalHousingMapper goalHousingMapper;
+    private final GoalMarketTrendCacheStore goalMarketTrendCacheStore;
 
     @Override
     public GoalDiagnosisResponse diagnose(Long memberId, GoalDiagnosisRequest request) {
@@ -276,6 +282,111 @@ public class GoalServiceImpl implements GoalService {
                     + calculateProjectedSavings(monthlySaving, months);
             if (expectedBudget >= targetAmount) {
                 return months;
+            }
+        }
+        return null;
+    }
+
+    // 현재 활성 목표에 대한 매물 시세 변화 데이터 조회
+    @Override
+    @Transactional(readOnly = true)
+    public GoalMarketTrendResponse getMarketTrend(Long memberId) {
+        // 회원 활성 목표 조회
+        Goal goal = goalMapper.findActiveByMemberId(memberId);
+        if (goal == null) {
+            throw new BusinessException(ErrorCode.GOAL_NOT_FOUND);
+        }
+
+        // redis 캐시 조회
+        return goalMarketTrendCacheStore.find(goal.getId())
+                .orElseGet(() -> refreshMarketTrend(goal.getId())); // 캐시 없으면 직접 갱신
+    }
+
+    // 시세 변화 데이터를 새로 계산한 뒤 Redis에 저장
+    @Override
+    @Transactional(readOnly = true)
+    public GoalMarketTrendResponse refreshMarketTrend(Long goalId) {
+        // 기본 목표 정보 조회
+        Goal goal = goalMapper.findById(goalId);
+        if (goal == null) {
+            throw new BusinessException(ErrorCode.GOAL_NOT_FOUND);
+        }
+
+        // 주거 희망 조건 조회
+        GoalHousing goalHousing = goalHousingMapper.findByGoalId(goalId);
+        if (goalHousing == null) {
+            throw new BusinessException(ErrorCode.GOAL_NOT_FOUND);
+        }
+
+        // 시세 변화 데이터 계산
+        GoalMarketTrendResponse response = computeMarketTrend(goal, goalHousing);
+
+        // Redis에 저장
+        goalMarketTrendCacheStore.save(goalId, response);
+        return response;
+    }
+
+    /**
+     * 목표의 희망 조건으로 실거래 중앙값을 다시 조회하고, reflectEta(현재 시세 반영 시 도달 예상 시점)만
+     * 오늘 기준 자산으로 다시 계산한다.
+     *
+     * <p>maintainEta(목표 유지 시 도달 예상 시점)는 재계산하지 않고 goal.target_date를 그대로 쓴다.
+     * 홈 화면 다른 곳에도 같은 target_date가 "목표 시점"으로 노출되는데, 여기서 오늘 자산 기준으로
+     * 다시 계산해버리면 같은 화면 안에서 목표 시점이 두 가지 다른 값으로 보이게 된다.
+     */
+    private GoalMarketTrendResponse computeMarketTrend(Goal goal, GoalHousing goalHousing) {
+        String regionName = regionQueryService.resolveRegionName(goalHousing.getRegionCode());
+
+        // 사용자 조건에 맞춰 현재 실거래 데이터를 다시 조회
+        RentMedianResponse currentStats = rentMedianService.getMedian(buildMedianRequest(
+                goalHousing.getRegionCode(), goalHousing.getHousingType(), goalHousing.getDealType(),
+                goalHousing.getAreaMin(), goalHousing.getAreaMax(),
+                goalHousing.getDepositMin(), goalHousing.getDepositMax(),
+                goalHousing.getMonthlyRentMin(), goalHousing.getMonthlyRentMax()));
+
+        if (currentStats.getSampleCount() == 0) {
+            throw new BusinessException(ErrorCode.GOAL_NO_MARKET_DATA);
+        }
+
+        long currentMiddleAmount = currentStats.getDeposit().getMedian(); // 현재 실거래 중앙값 추출
+        long initialMiddleAmount = goal.getTargetRentMiddleAmount(); // 목표 생성 당시 중앙값 조회
+
+        // 회원의 현재 자산 조회
+        AssetNetWorthBreakdown netWorth = assetService.getNetWorthBreakdown(goal.getMemberId());
+
+        // 목표 유지 시: 저장된 target_date 그대로 (다른 화면에 노출되는 목표 시점과 일치시킴)
+        YearMonth maintainEta = YearMonth.from(goal.getTargetDate());
+        // 현재 시세 반영 시: 오늘 자산 기준으로 다시 계산
+        YearMonth reflectEta = calculateEta(netWorth.getInterestBearingAssets(), netWorth.getFlatRecognizedAssets(),
+                goal.getMonthlySaving(), currentMiddleAmount);
+
+        return GoalMarketTrendResponse.builder()
+                .regionName(regionName)
+                .housingType(goalHousing.getHousingType())
+                .dealType(goalHousing.getDealType())
+                .areaMin(goalHousing.getAreaMin())
+                .areaMax(goalHousing.getAreaMax())
+                .updatedYm(YearMonth.parse(currentStats.getBaseEndYm(), YM_FORMATTER))
+                .changeAmount(currentMiddleAmount - initialMiddleAmount)
+                .targetAmount(goal.getTargetAmount())
+                .initialMiddleAmount(initialMiddleAmount)
+                .currentMiddleAmount(currentMiddleAmount)
+                .maintainEta(maintainEta)
+                .reflectEta(reflectEta)
+                .build();
+    }
+
+    /** 오늘(n=0)부터 상한까지, 자산 성장 + 적립식 저축이 targetAmount 이상이 되는 최초 시점을 탐색. 못 찾으면 null. */
+    private YearMonth calculateEta(long interestBearingAssets, long flatRecognizedAssets,
+            long monthlySaving, long targetAmount) {
+        for (long n = 0; n <= EXTEND_PERIOD_MAX_MONTHS; n++) {
+            // 예상 총 예산 계산
+            long projected = calculateGrownAmount(interestBearingAssets, n) + flatRecognizedAssets
+                    + calculateProjectedSavings(monthlySaving, n);
+
+            // 목표 금액보다 클 때 날짜 반환
+            if (projected >= targetAmount) {
+                return YearMonth.now().plusMonths(n);
             }
         }
         return null;

--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -356,9 +356,11 @@ public class GoalServiceImpl implements GoalService {
 
         // 목표 유지 시: 저장된 target_date 그대로 (다른 화면에 노출되는 목표 시점과 일치시킴)
         YearMonth maintainEta = YearMonth.from(goal.getTargetDate());
-        // 현재 시세 반영 시: 오늘 자산 기준으로 다시 계산
-        YearMonth reflectEta = calculateEta(netWorth.getInterestBearingAssets(), netWorth.getFlatRecognizedAssets(),
-                goal.getMonthlySaving(), currentMiddleAmount);
+        // 현재 시세 반영 시: 오늘 자산 기준으로 다시 계산 (목표 상세 조회와 같은 계산 재사용)
+        Long monthsToReachCurrentMiddle = calculateMonthToReach(netWorth, goal.getMonthlySaving(), currentMiddleAmount);
+        YearMonth reflectEta = monthsToReachCurrentMiddle == null
+                ? null
+                : YearMonth.now().plusMonths(monthsToReachCurrentMiddle);
 
         return GoalMarketTrendResponse.builder()
                 .regionName(regionName)
@@ -374,22 +376,6 @@ public class GoalServiceImpl implements GoalService {
                 .maintainEta(maintainEta)
                 .reflectEta(reflectEta)
                 .build();
-    }
-
-    /** 오늘(n=0)부터 상한까지, 자산 성장 + 적립식 저축이 targetAmount 이상이 되는 최초 시점을 탐색. 못 찾으면 null. */
-    private YearMonth calculateEta(long interestBearingAssets, long flatRecognizedAssets,
-            long monthlySaving, long targetAmount) {
-        for (long n = 0; n <= EXTEND_PERIOD_MAX_MONTHS; n++) {
-            // 예상 총 예산 계산
-            long projected = calculateGrownAmount(interestBearingAssets, n) + flatRecognizedAssets
-                    + calculateProjectedSavings(monthlySaving, n);
-
-            // 목표 금액보다 클 때 날짜 반환
-            if (projected >= targetAmount) {
-                return YearMonth.now().plusMonths(n);
-            }
-        }
-        return null;
     }
 
     /**

--- a/src/main/java/com/team/independence/property/service/RegionQueryService.java
+++ b/src/main/java/com/team/independence/property/service/RegionQueryService.java
@@ -4,4 +4,7 @@ public interface RegionQueryService {
 
     /** 시/도 + 군/구 이름으로 region_code를 조회한다. 없으면 BusinessException(REGION_NOT_FOUND). */
     String resolveRegionCode(String sido, String sigungu);
+
+    /** region_code로 지역 전체 지명을 조회한다. 없으면 BusinessException(REGION_NOT_FOUND). */
+    String resolveRegionName(String regionCode);
 }

--- a/src/main/java/com/team/independence/property/service/RegionQueryServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/RegionQueryServiceImpl.java
@@ -22,4 +22,14 @@ public class RegionQueryServiceImpl implements RegionQueryService {
         }
         return regionCode;
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public String resolveRegionName(String regionCode) {
+        String regionName = regionMapper.findFullNameByCode(regionCode);
+        if (regionName == null) {
+            throw new BusinessException(ErrorCode.REGION_NOT_FOUND);
+        }
+        return regionName;
+    }
 }

--- a/src/main/java/com/team/independence/scheduler/GoalMarketTrendScheduler.java
+++ b/src/main/java/com/team/independence/scheduler/GoalMarketTrendScheduler.java
@@ -1,0 +1,46 @@
+package com.team.independence.scheduler;
+
+import com.team.independence.goal.service.GoalMarketTrendBatchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 홈 화면 「매물 시세 변화」 카드용 목표 시세 변화 갱신 배치.
+ *
+ * <p>BatchConfig(@Profile("batch"))의 컴포넌트 스캔 대상이라 batch 프로필로 띄울 때만
+ * 등록된다. api 프로필로 실행하면 이 빈은 생성되지 않는다.
+ *
+ * <p>로직은 없다. Service를 호출만 한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GoalMarketTrendScheduler implements InitializingBean {
+
+    private final GoalMarketTrendBatchService goalMarketTrendBatchService;
+
+    /**
+     * 순수 Spring은 Boot와 달리 활성 프로필을 기동 로그에 찍어주지 않는다.
+     * 이 줄이 보이면 batch 프로필이 걸렸다는 뜻이다.
+     */
+    @Override
+    public void afterPropertiesSet() {
+        log.info("[배치] 목표 시세 변화 갱신 스케줄러 등록됨 (batch 프로필 활성)");
+    }
+
+    /**
+     * 매월 1일 새벽 6시.
+     *
+     * <p>전월세 실거래 동기화(4시)와 자산 동기화(4시)가 끝난 뒤로 뺐다. 이 배치는 그 둘의
+     * 최신 데이터(실거래 중앙값, 순자산)를 그대로 갖다 쓰므로 먼저 갱신돼 있어야 한다.
+     */
+    @Scheduled(cron = "0 0 6 1 * *", zone = "Asia/Seoul")
+    public void refreshGoalMarketTrends() {
+        log.info("[배치] 목표 시세 변화 갱신 시작");
+        goalMarketTrendBatchService.refreshAll();
+        log.info("[배치] 목표 시세 변화 갱신 종료");
+    }
+}

--- a/src/main/resources/mybatis/mapper/goal/GoalMapper.xml
+++ b/src/main/resources/mybatis/mapper/goal/GoalMapper.xml
@@ -36,13 +36,28 @@
         )
     </select>
 
-    <select id="findById" resultMap="goalMap">
-        SELECT id, member_id, goal_type, target_amount, target_rent_middle_amount,
-               target_date, monthly_saving, status,
-               market_alert_dismissed_at, market_alert_dismissed_price,
-               created_at, updated_at
-          FROM goal
-         WHERE id = #{id}
+    <select id="findActiveByMemberId" resultType="com.team.independence.goal.domain.Goal">
+        SELECT
+            id, member_id, goal_type, target_amount, target_rent_middle_amount,
+            target_date, monthly_saving, status,
+            market_alert_dismissed_at, market_alert_dismissed_price,
+            created_at, updated_at
+        FROM goal
+        WHERE member_id = #{memberId} AND status = 'ACTIVE'
+    </select>
+
+    <select id="findAllActiveGoalIds" resultType="long">
+        SELECT id FROM goal WHERE status = 'ACTIVE'
+    </select>
+
+    <select id="findById" resultType="com.team.independence.goal.domain.Goal">
+        SELECT
+            id, member_id, goal_type, target_amount, target_rent_middle_amount,
+            target_date, monthly_saving, status,
+            market_alert_dismissed_at, market_alert_dismissed_price,
+            created_at, updated_at
+        FROM goal
+        WHERE id = #{goalId}
     </select>
 
 </mapper>

--- a/src/test/java/com/team/independence/asset/service/AssetSyncServiceImplTest.java
+++ b/src/test/java/com/team/independence/asset/service/AssetSyncServiceImplTest.java
@@ -39,6 +39,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -226,7 +227,7 @@ class  AssetSyncServiceImplTest {
         service.syncAll();
 
         ArgumentCaptor<String> slackCaptor = ArgumentCaptor.forClass(String.class);
-        verify(slackNotifier, times(1)).sendBatchFailureSummary(slackCaptor.capture());
+        verify(slackNotifier, times(1)).sendBatchFailureSummary(eq("asset-sync"), slackCaptor.capture());
         assertThat(slackCaptor.getValue()).contains("memberId=2");
 
         verify(assetSummaryMapper, times(2)).upsert(any());
@@ -245,7 +246,7 @@ class  AssetSyncServiceImplTest {
 
         service.syncAll();
 
-        verify(slackNotifier, never()).sendBatchFailureSummary(anyString());
+        verify(slackNotifier, never()).sendBatchFailureSummary(anyString(), anyString());
     }
 
     // 더미 Response JSON (CodefMockClient와 동일)

--- a/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
@@ -69,7 +69,7 @@ class GoalDetailServiceImplTest {
         // 그 외 의존성은 이 경로에서 쓰이지 않아 null로 둔다.
         service = new GoalDetailServiceImpl(
                 goalHousingMapper, savingRecordMapper, assetService,
-                new GoalServiceImpl(null, null, null, goalMapper, null));
+                new GoalServiceImpl(null, null, null, goalMapper, null, null));
     }
 
     // ------------------------------------------------------------------
@@ -418,6 +418,16 @@ class GoalDetailServiceImplTest {
 
         @Override
         public boolean existsActiveByMemberId(Long memberId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Goal findActiveByMemberId(Long memberId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Long> findAllActiveGoalIds() {
             throw new UnsupportedOperationException();
         }
     }

--- a/src/test/java/com/team/independence/goal/service/GoalMarketTrendBatchServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalMarketTrendBatchServiceImplTest.java
@@ -1,0 +1,84 @@
+package com.team.independence.goal.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.team.independence.external.slack.SlackNotifier;
+import com.team.independence.goal.dto.GoalMarketTrendResponse;
+import com.team.independence.goal.mapper.GoalMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GoalMarketTrendBatchServiceImplTest {
+
+    @Mock GoalMapper goalMapper;
+    @Mock GoalService goalService;
+    @Mock SlackNotifier slackNotifier;
+
+    GoalMarketTrendBatchServiceImpl batchService;
+
+    @BeforeEach
+    void setUp() {
+        batchService = new GoalMarketTrendBatchServiceImpl(goalMapper, goalService, slackNotifier);
+    }
+
+    @Test
+    @DisplayName("refreshAll - 전체 성공 시 Slack 알림을 보내지 않는다")
+    void refreshAll_allSucceed_noSlackAlert() {
+        when(goalMapper.findAllActiveGoalIds()).thenReturn(List.of(1L, 2L, 3L));
+
+        batchService.refreshAll();
+
+        verify(goalService, times(1)).refreshMarketTrend(1L);
+        verify(goalService, times(1)).refreshMarketTrend(2L);
+        verify(goalService, times(1)).refreshMarketTrend(3L);
+        verify(slackNotifier, never()).sendBatchFailureSummary(any(), any());
+    }
+
+    @Test
+    @DisplayName("refreshAll - 일부 목표가 실패해도 나머지는 계속 처리되고, 실패는 요약 알림 1건으로 모아 보낸다")
+    void refreshAll_partialFailure_isolatedAndSummarized() {
+        when(goalMapper.findAllActiveGoalIds()).thenReturn(List.of(1L, 2L, 3L));
+        when(goalService.refreshMarketTrend(1L)).thenReturn(GoalMarketTrendResponse.builder().build());
+        doThrow(new RuntimeException("실거래 데이터 없음")).when(goalService).refreshMarketTrend(2L);
+        when(goalService.refreshMarketTrend(3L)).thenReturn(GoalMarketTrendResponse.builder().build());
+
+        batchService.refreshAll();
+
+        verify(goalService, times(1)).refreshMarketTrend(1L);
+        verify(goalService, times(1)).refreshMarketTrend(2L);
+        verify(goalService, times(1)).refreshMarketTrend(3L); // 2번 실패해도 3번은 계속 진행됨
+
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(slackNotifier, times(1)).sendBatchFailureSummary(eq("goal-market-trend"), messageCaptor.capture());
+        org.assertj.core.api.Assertions.assertThat(messageCaptor.getValue())
+                .contains("goalId=2")
+                .contains("실거래 데이터 없음");
+    }
+
+    @Test
+    @DisplayName("refreshAll - 전체 실패해도 배치 자체는 예외 없이 끝난다")
+    void refreshAll_allFail_doesNotThrow() {
+        when(goalMapper.findAllActiveGoalIds()).thenReturn(List.of(1L, 2L));
+        doThrow(new RuntimeException("실패1")).when(goalService).refreshMarketTrend(1L);
+        doThrow(new RuntimeException("실패2")).when(goalService).refreshMarketTrend(2L);
+
+        batchService.refreshAll();
+
+        verify(slackNotifier, times(1)).sendBatchFailureSummary(eq("goal-market-trend"), contains("2건"));
+    }
+}

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplMarketTrendTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplMarketTrendTest.java
@@ -1,0 +1,255 @@
+package com.team.independence.goal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.team.independence.asset.dto.AssetNetWorthBreakdown;
+import com.team.independence.asset.service.AssetService;
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.goal.domain.Goal;
+import com.team.independence.goal.domain.GoalHousing;
+import com.team.independence.goal.dto.GoalMarketTrendResponse;
+import com.team.independence.goal.mapper.GoalHousingMapper;
+import com.team.independence.goal.mapper.GoalMapper;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.RentMedianRequest;
+import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.dto.RentMedianResponse.Quartile;
+import com.team.independence.property.service.RegionQueryService;
+import com.team.independence.property.service.RentMedianService;
+import java.time.YearMonth;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GoalServiceImplMarketTrendTest {
+
+    @Mock RegionQueryService regionQueryService;
+    @Mock AssetService assetService;
+    @Mock RentMedianService rentMedianService;
+    @Mock GoalMapper goalMapper;
+    @Mock GoalHousingMapper goalHousingMapper;
+    @Mock GoalMarketTrendCacheStore goalMarketTrendCacheStore;
+
+    GoalServiceImpl service;
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long GOAL_ID = 100L;
+
+    @BeforeEach
+    void setUp() {
+        service = new GoalServiceImpl(
+                regionQueryService, assetService, rentMedianService,
+                goalMapper, goalHousingMapper, goalMarketTrendCacheStore);
+    }
+
+    private Goal goal(long targetAmount, long targetRentMiddleAmount, long monthlySaving) {
+        return Goal.builder()
+                .id(GOAL_ID)
+                .memberId(MEMBER_ID)
+                .goalType("HOUSING")
+                .targetAmount(targetAmount)
+                .targetRentMiddleAmount(targetRentMiddleAmount)
+                .targetDate(java.time.LocalDate.now().plusYears(1))
+                .monthlySaving(monthlySaving)
+                .status("ACTIVE")
+                .build();
+    }
+
+    private GoalHousing goalHousing() {
+        return GoalHousing.builder()
+                .goalId(GOAL_ID)
+                .regionCode("11680")
+                .housingType(HousingType.OFFICETEL)
+                .dealType(DealType.JEONSE)
+                .areaMin(10)
+                .areaMax(20)
+                .depositMin(0L)
+                .depositMax(500_000_000L)
+                .monthlyRentMin(0L)
+                .monthlyRentMax(0L)
+                .build();
+    }
+
+    private RentMedianResponse rentStats(int sampleCount, Long median, String baseEndYm) {
+        return RentMedianResponse.builder()
+                .regionCode("11680")
+                .regionName("서울 강남구")
+                .housingType(HousingType.OFFICETEL)
+                .dealType(DealType.JEONSE)
+                .baseStartYm("202509")
+                .baseEndYm(baseEndYm)
+                .sampleCount(sampleCount)
+                .deposit(sampleCount == 0 ? Quartile.empty() : Quartile.of(median - 1000, median, median + 1000))
+                .monthlyRent(Quartile.empty())
+                .build();
+    }
+
+    @Test
+    @DisplayName("getMarketTrend - 캐시 히트면 재계산 없이 캐시 값을 그대로 반환한다")
+    void getMarketTrend_cacheHit_returnsWithoutRecompute() {
+        when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(goal(100_000_000L, 90_000_000L, 1_000_000L));
+        GoalMarketTrendResponse cached = GoalMarketTrendResponse.builder().targetAmount(100_000_000L).build();
+        when(goalMarketTrendCacheStore.find(GOAL_ID)).thenReturn(Optional.of(cached));
+
+        GoalMarketTrendResponse result = service.getMarketTrend(MEMBER_ID);
+
+        assertThat(result).isSameAs(cached);
+        verify(rentMedianService, never()).getMedian(any());
+        verify(assetService, never()).getNetWorthBreakdown(anyLong());
+        verify(goalMarketTrendCacheStore, never()).save(any(), any());
+    }
+
+    @Test
+    @DisplayName("getMarketTrend - ACTIVE 목표가 없으면 GOAL_NOT_FOUND")
+    void getMarketTrend_noActiveGoal_throws() {
+        when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(null);
+
+        assertThatThrownBy(() -> service.getMarketTrend(MEMBER_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GOAL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("getMarketTrend - 캐시 미스면 refreshMarketTrend로 계산 후 캐시에 저장한다")
+    void getMarketTrend_cacheMiss_computesAndCaches() {
+        Goal goal = goal(100_000_000L, 90_000_000L, 1_000_000L);
+        when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(goal);
+        when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
+        when(goalMarketTrendCacheStore.find(GOAL_ID)).thenReturn(Optional.empty());
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
+        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
+        when(rentMedianService.getMedian(any(RentMedianRequest.class)))
+                .thenReturn(rentStats(5, 95_000_000L, "202607"));
+        when(assetService.getNetWorthBreakdown(MEMBER_ID))
+                .thenReturn(AssetNetWorthBreakdown.builder()
+                        .interestBearingAssets(0L)
+                        .flatRecognizedAssets(200_000_000L)
+                        .build());
+
+        GoalMarketTrendResponse result = service.getMarketTrend(MEMBER_ID);
+
+        assertThat(result.getCurrentMiddleAmount()).isEqualTo(95_000_000L);
+        assertThat(result.getChangeAmount()).isEqualTo(5_000_000L); // 95M - 90M
+        assertThat(result.getUpdatedYm()).isEqualTo(YearMonth.of(2026, 7));
+        verify(goalMarketTrendCacheStore).save(eq(GOAL_ID), any(GoalMarketTrendResponse.class));
+    }
+
+    @Test
+    @DisplayName("refreshMarketTrend - 조건에 맞는 실거래가 없으면 GOAL_NO_MARKET_DATA")
+    void refreshMarketTrend_noMarketData_throws() {
+        Goal goal = goal(100_000_000L, 90_000_000L, 1_000_000L);
+        when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
+        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
+        when(rentMedianService.getMedian(any(RentMedianRequest.class))).thenReturn(rentStats(0, null, "202607"));
+
+        assertThatThrownBy(() -> service.refreshMarketTrend(GOAL_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GOAL_NO_MARKET_DATA);
+
+        verify(goalMarketTrendCacheStore, never()).save(any(), any());
+    }
+
+    @Test
+    @DisplayName("refreshMarketTrend - 목표가 없으면 GOAL_NOT_FOUND")
+    void refreshMarketTrend_goalNotFound_throws() {
+        when(goalMapper.findById(GOAL_ID)).thenReturn(null);
+
+        assertThatThrownBy(() -> service.refreshMarketTrend(GOAL_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GOAL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("refreshMarketTrend - 희망 주거 조건이 없으면 GOAL_NOT_FOUND")
+    void refreshMarketTrend_goalHousingNotFound_throws() {
+        Goal goal = goal(100_000_000L, 90_000_000L, 1_000_000L);
+        when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(null);
+
+        assertThatThrownBy(() -> service.refreshMarketTrend(GOAL_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GOAL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("refreshMarketTrend - maintainEta는 재계산하지 않고 goal.target_date를 그대로 반환한다")
+    void refreshMarketTrend_maintainEta_usesStoredTargetDateAsIs() {
+        Goal goal = goal(1L, 90_000_000L, 1_000_000L); // targetAmount=1원, 사실상 이미 달성
+        when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
+        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
+        when(rentMedianService.getMedian(any(RentMedianRequest.class)))
+                .thenReturn(rentStats(5, 1L, "202607"));
+        when(assetService.getNetWorthBreakdown(MEMBER_ID))
+                .thenReturn(AssetNetWorthBreakdown.builder()
+                        .interestBearingAssets(0L)
+                        .flatRecognizedAssets(1_000_000_000L)
+                        .build());
+
+        GoalMarketTrendResponse result = service.refreshMarketTrend(GOAL_ID);
+
+        // 자산이 충분해 이미 달성 가능한 상황이어도 maintainEta는 재계산되지 않고 저장된 target_date 그대로다
+        assertThat(result.getMaintainEta()).isEqualTo(YearMonth.from(goal.getTargetDate()));
+        assertThat(result.getReflectEta()).isEqualTo(YearMonth.now());
+    }
+
+    @Test
+    @DisplayName("refreshMarketTrend - reflectEta는 상한(240개월) 내 도달 불가능하면 null, maintainEta는 그대로 target_date")
+    void refreshMarketTrend_unreachable_reflectEtaIsNull() {
+        Goal goal = goal(9_999_999_999L, 90_000_000L, 0L); // 저축 0, 목표는 사실상 도달 불가
+        when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
+        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
+        when(rentMedianService.getMedian(any(RentMedianRequest.class)))
+                .thenReturn(rentStats(5, 9_999_999_999L, "202607"));
+        when(assetService.getNetWorthBreakdown(MEMBER_ID))
+                .thenReturn(AssetNetWorthBreakdown.builder()
+                        .interestBearingAssets(0L)
+                        .flatRecognizedAssets(0L)
+                        .build());
+
+        GoalMarketTrendResponse result = service.refreshMarketTrend(GOAL_ID);
+
+        assertThat(result.getMaintainEta()).isEqualTo(YearMonth.from(goal.getTargetDate()));
+        assertThat(result.getReflectEta()).isNull();
+    }
+
+    @Test
+    @DisplayName("refreshMarketTrend - maintainEta(목표 유지)와 reflectEta(시세 반영)는 금액이 다르면 다른 시점으로 계산된다")
+    void refreshMarketTrend_maintainAndReflect_diverge() {
+        // targetAmount(100M)가 currentMiddleAmount(10M)보다 훨씬 커서, 반영(reflect) 쪽이 훨씬 빨리 도달해야 한다
+        Goal goal = goal(100_000_000L, 90_000_000L, 1_000_000L);
+        when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
+        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
+        when(rentMedianService.getMedian(any(RentMedianRequest.class)))
+                .thenReturn(rentStats(5, 10_000_000L, "202607"));
+        when(assetService.getNetWorthBreakdown(MEMBER_ID))
+                .thenReturn(AssetNetWorthBreakdown.builder()
+                        .interestBearingAssets(0L)
+                        .flatRecognizedAssets(0L)
+                        .build());
+
+        GoalMarketTrendResponse result = service.refreshMarketTrend(GOAL_ID);
+
+        assertThat(result.getMaintainEta()).isNotNull();
+        assertThat(result.getReflectEta()).isNotNull();
+        assertThat(result.getReflectEta()).isLessThan(result.getMaintainEta());
+    }
+}

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplSummaryTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplSummaryTest.java
@@ -1,0 +1,192 @@
+package com.team.independence.goal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.team.independence.asset.dto.AssetNetWorthBreakdown;
+import com.team.independence.asset.service.AssetService;
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.goal.domain.Goal;
+import com.team.independence.goal.domain.GoalHousing;
+import com.team.independence.goal.dto.GoalSummaryResponse;
+import com.team.independence.goal.mapper.GoalHousingMapper;
+import com.team.independence.goal.mapper.GoalMapper;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.service.RegionQueryService;
+import com.team.independence.property.service.RentMedianService;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GoalServiceImplSummaryTest {
+
+    @Mock RegionQueryService regionQueryService;
+    @Mock AssetService assetService;
+    @Mock RentMedianService rentMedianService;
+    @Mock GoalMapper goalMapper;
+    @Mock GoalHousingMapper goalHousingMapper;
+    @Mock GoalMarketTrendCacheStore goalMarketTrendCacheStore;
+
+    GoalServiceImpl service;
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long GOAL_ID = 100L;
+
+    @BeforeEach
+    void setUp() {
+        service = new GoalServiceImpl(
+                regionQueryService, assetService, rentMedianService,
+                goalMapper, goalHousingMapper, goalMarketTrendCacheStore);
+    }
+
+    private Goal goal(long targetAmount, long monthlySaving) {
+        return goal(targetAmount, monthlySaving, LocalDate.now().plusYears(1));
+    }
+
+    private Goal goal(long targetAmount, long monthlySaving, LocalDate targetDate) {
+        return Goal.builder()
+                .id(GOAL_ID)
+                .memberId(MEMBER_ID)
+                .goalType("HOUSING")
+                .targetAmount(targetAmount)
+                .targetRentMiddleAmount(90_000_000L)
+                .targetDate(targetDate)
+                .monthlySaving(monthlySaving)
+                .status("ACTIVE")
+                .build();
+    }
+
+    private GoalHousing goalHousing() {
+        return GoalHousing.builder()
+                .goalId(GOAL_ID)
+                .regionCode("11680")
+                .housingType(HousingType.OFFICETEL)
+                .dealType(DealType.JEONSE)
+                .areaMin(10)
+                .areaMax(20)
+                .depositMin(0L)
+                .depositMax(500_000_000L)
+                .monthlyRentMin(0L)
+                .monthlyRentMax(0L)
+                .build();
+    }
+
+    @Test
+    @DisplayName("getSummary - 목표/주거조건/진행상황을 모두 채워 반환한다")
+    void getSummary_returnsFullSummary() {
+        Goal goal = goal(100_000_000L, 1_000_000L);
+        when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(goal);
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
+        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
+        when(assetService.getNetWorthBreakdown(MEMBER_ID))
+                .thenReturn(AssetNetWorthBreakdown.builder()
+                        .interestBearingAssets(0L)
+                        .flatRecognizedAssets(20_000_000L)
+                        .build());
+
+        GoalSummaryResponse result = service.getSummary(MEMBER_ID);
+
+        assertThat(result.getGoalId()).isEqualTo(GOAL_ID);
+        assertThat(result.getGoalType()).isEqualTo("HOUSING");
+        assertThat(result.getTargetAmount()).isEqualTo(100_000_000L);
+        assertThat(result.getTargetDate()).isEqualTo(YearMonth.from(goal.getTargetDate()));
+
+        assertThat(result.getHousing().getRegionName()).isEqualTo("서울 강남구");
+        assertThat(result.getHousing().getHousingType()).isEqualTo(HousingType.OFFICETEL);
+        assertThat(result.getHousing().getDealType()).isEqualTo(DealType.JEONSE);
+        assertThat(result.getHousing().getAreaMin()).isEqualTo(10);
+        assertThat(result.getHousing().getAreaMax()).isEqualTo(20);
+
+        assertThat(result.getProgress().getCurrentAmount()).isEqualTo(20_000_000L);
+        assertThat(result.getProgress().getRemainingAmount()).isEqualTo(80_000_000L);
+        assertThat(result.getProgress().getAchievementRate()).isEqualTo(20.0);
+        // targetDate가 오늘부터 정확히 1년 뒤이므로 재계산 없이 12개월이 그대로 나온다
+        assertThat(result.getProgress().getRemainingMonths()).isEqualTo(12L);
+    }
+
+    @Test
+    @DisplayName("getSummary - 활성 목표가 없으면 GOAL_NOT_FOUND")
+    void getSummary_noActiveGoal_throws() {
+        when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(null);
+
+        assertThatThrownBy(() -> service.getSummary(MEMBER_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GOAL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("getSummary - 희망 주거 조건이 없으면 GOAL_NOT_FOUND")
+    void getSummary_goalHousingNotFound_throws() {
+        when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(goal(100_000_000L, 1_000_000L));
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(null);
+
+        assertThatThrownBy(() -> service.getSummary(MEMBER_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GOAL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("getSummary - 현재 자금이 목표 금액을 넘으면 remainingAmount 0, achievementRate 100으로 clamp")
+    void getSummary_overachieved_clampsToZeroAndHundred() {
+        Goal goal = goal(50_000_000L, 1_000_000L);
+        when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(goal);
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
+        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
+        when(assetService.getNetWorthBreakdown(MEMBER_ID))
+                .thenReturn(AssetNetWorthBreakdown.builder()
+                        .interestBearingAssets(0L)
+                        .flatRecognizedAssets(80_000_000L)
+                        .build());
+
+        GoalSummaryResponse result = service.getSummary(MEMBER_ID);
+
+        assertThat(result.getProgress().getRemainingAmount()).isEqualTo(0L);
+        assertThat(result.getProgress().getAchievementRate()).isEqualTo(100.0);
+    }
+
+    @Test
+    @DisplayName("getSummary - remainingMonths는 저축액과 무관하게 저장된 target_date로만 계산된다")
+    void getSummary_remainingMonths_derivedFromStoredTargetDate() {
+        // 저축액 0(재계산이었다면 도달 불가로 null이 나왔을 상황)이어도 targetDate 기준 개월수가 그대로 나와야 한다
+        Goal goal = goal(100_000_000L, 0L, LocalDate.now().plusMonths(5));
+        when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(goal);
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
+        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
+        when(assetService.getNetWorthBreakdown(MEMBER_ID))
+                .thenReturn(AssetNetWorthBreakdown.builder()
+                        .interestBearingAssets(0L)
+                        .flatRecognizedAssets(20_000_000L)
+                        .build());
+
+        GoalSummaryResponse result = service.getSummary(MEMBER_ID);
+
+        assertThat(result.getProgress().getRemainingMonths()).isEqualTo(5L);
+    }
+
+    @Test
+    @DisplayName("getSummary - target_date가 이미 지났으면 remainingMonths는 0으로 clamp")
+    void getSummary_targetDatePassed_remainingMonthsClampsToZero() {
+        Goal goal = goal(100_000_000L, 1_000_000L, LocalDate.now().minusMonths(3));
+        when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(goal);
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
+        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
+        when(assetService.getNetWorthBreakdown(MEMBER_ID))
+                .thenReturn(AssetNetWorthBreakdown.builder()
+                        .interestBearingAssets(0L)
+                        .flatRecognizedAssets(20_000_000L)
+                        .build());
+
+        GoalSummaryResponse result = service.getSummary(MEMBER_ID);
+
+        assertThat(result.getProgress().getRemainingMonths()).isEqualTo(0L);
+    }
+}

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplTest.java
@@ -25,7 +25,7 @@ class GoalServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        service = new GoalServiceImpl(null, null, null, null, null);
+        service = new GoalServiceImpl(null, null, null, null, null, null);
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## #️⃣연관된 이슈

- #37 

## 📝작업 내용

### 1. 홈 화면 매물 시세 변화 API 구현
- `GET /api/v1/goals/market-trend`로 따로 분리해 생성 (API 명세서에 추가)
- 회원의 활성 목표를 기준으로 홈 화면의 매물 시세 변화 카드에 필요한 데이터 제공
- 반환 정보:
    - 목표 설정 당시 실거래 중앙값
    - 현재 실거래 중앙값
    - 설정 시점 대비 시세 변동액
    - 기존 목표를 유지할 경우의 예상 달성 시점 maintainEta
    - 현재 시세를 반영할 경우의 예상 달성 시점 reflectEta
- reflectEta는 현재 자산과 변경된 실거래 시세를 기준으로 재계산

### 2. 매물 시세 변화 Redis 캐시 적용
- API 요청 시 Redis 캐시를 우선 조회하도록 구현
- 캐시 키: `goal:market-trend:{goalId}`
- 캐시 TTL: 35일
- 캐시가 존재하면 저장된 결과를 즉시 반환
- 캐시 미스가 발생한 경우에만 실거래 시세와 현재 자산을 조회해 결과를 계산한 후 Redis에 저장
- 반복적인 외부 데이터 및 자산 조회를 줄여 홈 화면 응답 성능을 개선

### 3. 매물 시세 변화 정기 배치 구현
- `GoalMarketTrendScheduler` 추가
- 매월 1일 06시에 전체 ACTIVE 목표의 매물 시세 변화 캐시 갱신
- 목표별로 다음 정보를 다시 조회해 캐시를 갱신
    - 최신 실거래 중앙값
    - 현재 자산
    - 현재 시세 반영 예상 달성 시점
- 실거래 데이터 배치와 자산 동기화 배치가 완료된 이후 실행되도록 스케줄 설정
- 특정 목표의 캐시 갱신에 실패하더라도 나머지 활성 목표의 갱신은 계속 진행되도록 처리

### 4. 홈 화면 목표 달성 요약 API 구현
-  기존 `GET /api/v1/goals/{goalId}/summary`를 `GET /api/v1/goals/summary`로 변경
- 별도의 goalId를 받지 않고 로그인 회원의 memberId를 기준으로 활성 목표 조회
- 홈 화면의 목표 달성 요약 카드에 필요한 데이터 제공

### 5. Slack 배치 실패 알림 중복 방지 개선
- 여러 배치가 공통으로 사용하는 SlackNotifier의 중복 알림 방지 키를 배치 이름별로 분리
- 기존에는 하나의 배치에서 실패 알림을 전송하면 동일한 dedup 키 때문에 다른 배치의 실패 알림까지 억제될 수 있었음
- `slack:batch-fail:{batchName}`와 같이 배치별 키를 사용하도록 수정
- 서로 다른 배치의 실패 알림이 독립적으로 전송되도록 개선

## 👀 참고 사항
### 1. 배치 실행 순서 의존성

`GoalMarketTrendScheduler`는 최신 실거래 데이터와 최신 순자산을 기준으로 매물 시세 변화를 계산합니다.

현재 배치 실행 순서는 다음과 같습니다.

- 실거래가 수집 배치 RentTransactionSyncScheduler: 매월 1일 04:00
- 자산 동기화 배치
- 매물 시세 변화 배치 GoalMarketTrendScheduler: 매월 1일 06:00

GoalMarketTrendScheduler는 실거래가 수집 및 자산 동기화가 완료된 이후 실행되어야 합니다.

### 2. 홈 화면 API별 memberId전달 방식 불일치

현재 홈 화면에서 사용하는 세 API가 서로 다른 방식으로 memberId를 전달받습니다.

API | 전달 방식
-- | --
GET /api/v1/goals/summary | @LoginMember — 인증 정보에서 조회
GET /api/v1/goals/market-trend | @RequestParam memberId — 쿼리 파라미터
GET /api/v1/assets/summary/{memberId} | @PathVariable memberId — URL 경로

이번 PR에서는 기존 API 계약을 유지하기 위해 전달 방식을 통일하지 않았습니다. 추후 인증 구조가 한가지 방식으로 정착되면 홈 화면 관련 API의 회원 식별 방식도 함께 정리할 예정입니다.