### PR TITLE
refactor: 컨트롤러 memberId 파라미터 @LoginMember로 전환

### DIFF
--- a/src/main/java/com/team/independence/asset/controller/AssetController.java
+++ b/src/main/java/com/team/independence/asset/controller/AssetController.java
@@ -17,7 +17,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
-
 import java.util.List;
 
 @RestController
@@ -35,7 +34,7 @@ public class AssetController {
 
     @PostMapping("/link")
     public ApiResponse<AssetLinkResponse> linkAccount(
-            @RequestParam Long memberId,
+            @LoginMember Long memberId,
             @RequestBody AssetLinkRequest request) {
         return ApiResponse.ok(assetService.linkAccount(memberId, request));
     }
@@ -48,13 +47,13 @@ public class AssetController {
 
     @GetMapping("/connections")
     public ApiResponse<List<LinkedOrganizationResponse>> getConnections(
-            @RequestParam Long memberId) {
+            @LoginMember Long memberId) {
         return ApiResponse.ok(assetService.getConnections(memberId));
     }
 
     @PostMapping("/sync")
     public ResponseEntity<ApiResponse<SyncJobResponse>> startSync(
-            @RequestParam Long memberId,
+            @LoginMember Long memberId,
             HttpServletRequest request) {
         SyncJobResponse response = assetSyncJobStarter.start(memberId);
         URI location = UriComponentsBuilder
@@ -72,31 +71,31 @@ public class AssetController {
         return ApiResponse.ok(assetSyncService.getSyncStatus(jobId));
     }
 
-    @GetMapping("/summary/{memberId}")
-    public ApiResponse<AssetSummaryResponse> getSummary(@PathVariable Long memberId) {
+    @GetMapping("/summary")
+    public ApiResponse<AssetSummaryResponse> getSummary(@LoginMember Long memberId) {
         return ApiResponse.ok(assetSummaryService.getSummary(memberId));
     }
 
-    @GetMapping("/accounts/{memberId}")
-    public ApiResponse<AssetAccountListResponse> getAccountList(@PathVariable Long memberId) {
+    @GetMapping("/accounts")
+    public ApiResponse<AssetAccountListResponse> getAccountList(@LoginMember Long memberId) {
         return ApiResponse.ok(assetAccountListService.getAccountList(memberId));
     }
 
-    @GetMapping("/manual/{memberId}")
-    public ApiResponse<List<ManualAssetResponse>> getManualAssets(@PathVariable Long memberId) {
+    @GetMapping("/manual")
+    public ApiResponse<List<ManualAssetResponse>> getManualAssets(@LoginMember Long memberId) {
         return ApiResponse.ok(manualAssetService.getManualAssets(memberId));
     }
 
     @PostMapping("/manual")
     public ApiResponse<ManualAssetResponse> createManualAsset(
-            @RequestParam Long memberId,
+            @LoginMember Long memberId,
             @RequestBody ManualAssetRequest request) {
         return ApiResponse.ok(manualAssetService.createManualAsset(memberId, request));
     }
 
     @PutMapping("/manual/{id}")
     public ApiResponse<ManualAssetResponse> updateManualAsset(
-            @RequestParam Long memberId,
+            @LoginMember Long memberId,
             @PathVariable Long id,
             @RequestBody ManualAssetRequest request) {
         return ApiResponse.ok(manualAssetService.updateManualAsset(memberId, id, request));
@@ -104,7 +103,7 @@ public class AssetController {
 
     @DeleteMapping("/manual/{id}")
     public ApiResponse<Void> deleteManualAsset(
-            @RequestParam Long memberId,
+            @LoginMember Long memberId,
             @PathVariable Long id) {
         manualAssetService.deleteManualAsset(memberId, id);
         return ApiResponse.ok(null);
@@ -112,7 +111,7 @@ public class AssetController {
 
     @DeleteMapping("/connections/organizations/{organizationCode}")
     public ApiResponse<UnlinkOrganizationResponse> unlinkOrganization(
-            @RequestParam Long memberId,
+            @LoginMember Long memberId,
             @PathVariable String organizationCode) {
         return ApiResponse.ok(assetService.unlinkOrganization(memberId, organizationCode));
     }

--- a/src/main/java/com/team/independence/goal/controller/GoalController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalController.java
@@ -32,14 +32,14 @@ public class GoalController {
 
     @PostMapping("/diagnosis")
     public ApiResponse<GoalDiagnosisResponse> diagnose(
-            @RequestParam Long memberId,
+            @LoginMember Long memberId,
             @Valid @RequestBody GoalDiagnosisRequest request) {
         return ApiResponse.ok(goalService.diagnose(memberId, request));
     }
 
     @PostMapping
     public ApiResponse<GoalResponse> createGoal(
-            @RequestParam Long memberId,
+            @LoginMember Long memberId,
             @Valid @RequestBody GoalCreateRequest request) {
         return ApiResponse.ok(goalService.createGoal(memberId, request));
     }
@@ -60,7 +60,7 @@ public class GoalController {
     }
 
     @GetMapping("/market-trend")
-    public ApiResponse<GoalMarketTrendResponse> getMarketTrend(@RequestParam Long memberId) {
+    public ApiResponse<GoalMarketTrendResponse> getMarketTrend(@LoginMember Long memberId) {
         return ApiResponse.ok(goalService.getMarketTrend(memberId));
     }
 


### PR DESCRIPTION
## 작업 내용
- `AssetController`, `GoalController`의 모든 엔드포인트에서 `@RequestParam/@PathVariable Long memberId`를 `@LoginMember Long memberId`로 교체
- JWT 토큰에서 memberId를 자동 추출하므로 클라이언트가 memberId를 직접 전달할 필요 없음
- PathVariable로 노출되던 URL 정리: `/summary/{memberId}` → `/summary`, `/accounts/{memberId}` → `/accounts`, `/manual/{memberId}` → `/manual`

## 변경된 엔드포인트
| Before | After |
|---|---|
| `GET /assets/summary/{memberId}` | `GET /assets/summary` |
| `GET /assets/accounts/{memberId}` | `GET /assets/accounts` |
| `GET /assets/manual/{memberId}` | `GET /assets/manual` |
| `POST /assets/link?memberId=` | `POST /assets/link` (토큰에서 추출) |
| `POST /goals/diagnosis?memberId=` | `POST /goals/diagnosis` (토큰에서 추출) |
