### PR TITLE
fix: 목표 생성 시 월 저축액 캐시 동기화

### DIFF
--- a/src/main/java/com/team/independence/asset/mapper/AssetSummaryMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/AssetSummaryMapper.java
@@ -2,9 +2,11 @@ package com.team.independence.asset.mapper;
 
 import com.team.independence.asset.domain.AssetSummary;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface AssetSummaryMapper {
     AssetSummary findByMemberId(Long memberId);
     void upsert(AssetSummary assetSummary);
+    void upsertMonthlySavings(@Param("memberId") Long memberId, @Param("monthlySavings") Long monthlySavings);
 }

--- a/src/main/java/com/team/independence/asset/service/AssetSummaryService.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSummaryService.java
@@ -4,4 +4,5 @@ import com.team.independence.asset.dto.AssetSummaryResponse;
 
 public interface AssetSummaryService {
     AssetSummaryResponse getSummary(Long memberId);
+    void updateMonthlySavings(Long memberId, Long monthlySavings);
 }

--- a/src/main/java/com/team/independence/asset/service/AssetSummaryServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSummaryServiceImpl.java
@@ -12,6 +12,7 @@ import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -92,6 +93,12 @@ public class AssetSummaryServiceImpl implements AssetSummaryService {
                         .build())
                 .loans(loanItems)
                 .build();
+    }
+
+    @Override
+    @Transactional
+    public void updateMonthlySavings(Long memberId, Long monthlySavings) {
+        assetSummaryMapper.upsertMonthlySavings(memberId, monthlySavings);
     }
 
     /**

--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -2,6 +2,7 @@ package com.team.independence.goal.service;
 
 import com.team.independence.asset.dto.AssetNetWorthBreakdown;
 import com.team.independence.asset.service.AssetService;
+import com.team.independence.asset.service.AssetSummaryService;
 import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.goal.domain.Goal;
@@ -62,6 +63,7 @@ public class GoalServiceImpl implements GoalService {
 
     private final RegionQueryService regionQueryService;
     private final AssetService assetService; // 자산 정보 조회
+    private final AssetSummaryService assetSummaryService; // asset_summary.monthly_savings 캐시 갱신
     private final RentMedianService rentMedianService; // 조건에 맞는 실거래 4분위값 조회
     private final GoalMapper goalMapper;
     private final GoalHousingMapper goalHousingMapper;
@@ -213,6 +215,9 @@ public class GoalServiceImpl implements GoalService {
                 .status(GOAL_STATUS_ACTIVE)
                 .build();
         goalMapper.insert(goal);
+
+        // assets/summary가 보여주는 monthlySavings는 asset_summary 캐시에서 읽으므로 goal 저장 시점에 함께 갱신한다
+        assetSummaryService.updateMonthlySavings(memberId, request.getMonthlySavings());
 
         GoalHousing goalHousing = GoalHousing.builder()
                 .goalId(goal.getId())

--- a/src/main/resources/mybatis/mapper/asset/AssetSummaryMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/AssetSummaryMapper.xml
@@ -31,4 +31,11 @@
             synced_at    = VALUES(synced_at)
     </insert>
 
+    <insert id="upsertMonthlySavings">
+        INSERT INTO asset_summary (member_id, monthly_savings)
+        VALUES (#{memberId}, #{monthlySavings})
+        ON DUPLICATE KEY UPDATE
+            monthly_savings = VALUES(monthly_savings)
+    </insert>
+
 </mapper>

--- a/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
@@ -69,7 +69,7 @@ class GoalDetailServiceImplTest {
         // 그 외 의존성은 이 경로에서 쓰이지 않아 null로 둔다.
         service = new GoalDetailServiceImpl(
                 goalHousingMapper, savingRecordMapper, assetService,
-                new GoalServiceImpl(null, null, null, goalMapper, null, null));
+                new GoalServiceImpl(null, null, null, null, goalMapper, null, null));
     }
 
     // ------------------------------------------------------------------

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplMarketTrendTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplMarketTrendTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import com.team.independence.asset.dto.AssetNetWorthBreakdown;
 import com.team.independence.asset.service.AssetService;
+import com.team.independence.asset.service.AssetSummaryService;
 import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.goal.domain.Goal;
@@ -40,6 +41,7 @@ class GoalServiceImplMarketTrendTest {
 
     @Mock RegionQueryService regionQueryService;
     @Mock AssetService assetService;
+    @Mock AssetSummaryService assetSummaryService;
     @Mock RentMedianService rentMedianService;
     @Mock GoalMapper goalMapper;
     @Mock GoalHousingMapper goalHousingMapper;
@@ -53,7 +55,7 @@ class GoalServiceImplMarketTrendTest {
     @BeforeEach
     void setUp() {
         service = new GoalServiceImpl(
-                regionQueryService, assetService, rentMedianService,
+                regionQueryService, assetService, assetSummaryService, rentMedianService,
                 goalMapper, goalHousingMapper, goalMarketTrendCacheStore);
     }
 

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplSummaryTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplSummaryTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import com.team.independence.asset.dto.AssetNetWorthBreakdown;
 import com.team.independence.asset.service.AssetService;
+import com.team.independence.asset.service.AssetSummaryService;
 import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.goal.domain.Goal;
@@ -31,6 +32,7 @@ class GoalServiceImplSummaryTest {
 
     @Mock RegionQueryService regionQueryService;
     @Mock AssetService assetService;
+    @Mock AssetSummaryService assetSummaryService;
     @Mock RentMedianService rentMedianService;
     @Mock GoalMapper goalMapper;
     @Mock GoalHousingMapper goalHousingMapper;
@@ -44,7 +46,7 @@ class GoalServiceImplSummaryTest {
     @BeforeEach
     void setUp() {
         service = new GoalServiceImpl(
-                regionQueryService, assetService, rentMedianService,
+                regionQueryService, assetService, assetSummaryService, rentMedianService,
                 goalMapper, goalHousingMapper, goalMarketTrendCacheStore);
     }
 

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplTest.java
@@ -25,7 +25,7 @@ class GoalServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        service = new GoalServiceImpl(null, null, null, null, null, null);
+        service = new GoalServiceImpl(null, null, null, null, null, null, null);
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## 📝작업 내용
- `GET /api/v1/assets/summary`가 asset_summary.monthly_savings 값을 그대로 반환하지만, 해당 컬럼을 갱신하는 로직이 없어 목표에 설정한 월 저축액과 관계없이 항상 0으로 조회되던 문제를 수정
- AssetSummaryMapper에 `upsertMonthlySavings` 쿼리를 추가하고, AssetSummaryService.updateMonthlySavings(memberId, monthlySavings)를 통해 월 저축액 캐시를 갱신할 수 있도록 구현
- GoalServiceImpl.createGoal에서 목표 저장이 완료된 직후 `updateMonthlySavings`를 호출해, 새로 생성한 목표의 월 저축액이 asset_summary에도 함께 반영되도록 연결했습니다.

<img width="478" height="335" alt="스크린샷 2026-08-05 오후 5 19 27" src="https://github.com/user-attachments/assets/b04b92ad-437e-454b-873f-58ba3ea0c184" />

## 참고사항
추후 월 저축액 변경이나 목표 삭제 기능이 추가되면 해당 시점에도 updateMonthlySavings 호출이 필요합니다.

- 월 저축액 변경 시: 변경된 금액으로 갱신
- 목표 삭제 또는 ARCHIVED 전환 시: 0으로 갱신