### PR TITLE
fix: 자산 연동/해제 버그 수정 및 회원가입 생년월일 세기 오류 수정

### DIFF
--- a/src/main/java/com/team/independence/asset/service/AssetServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetServiceImpl.java
@@ -1,5 +1,6 @@
 package com.team.independence.asset.service;
 
+import com.team.independence.asset.domain.AssetSummary;
 import com.team.independence.asset.domain.ConnectedAccount;
 import com.team.independence.asset.domain.ConnectedInstitution;
 import com.team.independence.asset.dto.AssetAccountQueryItem;
@@ -10,6 +11,7 @@ import com.team.independence.asset.dto.LinkedOrganizationResponse;
 import com.team.independence.asset.dto.UnlinkOrganizationResponse;
 import com.team.independence.asset.domain.Institution;
 import com.team.independence.asset.mapper.AssetAccountMapper;
+import com.team.independence.asset.mapper.AssetSummaryMapper;
 import com.team.independence.asset.mapper.ConnectedAccountMapper;
 import com.team.independence.asset.mapper.ConnectedInstitutionMapper;
 import com.team.independence.asset.mapper.InstitutionMapper;
@@ -30,6 +32,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -48,6 +51,7 @@ public class AssetServiceImpl implements AssetService {
     private final ConnectedInstitutionMapper connectedInstitutionMapper;
     private final InstitutionMapper institutionMapper;
     private final AssetAccountMapper assetAccountMapper;
+    private final AssetSummaryMapper assetSummaryMapper;
     private final LoanAccountMapper loanAccountMapper;
     private final ManualAssetMapper manualAssetMapper;
     private final CodefClient codefClient;
@@ -60,6 +64,7 @@ public class AssetServiceImpl implements AssetService {
     @Override
     @Transactional
     public AssetLinkResponse linkAccount(Long memberId, AssetLinkRequest request) {
+        log.debug("linkAccount request: memberId={}, request={}", memberId, request);
         String lockKey = LOCK_KEY_PREFIX + memberId;
         boolean locked = Boolean.TRUE.equals(
                 redisTemplate.opsForValue().setIfAbsent(lockKey, "1", LOCK_TTL_SECONDS, TimeUnit.SECONDS)
@@ -73,10 +78,13 @@ public class AssetServiceImpl implements AssetService {
             String encryptedPassword = rsaEncryptor.encrypt(codefProperties.getPublicKey(), request.getPassword());
             String birthDate = request.getBirthDate();
 
+            String clientType = request.getClientType() != null ? request.getClientType()
+                    : "ST".equals(request.getBusinessType()) ? "A" : "P";
+
             CodefAccountRequest.CodefAccountItem item = CodefAccountRequest.CodefAccountItem.builder()
                     .countryCode(request.getCountryCode() != null ? request.getCountryCode() : "KR")
                     .businessType(request.getBusinessType())
-                    .clientType(request.getClientType() != null ? request.getClientType() : "P")
+                    .clientType(clientType)
                     .organization(request.getOrganization())
                     .loginType(request.getLoginType())
                     .id(request.getId())
@@ -184,11 +192,22 @@ public class AssetServiceImpl implements AssetService {
         // CODEF 삭제 성공 후에만 DB 삭제
         codefClient.deleteAccount(accessToken, connectedId, item);
 
+        assetAccountMapper.deleteByConnectedInstitutionId(institution.getId());
+        loanAccountMapper.deleteByConnectedInstitutionId(institution.getId());
         connectedInstitutionMapper.deleteByConnectedAccountIdAndInstitutionCode(account.getId(), organizationCode);
 
         if (connectedInstitutionMapper.countByConnectedAccountId(account.getId()) == 0) {
             connectedAccountMapper.deleteById(account.getId());
         }
+
+        Long totalAssets = assetAccountMapper.sumCurrentValueByMemberId(memberId);
+        Long loanBalance = loanAccountMapper.sumLoanBalanceByMemberId(memberId);
+        assetSummaryMapper.upsert(AssetSummary.builder()
+                .memberId(memberId)
+                .totalAssets(totalAssets != null ? totalAssets : 0L)
+                .loanBalance(loanBalance != null ? loanBalance : 0L)
+                .syncedAt(LocalDateTime.now())
+                .build());
 
         return UnlinkOrganizationResponse.builder()
                 .organizationCode(organizationCode)

--- a/src/main/java/com/team/independence/auth/service/KakaoOAuthServiceImpl.java
+++ b/src/main/java/com/team/independence/auth/service/KakaoOAuthServiceImpl.java
@@ -65,6 +65,10 @@ public class KakaoOAuthServiceImpl implements KakaoOAuthService {
         LocalDate birthDate;
         try {
             birthDate = LocalDate.parse(request.birthDate(), DateTimeFormatter.ofPattern("yyMMdd"));
+            // yyMMdd는 99년생 이상의 경우 20xx로 해석하고 미래 날짜면 100년 차감
+            if (birthDate.isAfter(LocalDate.now())) {
+                birthDate = birthDate.minusYears(100);
+            }
         } catch (DateTimeParseException e) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }

--- a/src/main/java/com/team/independence/external/codef/CodefRealClient.java
+++ b/src/main/java/com/team/independence/external/codef/CodefRealClient.java
@@ -51,7 +51,33 @@ public class CodefRealClient implements CodefClient {
 
     @Override
     public CodefApiResponse deleteAccount(String accessToken, String connectedId, CodefAccountRequest.CodefAccountItem item) {
-        return call(accessToken, DELETE_PATH, CodefAccountRequest.builder().connectedId(connectedId).accountList(List.of(item)).build());
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(accessToken);
+            CodefAccountRequest body = CodefAccountRequest.builder()
+                    .connectedId(connectedId).accountList(List.of(item)).build();
+            ResponseEntity<String> response = restTemplate.exchange(
+                    properties.getApiDomain() + DELETE_PATH,
+                    HttpMethod.POST, new HttpEntity<>(body, headers), String.class);
+            String decoded = URLDecoder.decode(response.getBody(), StandardCharsets.UTF_8);
+            CodefApiResponse result = objectMapper.readValue(decoded, CodefApiResponse.class);
+            String code = result.getResult().getCode();
+            if ("CF-04011".equals(code)) {
+                log.warn("CODEF deleteAccount: 기관 등록 정보 없음(CF-04011), DB 정리 진행 org={}", item.getOrganization());
+                return result;
+            }
+            if (!result.isSuccess()) {
+                log.error("CODEF API 오류: code={}", code);
+                throw new BusinessException(ErrorCode.ASSET_CODEF_API_ERROR, result.getResult().getMessage());
+            }
+            return result;
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("CODEF deleteAccount 실패: org={}", item.getOrganization(), e);
+            throw new BusinessException(ErrorCode.ASSET_CODEF_API_ERROR);
+        }
     }
 
     @Override


### PR DESCRIPTION
## #️⃣연관된 이슈

> #51 

## 📝작업 내용

프론트엔드 연동 테스트 중 발견된 자산 연동/해제 관련 버그 4건을 수정했습니다.

### 1. 기관 연동 해제 시 FK 제약 위반 (`AssetServiceImpl`)
  
  `connected_institution` 삭제 전 자식 테이블을 먼저 삭제하지 않아 FK 제약 위반이 발생하던 문제를 수정했습니다.
  
  **올바른 삭제 순서**
  `asset_account` → `loan_account` → `connected_institution` → (기관 0개 시) `connected_account`

  ### 2. CODEF CF-04011 정상 처리 (`CodefRealClient`)
  
  기관 연동 해제 시 CODEF에 해당 기관 등록 정보가 없을 경우(`CF-04011`) 예외를 던져 DB 정리가 중단되던 문제를 수정했습니다. `CF-04011`은 이미 삭제된 것으로 간주하고 DB 정리를 계속 진행하도록 변경했습니다.
  
  ### 3. 연동 해제 후 `asset_summary` 미갱신 (`AssetServiceImpl`)

  기관 연동 해제 후 `asset_summary`가 이전 동기화 값으로 남아 있는 문제를 수정했습니다. `unlinkOrganization()` 완료 후 총 자산 및 대출 잔액을 재계산하여 upsert하도록 처리했습니다.
  
  ### 4. `clientType` 미전송 시 잘못된 기본값 (`AssetServiceImpl`)
  
  프론트에서 `clientType`을 전송하지 않을 경우 모든 기관에 `"P"`로 고정되던 문제를 수정했습니다. `businessType` 기반으로 은행(`BK`)은 `"P"`, 증권(`ST`)은 `"A"`로 자동 설정했습니다.
  
  ### 5. 회원가입 생년월일 세기 오류 (`KakaoOAuthServiceImpl`)

  `yyMMdd` 패턴으로 생년월일을 파싱할 때 `98`을 `2098`로 해석하는 문제를 수정했습니다. 파싱 결과가 미래 날짜이면 100년을 차감하여 1900년대로 보정합니다.


### 스크린샷
<img width="386" height="498" alt="스크린샷 2026-08-05 오후 5 28 56" src="https://github.com/user-attachments/assets/768ae064-ea35-46b8-b437-e1dd7e882b51" />

<img width="425" height="702" alt="스크린샷 2026-08-05 오후 5 29 07" src="https://github.com/user-attachments/assets/fdecb6f3-6bfe-4649-9935-3dadb495264a" />


## 💬리뷰 요구사항

> `clientType` 기본값 처리를 백엔드 서비스 레이어에서 하는 것이 맞는지, 아니면 프론트에서 항상 명시적으로 전송하는 방향으로 협의해야 하는지 의견 부탁드립니다.