### PR TITLE
feat(compare): 스냅샷이 없어도 현재 값으로 또래 비교를 제공

### DIFF
--- a/src/main/java/com/team/independence/common/exception/ErrorCode.java
+++ b/src/main/java/com/team/independence/common/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     COMPARE_SNAPSHOT_NOT_FOUND("COMPARE_001", "비교할 집계 데이터가 없습니다.", HttpStatus.NOT_FOUND),
     COMPARE_INVALID_RANGE("COMPARE_002", "비교 기준 범위가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
     COMPARE_CONSENT_REQUIRED("COMPARE_003", "또래 비교 약관 동의가 필요합니다.", HttpStatus.FORBIDDEN),
+    COMPARE_ASSET_REQUIRED("COMPARE_004", "자산 연동이 필요합니다.", HttpStatus.NOT_FOUND),
 
     // ===== 정책 POLICY_xxx =====
     POLICY_NOT_FOUND("POLICY_001", "정책을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/team/independence/compare/mapper/GoalSnapshotMapper.java
+++ b/src/main/java/com/team/independence/compare/mapper/GoalSnapshotMapper.java
@@ -28,6 +28,25 @@ public interface GoalSnapshotMapper {
     GoalSnapshot findByMemberAndYm(@Param("memberId") Long memberId,
                                    @Param("snapshotYm") String snapshotYm);
 
+    /**
+     * 기준 회원의 지금 값. 스냅샷이 아직 없을 때만 쓴다.
+     *
+     * <p>스냅샷은 매월 1일 배치가 만든다. 그래서 이번 달에 목표를 세운 사람은 다음 달까지
+     * 자기 기준값이 없어 비교를 아예 볼 수 없었다. 그 한 달을 메우려고, 배치가 넣는 것과
+     * 같은 값을 goal · goal_housing · member · asset_summary에서 그 자리에서 계산해 온다.
+     *
+     * <p>DB에 쓰지 않는다. 조회 API가 데이터를 만들지 않게 하려는 것이다. 대신 이번 달에는
+     * 내가 남의 코호트에 잡히지 않는다. 다음 배치가 돌면 자연히 들어간다.
+     *
+     * <p>자산 연동을 안 했으면 asset_summary 행이 없어 null이 나온다. 순자산이 코호트 범위의
+     * 기준이라 0으로 대신 채우면 엉뚱한 또래와 묶인다. 그래서 채우지 않고 null로 두고,
+     * 서비스가 '자산 연동이 필요하다'고 안내한다.
+     *
+     * @param baseDate 나이 계산 기준일(오늘)
+     */
+    GoalSnapshot findLiveByMember(@Param("memberId") Long memberId,
+                                  @Param("baseDate") LocalDate baseDate);
+
     /** 코호트 인원 수. k-익명성 판단에 쓴다 */
     int countCohort(CohortCondition condition);
 
@@ -53,6 +72,15 @@ public interface GoalSnapshotMapper {
 
     /** 월 저축액의 가운데 50%(25~75 백분위) 구간 */
     SavingRangeResult findSavingRange(CohortCondition condition);
+
+    /**
+     * 회원에게 진행 중인 목표가 있는지.
+     *
+     * <p>스냅샷이 없을 때 "목표를 안 세운 것"과 "목표는 있으나 아직 집계 전"을 가르는 데 쓴다.
+     * goal 테이블을 읽지만 EXISTS 한 번이고, 아래 배치(insertSnapshots)도 이미 goal을 읽고 있어
+     * 의존 범위가 늘지 않는다.
+     */
+    boolean existsActiveGoal(@Param("memberId") Long memberId);
 
     /**
      * 해당 월의 스냅샷을 만든다(배치 전용).

--- a/src/main/java/com/team/independence/compare/service/CompareServiceImpl.java
+++ b/src/main/java/com/team/independence/compare/service/CompareServiceImpl.java
@@ -1,5 +1,7 @@
 package com.team.independence.compare.service;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -34,7 +36,8 @@ import lombok.RequiredArgsConstructor;
 /**
  * 또래 비교 집계.
  *
- * <p>응답의 모든 값이 goal_snapshot 집계 결과다.
+ * <p>비교 대상(또래)의 값은 모두 goal_snapshot 집계 결과다.
+ * 기준이 되는 내 값만, 스냅샷이 아직 없으면 지금 값을 읽어서 쓴다. ({@link #findBaseline})
  */
 @Service
 @RequiredArgsConstructor
@@ -61,6 +64,9 @@ public class CompareServiceImpl implements CompareService {
     /** 달성률 구간 개수. 0~10 … 70~80 여덟 칸에 마지막 80~100 한 칸 */
     private static final int BUCKET_SIZE = 9;
 
+    /** 집계 기준월 형식 YYYYMM. 배치(GoalSnapshotBatchServiceImpl)와 같은 형식이어야 한다 */
+    private static final DateTimeFormatter YM = DateTimeFormatter.ofPattern("yyyyMM");
+
     /** 화면 표시명. DB에는 코드만 저장하므로 여기서 붙인다 */
     private static final Map<String, String> DEAL_TYPE_LABELS = new LinkedHashMap<>();
 
@@ -83,13 +89,23 @@ public class CompareServiceImpl implements CompareService {
         validateRange(assetRange, ageRange);
         validateConsent(memberId);
 
+        // 비교 대상은 배치가 만든 스냅샷이다. 배치가 한 번도 안 돌았으면 이번 달을 기준월로 삼는다.
+        // 그러면 대상이 0명이라 아래에서 인원 미달로 내려간다. 예전처럼 '목표 미설정'이 뜨지 않는다.
         String snapshotYm = goalSnapshotMapper.findLatestSnapshotYm();
-        GoalSnapshot me = (snapshotYm == null)
-                ? null
-                : goalSnapshotMapper.findByMemberAndYm(memberId, snapshotYm);
+        if (snapshotYm == null) {
+            snapshotYm = LocalDate.now().format(YM);
+        }
+
+        GoalSnapshot me = findBaseline(memberId, snapshotYm);
 
         if (me == null) {
-            throw new BusinessException(ErrorCode.COMPARE_SNAPSHOT_NOT_FOUND);
+            // 기준값을 못 만드는 이유가 두 가지라 안내 문구가 달라야 한다.
+            //   목표가 없다              → 목표를 세우라고 안내
+            //   목표는 있으나 자산이 없다 → 자산을 연동하라고 안내
+            // 순자산이 코호트 범위의 기준이라, 자산이 없으면 누구와 비교할지를 정할 수 없다.
+            throw new BusinessException(goalSnapshotMapper.existsActiveGoal(memberId)
+                    ? ErrorCode.COMPARE_ASSET_REQUIRED
+                    : ErrorCode.COMPARE_SNAPSHOT_NOT_FOUND);
         }
 
         CohortCondition condition = CohortCondition.of(
@@ -126,6 +142,27 @@ public class CompareServiceImpl implements CompareService {
                         .cohortRangeMax(savingRange.getCohortRangeMax())
                         .build())
                 .build();
+    }
+
+    /**
+     * 비교 기준이 되는 내 값.
+     *
+     * <p>스냅샷이 있으면 그대로 쓴다. 없으면 goal · member · asset_summary에서 지금 값을 읽어
+     * 같은 모양으로 만들어 쓴다.
+     *
+     * <p>두 번째 경로가 필요한 이유는 스냅샷이 매월 1일에만 생기기 때문이다. 그 전에는
+     * 이번 달에 목표를 세운 사람의 행이 없고, 순자산·나이가 없으면 코호트 범위를 못 정해서
+     * 비교를 통째로 못 보여줬다. 서비스 초기에는 대부분의 회원이 이 상태다.
+     *
+     * <p>여기서 만든 값은 저장하지 않는다. 조회 API가 데이터를 만들면 안 되기 때문이다.
+     * 그 대가로 이번 달에는 내가 남의 코호트 인원에 잡히지 않는다. 다음 배치가 넣어준다.
+     *
+     * <p>비교 대상은 여전히 기준월 스냅샷이라, 내 값만 오늘 기준이고 남들은 그 달 1일 기준이다.
+     * 한 달 안의 차이라 통계 해석을 뒤집을 정도는 아니라고 보고 이대로 둔다.
+     */
+    private GoalSnapshot findBaseline(Long memberId, String snapshotYm) {
+        GoalSnapshot snapshot = goalSnapshotMapper.findByMemberAndYm(memberId, snapshotYm);
+        return snapshot != null ? snapshot : goalSnapshotMapper.findLiveByMember(memberId, LocalDate.now());
     }
 
     /**

--- a/src/main/resources/mybatis/mapper/compare/GoalSnapshotMapper.xml
+++ b/src/main/resources/mybatis/mapper/compare/GoalSnapshotMapper.xml
@@ -51,6 +51,53 @@
           AND snapshot_ym = #{snapshotYm}
     </select>
 
+    <!--
+      스냅샷이 아직 없는 회원의 기준값을 지금 계산한다.
+
+      아래 배치(insertSnapshots)가 넣는 값과 계산식을 똑같이 맞췄다. 한쪽만 고치면
+      같은 사람이 이번 달과 다음 달에 다른 달성률로 보인다. 고칠 때 둘 다 고칠 것.
+
+      배치와 다른 점은 순자산을 어디서 읽느냐 하나다.
+        배치       asset_snapshot  그 달 1일에 굳힌 값
+        여기       asset_summary   지금 값(동기화 시각 기준)
+      asset_snapshot에는 아직 아무도 INSERT 하지 않아서 이번 달 행을 기대할 수 없다.
+
+      JOIN이라 asset_summary 행이 없으면 결과가 없다. 자산 연동을 안 한 경우이고,
+      서비스가 그 null을 받아 '자산 연동이 필요하다'로 안내한다.
+
+      snapshot_ym은 넣지 않는다. 비교 기준월은 서비스가 따로 들고 있고,
+      여기 값은 어느 달에도 저장되지 않은 임시 값이라 달을 붙이면 오해를 부른다.
+    -->
+    <select id="findLiveByMember" resultMap="goalSnapshotMap">
+        SELECT
+        g.member_id     AS member_id,
+        g.id            AS goal_id,
+        gh.region_code  AS region_code,
+        TIMESTAMPDIFF(YEAR, m.birth_date, #{baseDate}) AS age,
+        (a.total_assets - a.loan_balance)              AS net_assets,
+        g.goal_type     AS goal_type,
+        gh.housing_type AS housing_type,
+        gh.deal_type    AS deal_type,
+        g.target_amount AS target_amount,
+        <!-- 달성률 = 순자산 / 목표금액. 0~100으로 자른다 (배치와 같은 식) -->
+        LEAST(100, GREATEST(0,
+        ROUND((a.total_assets - a.loan_balance) * 100 / g.target_amount, 2))) AS achievement_rate,
+        <!-- 준비 기간 = 목표를 세운 날부터 희망 시점까지 (배치와 같은 식) -->
+        GREATEST(0, TIMESTAMPDIFF(MONTH, DATE(g.created_at), g.target_date)) AS prep_months,
+        g.monthly_saving AS monthly_saving
+        FROM goal g
+        JOIN goal_housing  gh ON gh.goal_id  = g.id
+        JOIN member        m  ON m.id        = g.member_id
+        JOIN asset_summary a  ON a.member_id = g.member_id
+        WHERE g.member_id = #{memberId}
+        AND g.status = 'ACTIVE'
+        <!-- 0으로 나누기 방지 -->
+        AND g.target_amount > 0
+        <!-- 목표가 여러 개면 배치와 같이 가장 최근 것 하나만 -->
+        ORDER BY g.id DESC
+        LIMIT 1
+    </select>
+
     <select id="countCohort" resultType="int">
         SELECT COUNT(*)
         FROM goal_snapshot
@@ -119,6 +166,18 @@
         <include refid="cohortWhere"/>
         ) t
         WHERE quartile IN (2, 3)
+    </select>
+
+    <!--
+      스냅샷이 없을 때 안내 문구를 가르기 위한 조회.
+      goal 테이블을 읽지만 EXISTS 한 번이라 idx_goal_member_status 를 그대로 탄다.
+    -->
+    <select id="existsActiveGoal" resultType="boolean">
+        SELECT EXISTS(
+            SELECT 1 FROM goal
+            WHERE member_id = #{memberId}
+              AND status = 'ACTIVE'
+        )
     </select>
 
     <!--

--- a/src/test/java/com/team/independence/compare/service/CompareServiceImplTest.java
+++ b/src/test/java/com/team/independence/compare/service/CompareServiceImplTest.java
@@ -214,21 +214,97 @@ class CompareServiceImplTest {
     }
 
     @Test
-    @DisplayName("내 스냅샷이 없으면 집계 데이터 없음으로 처리한다")
-    void 스냅샷이_없으면_예외() {
+    @DisplayName("목표도 없고 스냅샷도 없으면 목표 미설정으로 처리한다")
+    void 목표가_없으면_미설정_예외() {
         mapper.me = null;
+        mapper.live = null;
+        mapper.hasActiveGoal = false;
 
         assertEquals(ErrorCode.COMPARE_SNAPSHOT_NOT_FOUND,
                 assertThrows(BusinessException.class, this::call).getErrorCode());
     }
 
     @Test
-    @DisplayName("집계된 달이 하나도 없어도 같은 예외로 처리한다")
+    @DisplayName("집계된 달이 하나도 없어도 목표가 없으면 같은 예외다")
     void 스냅샷_월이_없으면_예외() {
         mapper.latestYm = null;
+        mapper.me = null;
+        mapper.live = null;
+        mapper.hasActiveGoal = false;
 
         assertEquals(ErrorCode.COMPARE_SNAPSHOT_NOT_FOUND,
                 assertThrows(BusinessException.class, this::call).getErrorCode());
+    }
+
+    @Test
+    @DisplayName("목표는 있는데 자산이 없으면 자산 연동 안내로 처리한다")
+    void 자산이_없으면_연동_예외() {
+        // 순자산이 코호트 범위의 기준이라, 0으로 채우면 엉뚱한 또래와 묶인다.
+        mapper.me = null;
+        mapper.live = null;
+        mapper.hasActiveGoal = true;
+
+        assertEquals(ErrorCode.COMPARE_ASSET_REQUIRED,
+                assertThrows(BusinessException.class, this::call).getErrorCode());
+    }
+
+    @Test
+    @DisplayName("기준값을 못 만들면 집계 쿼리는 돌리지 않는다")
+    void 기준값이_없으면_쿼리를_돌리지_않는다() {
+        mapper.me = null;
+        mapper.live = null;
+        mapper.hasActiveGoal = true;
+
+        assertThrows(BusinessException.class, this::call);
+
+        assertEquals(0, mapper.aggregateCalls);
+    }
+
+    // ------------------------------------------------------------------
+    // 스냅샷이 아직 없을 때 (목표를 세운 그 달)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("스냅샷이 없으면 지금 값으로 비교한다")
+    void 스냅샷이_없으면_실시간_값을_쓴다() {
+        // 매월 1일 배치 전에는 내 행이 없다. 그렇다고 한 달을 기다리게 하지 않는다.
+        mapper.me = null;
+        mapper.live = liveSnapshot(31, 40_000_000L, 75.0, 1_200_000L);
+        mapper.hasActiveGoal = true;
+        mapper.cohortCount = 10;
+
+        CompareResponse response = call();
+
+        assertEquals(75.0, response.getAchievementDistribution().getMyRate(), 0.0001);
+        assertEquals(1_200_000L, response.getSavingRange().getMyMonthlySaving().longValue());
+    }
+
+    @Test
+    @DisplayName("스냅샷이 있으면 지금 값을 읽지 않는다")
+    void 스냅샷이_있으면_실시간_조회를_하지_않는다() {
+        // 이미 굳은 값이 있으면 그게 정답이다. 쓸데없이 한 번 더 읽지 않는다.
+        mapper.cohortCount = 10;
+
+        call();
+
+        assertEquals(0, mapper.liveCalls);
+    }
+
+    @Test
+    @DisplayName("실시간 값도 코호트 범위의 기준이 된다")
+    void 실시간_값으로_코호트_범위를_잡는다() {
+        mapper.me = null;
+        mapper.live = liveSnapshot(31, 40_000_000L, 75.0, 1_200_000L);
+        mapper.hasActiveGoal = true;
+        mapper.cohortCount = 10;
+
+        call();
+
+        // ±1,000만 / ±2세가 실시간 값 기준으로 벌어져야 한다.
+        assertEquals(30_000_000L, mapper.lastCondition.getNetAssetsMin());
+        assertEquals(50_000_000L, mapper.lastCondition.getNetAssetsMax());
+        assertEquals(29, mapper.lastCondition.getAgeMin());
+        assertEquals(33, mapper.lastCondition.getAgeMax());
     }
 
     // ------------------------------------------------------------------
@@ -304,6 +380,17 @@ class CompareServiceImplTest {
         return row;
     }
 
+    /** 스냅샷이 없을 때 goal·asset_summary에서 즉석으로 만들어지는 기준값 */
+    private static GoalSnapshot liveSnapshot(int age, long netAssets, double rate, long monthlySaving) {
+        GoalSnapshot snapshot = new GoalSnapshot();
+        snapshot.setMemberId(MEMBER_ID);
+        snapshot.setAge(age);
+        snapshot.setNetAssets(netAssets);
+        snapshot.setAchievementRate(rate);
+        snapshot.setMonthlySaving(monthlySaving);
+        return snapshot;
+    }
+
     /** 동의 여부를 테스트가 정해주는 가짜 AgreementService */
     private static class FakeAgreementService implements AgreementService {
 
@@ -357,6 +444,16 @@ class CompareServiceImplTest {
         private List<AchievementBucketCount> buckets = new ArrayList<>();
         private int aggregateCalls = 0;
 
+        /** 회원에게 진행 중인 목표가 있는지. 기준값을 못 만들 때 어떤 예외가 나갈지를 가른다 */
+        private boolean hasActiveGoal = false;
+
+        /** 스냅샷이 없을 때 대신 읽어오는 지금 값. null이면 자산 연동이 안 된 상태 */
+        private GoalSnapshot live = null;
+        private int liveCalls = 0;
+
+        /** 집계 쿼리에 실제로 넘어간 코호트 조건. 범위를 제대로 잡았는지 확인용 */
+        private CohortCondition lastCondition;
+
         private static GoalSnapshot defaultSnapshot() {
             GoalSnapshot snapshot = new GoalSnapshot();
             snapshot.setMemberId(MEMBER_ID);
@@ -379,7 +476,14 @@ class CompareServiceImplTest {
         }
 
         @Override
+        public GoalSnapshot findLiveByMember(Long memberId, LocalDate baseDate) {
+            liveCalls++;
+            return live;
+        }
+
+        @Override
         public int countCohort(CohortCondition condition) {
+            lastCondition = condition;
             return cohortCount;
         }
 
@@ -409,6 +513,11 @@ class CompareServiceImplTest {
         public List<AchievementBucketCount> countByAchievementBucket(CohortCondition condition) {
             aggregateCalls++;
             return buckets;
+        }
+
+        @Override
+        public boolean existsActiveGoal(Long memberId) {
+            return hasActiveGoal;
         }
 
         /**


### PR DESCRIPTION
## 📝작업 내용
 
또래 비교는 `goal_snapshot`을 읽는데 이 테이블은 매월 1일 배치가 채웁니다.
그래서 **이번 달에 목표를 세운 사람은 다음 달까지 비교를 볼 수 없었습니다.**
코호트를 내 순자산·나이 기준으로 잡기 때문에, 내 행이 없으면 범위 자체를
만들 수 없어 통계 조회 전에 실패합니다.
 
스냅샷이 없으면 `goal` · `goal_housing` · `member` · `asset_summary`에서
기준값을 그 자리에서 계산해 씁니다. 계산식은 배치와 동일하고,
순자산 출처만 `asset_snapshot` → `asset_summary`로 다릅니다.

대신 이번 달에는 내가 남의 코호트 인원에 안 잡히는데, 다음 배치가 넣어줍니다.
 
### COMPARE_004 의미 변경
 
집계 대기 상태가 없어져서 자산 연동 안내로 바꿨습니다.
 
```
COMPARE_001  목표 없음             → 목표 설정 유도
COMPARE_004  목표는 있으나 자산 없음  → 자산 연동 유도   (변경)
```
 
### 변경 파일 (5개)
 
```
CompareServiceImpl.java       findBaseline() 추가
GoalSnapshotMapper.java/.xml  findLiveByMember() 추가
ErrorCode.java                COMPARE_004 의미 변경
CompareServiceImplTest.java   18 → 21개
```