### PR TITLE
feat: 카드사별 보유 카드 정보 조회 기능 추가

### DIFF
--- a/sql/full_schema.sql
+++ b/sql/full_schema.sql
@@ -279,7 +279,7 @@ CREATE TABLE connected_institution (
     status               VARCHAR(20)  NOT NULL DEFAULT 'ACTIVE' COMMENT 'ACTIVE/AUTH_EXPIRED/ERROR',
     last_synced_at       DATETIME     NULL     COMMENT '이 기관 마지막 동기화 시각',
     last_error_code      VARCHAR(30)  NULL     COMMENT 'CODEF 실패 코드(비밀번호 오류, 계정 잠김 등)',
-    last_error_message   VARCHAR(255) NULL     COMMENT '사용자 안내 문구',
+    last_error_message   TEXT         NULL     COMMENT '사용자 안내 문구',
     last_attempted_at    DATETIME     NULL     COMMENT '마지막 연동 시도 시각(성공·실패 무관)',
     created_at           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at           DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -332,6 +332,26 @@ CREATE TABLE loan_account (
     KEY idx_loan_account_inst (connected_institution_id),
     CONSTRAINT fk_loan_account_inst FOREIGN KEY (connected_institution_id) REFERENCES connected_institution (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='대출 계좌(부채)';
+
+CREATE TABLE card_account (
+    id                       BIGINT       NOT NULL AUTO_INCREMENT,
+    connected_institution_id BIGINT       NOT NULL COMMENT '연결된 기관 FK',
+    card_no                  VARCHAR(30)  NOT NULL COMMENT '마스킹된 카드번호(resCardNo)',
+    is_sleep                 VARCHAR(10)  NOT NULL DEFAULT 'N' COMMENT '휴면 여부(resSleepYN: Y/N)',
+    card_name                VARCHAR(100) NOT NULL COMMENT '카드명(resCardName)',
+    card_type                VARCHAR(20)  NOT NULL COMMENT '카드 종류(resCardType: 신용/체크)',
+    is_traffic               VARCHAR(10)  NOT NULL DEFAULT 'N' COMMENT '교통 기능 여부(resTrafficYN: Y/N)',
+    image_link               VARCHAR(500) NULL     COMMENT '카드 이미지 URL(resImageLink)',
+    issue_date               DATE         NULL     COMMENT '발급일(resIssueDate: YYYYMMDD)',
+    valid_period             VARCHAR(6)   NULL     COMMENT '유효기간(resValidPeriod: YYYYMM)',
+    state                    VARCHAR(20)  NULL     COMMENT '카드 상태(resState: 정상/분실/해지 등)',
+    raw_response             JSON         NOT NULL COMMENT 'CODEF 원본 응답',
+    created_at               DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at               DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    KEY idx_card_account_inst (connected_institution_id),
+    CONSTRAINT fk_card_account_inst FOREIGN KEY (connected_institution_id) REFERENCES connected_institution (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='카드 계좌. 동기화 시 응답에 없는 카드는 물리 삭제';
 
 -- =====================================================================
 -- [목표 종속]

--- a/sql/institution_master.sql
+++ b/sql/institution_master.sql
@@ -18,3 +18,12 @@ INSERT INTO institution (code, name, institution_type, business_type, login_type
 ('0240', '삼성증권', 'STOCK', 'ST', '1', '주식 · 펀드', 16),
 ('0243', '한국투자증권', 'STOCK', 'ST', '1', '주식 · 펀드', 15),
 ('0247', 'NH투자증권', 'STOCK', 'ST', '1', '주식 · 펀드', 16);
+
+
+INSERT INTO institution (code, name, institution_type, business_type, login_type, product_label, display_order, extra_field_schema) VALUES
+-- 카드
+('0301', 'KB국민카드', 'CARD', 'CD', '1', '카드', 17, '[{"key":"cardNo","label":"카드번호","type":"text","required":false},{"key":"cardPassword","label":"카드 비밀번호","type":"password","required":false}]'),
+('0302', '현대카드', 'CARD', 'CD', '1', '카드', 18, '[{"key":"cardNo","label":"카드번호","type":"text","required":true},{"key":"cardPassword","label":"카드 비밀번호","type":"password","required":true}]'),
+('0303', '삼성카드', 'CARD', 'CD', '1', '카드', 19, NULL),
+('0306', '신한카드', 'CARD', 'CD', '1', '카드', 20, NULL),
+('0309', '우리카드', 'CARD', 'CD', '1', '카드', 21, '[{"key":"birthDate","label":"생년월일","type":"text","required":false,"placeholder":"YYYYMMDD"}]');

--- a/src/main/java/com/team/independence/asset/controller/AssetController.java
+++ b/src/main/java/com/team/independence/asset/controller/AssetController.java
@@ -81,6 +81,11 @@ public class AssetController {
         return ApiResponse.ok(assetAccountListService.getAccountList(memberId));
     }
 
+    @GetMapping("/cards")
+    public ApiResponse<List<CardAccountResponse>> getCardList(@LoginMember Long memberId) {
+        return ApiResponse.ok(assetService.getCardList(memberId));
+    }
+
     @GetMapping("/manual")
     public ApiResponse<List<ManualAssetResponse>> getManualAssets(@LoginMember Long memberId) {
         return ApiResponse.ok(manualAssetService.getManualAssets(memberId));

--- a/src/main/java/com/team/independence/asset/domain/CardAccount.java
+++ b/src/main/java/com/team/independence/asset/domain/CardAccount.java
@@ -1,0 +1,28 @@
+package com.team.independence.asset.domain;
+
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CardAccount {
+    private Long id;
+    private Long connectedInstitutionId;
+    private String cardNo;
+    private String isSleep;  // Y / N
+    private String cardName;
+    private String cardType;  // 신용 / 체크
+    private String isTraffic;  // Y / N
+    private String imageLink;
+    private LocalDate issueDate;
+    private String validPeriod;  // YYYYMM
+    private String state;
+    private String rawResponse;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/team/independence/asset/dto/AssetSyncResponse.java
+++ b/src/main/java/com/team/independence/asset/dto/AssetSyncResponse.java
@@ -20,6 +20,7 @@ public class AssetSyncResponse {
         private boolean success;
         private int assetAccountCount;
         private int loanAccountCount;
+        private int cardAccountCount;
         private String errorCode;
         private String errorMessage;
     }

--- a/src/main/java/com/team/independence/asset/dto/CardAccountResponse.java
+++ b/src/main/java/com/team/independence/asset/dto/CardAccountResponse.java
@@ -1,0 +1,35 @@
+package com.team.independence.asset.dto;
+
+import com.team.independence.asset.domain.CardAccount;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class CardAccountResponse {
+    private String cardNo;
+    private boolean isSleep;
+    private String cardName;
+    private String cardType;
+    private boolean isTraffic;
+    private String imageLink;
+    private LocalDate issueDate;
+    private String validPeriod;
+    private String state;
+
+    public static CardAccountResponse from(CardAccount card) {
+        return CardAccountResponse.builder()
+                .cardNo(card.getCardNo())
+                .isSleep("Y".equals(card.getIsSleep()))
+                .cardName(card.getCardName())
+                .cardType(card.getCardType())
+                .isTraffic("Y".equals(card.getIsTraffic()))
+                .imageLink(card.getImageLink())
+                .issueDate(card.getIssueDate())
+                .validPeriod(card.getValidPeriod())
+                .state(card.getState())
+                .build();
+    }
+}

--- a/src/main/java/com/team/independence/asset/mapper/CardAccountMapper.java
+++ b/src/main/java/com/team/independence/asset/mapper/CardAccountMapper.java
@@ -1,0 +1,14 @@
+package com.team.independence.asset.mapper;
+
+import com.team.independence.asset.domain.CardAccount;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface CardAccountMapper {
+    void insertAll(@Param("list") List<CardAccount> list);
+    void deleteByConnectedInstitutionId(Long connectedInstitutionId);
+    List<CardAccount> findByMemberId(Long memberId);
+}

--- a/src/main/java/com/team/independence/asset/service/AssetService.java
+++ b/src/main/java/com/team/independence/asset/service/AssetService.java
@@ -3,6 +3,7 @@ package com.team.independence.asset.service;
 import com.team.independence.asset.dto.AssetLinkRequest;
 import com.team.independence.asset.dto.AssetLinkResponse;
 import com.team.independence.asset.dto.AssetNetWorthBreakdown;
+import com.team.independence.asset.dto.CardAccountResponse;
 import com.team.independence.asset.dto.LinkedOrganizationResponse;
 import com.team.independence.asset.dto.UnlinkOrganizationResponse;
 
@@ -12,6 +13,7 @@ public interface AssetService {
     AssetLinkResponse linkAccount(Long memberId, AssetLinkRequest request);
     List<LinkedOrganizationResponse> getConnections(Long memberId);
     UnlinkOrganizationResponse unlinkOrganization(Long memberId, String organizationCode);
+    List<CardAccountResponse> getCardList(Long memberId);
 
     /**
      * 예산 계산용 순자산 분해.

--- a/src/main/java/com/team/independence/asset/service/AssetServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetServiceImpl.java
@@ -7,11 +7,13 @@ import com.team.independence.asset.dto.AssetAccountQueryItem;
 import com.team.independence.asset.dto.AssetLinkRequest;
 import com.team.independence.asset.dto.AssetLinkResponse;
 import com.team.independence.asset.dto.AssetNetWorthBreakdown;
+import com.team.independence.asset.dto.CardAccountResponse;
 import com.team.independence.asset.dto.LinkedOrganizationResponse;
 import com.team.independence.asset.dto.UnlinkOrganizationResponse;
 import com.team.independence.asset.domain.Institution;
 import com.team.independence.asset.mapper.AssetAccountMapper;
 import com.team.independence.asset.mapper.AssetSummaryMapper;
+import com.team.independence.asset.mapper.CardAccountMapper;
 import com.team.independence.asset.mapper.ConnectedAccountMapper;
 import com.team.independence.asset.mapper.ConnectedInstitutionMapper;
 import com.team.independence.asset.mapper.InstitutionMapper;
@@ -52,6 +54,7 @@ public class AssetServiceImpl implements AssetService {
     private final InstitutionMapper institutionMapper;
     private final AssetAccountMapper assetAccountMapper;
     private final AssetSummaryMapper assetSummaryMapper;
+    private final CardAccountMapper cardAccountMapper;
     private final LoanAccountMapper loanAccountMapper;
     private final ManualAssetMapper manualAssetMapper;
     private final CodefClient codefClient;
@@ -194,6 +197,7 @@ public class AssetServiceImpl implements AssetService {
 
         assetAccountMapper.deleteByConnectedInstitutionId(institution.getId());
         loanAccountMapper.deleteByConnectedInstitutionId(institution.getId());
+        cardAccountMapper.deleteByConnectedInstitutionId(institution.getId());
         connectedInstitutionMapper.deleteByConnectedAccountIdAndInstitutionCode(account.getId(), organizationCode);
 
         if (connectedInstitutionMapper.countByConnectedAccountId(account.getId()) == 0) {
@@ -213,6 +217,14 @@ public class AssetServiceImpl implements AssetService {
                 .organizationCode(organizationCode)
                 .organizationName(institutionInfo.getName())
                 .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CardAccountResponse> getCardList(Long memberId) {
+        return cardAccountMapper.findByMemberId(memberId).stream()
+                .map(CardAccountResponse::from)
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
@@ -3,6 +3,7 @@ package com.team.independence.asset.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team.independence.asset.domain.AssetAccount;
+import com.team.independence.asset.domain.CardAccount;
 import com.team.independence.asset.domain.ConnectedAccount;
 import com.team.independence.asset.domain.ConnectedInstitution;
 import com.team.independence.asset.domain.LoanAccount;
@@ -12,6 +13,7 @@ import com.team.independence.asset.dto.SyncJobStatusResponse;
 import com.team.independence.asset.domain.AssetSummary;
 import com.team.independence.asset.mapper.AssetAccountMapper;
 import com.team.independence.asset.mapper.AssetSummaryMapper;
+import com.team.independence.asset.mapper.CardAccountMapper;
 import com.team.independence.asset.mapper.ConnectedAccountMapper;
 import com.team.independence.asset.mapper.ConnectedInstitutionMapper;
 import com.team.independence.asset.mapper.InstitutionMapper;
@@ -26,6 +28,8 @@ import com.team.independence.external.codef.CodefTokenManager;
 import com.team.independence.external.codef.dto.CodefBankAccountResponse;
 import com.team.independence.external.codef.dto.CodefBankAccountResponse.CodefDepositItem;
 import com.team.independence.external.codef.dto.CodefBankAccountResponse.CodefLoanItem;
+import com.team.independence.external.codef.dto.CodefCardResponse;
+import com.team.independence.external.codef.dto.CodefCardResponse.CodefCardItem;
 import com.team.independence.external.codef.dto.CodefStockAccountResponse;
 import com.team.independence.external.codef.dto.CodefStockAccountResponse.CodefStockAccountItem;
 import com.team.independence.external.codef.dto.CodefStockFinancialAssetsResponse;
@@ -49,6 +53,7 @@ public class AssetSyncServiceImpl implements AssetSyncService {
 
     private static final String BUSINESS_TYPE_STOCK = "ST";
     private static final String BUSINESS_TYPE_BANK = "BK";
+    private static final String BUSINESS_TYPE_CARD = "CD";
 
     private static final String DEPOSIT_CODE_DEMAND = "11";
     private static final String DEPOSIT_CODE_SAVINGS = "12";
@@ -66,6 +71,7 @@ public class AssetSyncServiceImpl implements AssetSyncService {
     private final ConnectedInstitutionMapper connectedInstitutionMapper;
     private final InstitutionMapper institutionMapper;
     private final AssetAccountMapper assetAccountMapper;
+    private final CardAccountMapper cardAccountMapper;
     private final LoanAccountMapper loanAccountMapper;
     private final AssetSummaryMapper assetSummaryMapper;
     private final CodefClient codefClient;
@@ -179,11 +185,62 @@ public class AssetSyncServiceImpl implements AssetSyncService {
             if (BUSINESS_TYPE_STOCK.equals(businessType)) {
                 return syncStockInstitution(institution, connectedId, accessToken, institutionCode, orgName);
             }
+            if (BUSINESS_TYPE_CARD.equals(businessType)) {
+                return syncCardInstitution(institution, connectedId, birthDate, accessToken, institutionCode, orgName);
+            }
             return syncBankInstitution(institution, connectedId, birthDate, accessToken, institutionCode, orgName);
         } catch (Exception e) {
             log.error("계좌 동기화 실패: org={}", institutionCode, e);
             return recordFailure(institution, orgName, "SYNC_ERROR", e.getMessage());
         }
+    }
+
+    private InstitutionSyncResult syncCardInstitution(ConnectedInstitution institution,
+                                                       String connectedId, String birthDate,
+                                                       String accessToken,
+                                                       String institutionCode, String orgName) {
+        CodefCardResponse response =
+                codefClient.getCardList(accessToken, connectedId, institutionCode, "", "", birthDate);
+
+        if (!response.isSuccess()) {
+            return recordFailure(institution, orgName, response.getResultCode(), response.getResultMessage());
+        }
+
+        List<CardAccount> cardAccounts = new ArrayList<>();
+        for (CodefCardItem item : response.getCards()) {
+            cardAccounts.add(CardAccount.builder()
+                    .connectedInstitutionId(institution.getId())
+                    .cardNo(item.getResCardNo())
+                    .isSleep(item.getResSleepYN() != null ? item.getResSleepYN() : "N")
+                    .cardName(item.getResCardName())
+                    .cardType(item.getResCardType())
+                    .isTraffic(item.getResTrafficYN() != null ? item.getResTrafficYN() : "N")
+                    .imageLink(item.getResImageLink())
+                    .issueDate(parseDate(item.getResIssueDate()))
+                    .validPeriod(item.getResValidPeriod())
+                    .state(item.getResState())
+                    .rawResponse(toJson(item))
+                    .build());
+        }
+
+        cardAccountMapper.deleteByConnectedInstitutionId(institution.getId());
+        if (!cardAccounts.isEmpty()) cardAccountMapper.insertAll(cardAccounts);
+
+        institution.setStatus("ACTIVE");
+        institution.setLastSyncedAt(LocalDateTime.now());
+        institution.setLastAttemptedAt(LocalDateTime.now());
+        institution.setLastErrorCode(null);
+        institution.setLastErrorMessage(null);
+        connectedInstitutionMapper.updateSyncResult(institution);
+
+        log.info("카드 동기화 완료: org={}, 카드수={}", institutionCode, cardAccounts.size());
+
+        return InstitutionSyncResult.builder()
+                .organizationCode(institutionCode)
+                .organizationName(orgName)
+                .success(true)
+                .cardAccountCount(cardAccounts.size())
+                .build();
     }
 
     private InstitutionSyncResult syncBankInstitution(ConnectedInstitution institution,
@@ -464,7 +521,8 @@ public class AssetSyncServiceImpl implements AssetSyncService {
         institution.setStatus("ERROR");
         institution.setLastAttemptedAt(LocalDateTime.now());
         institution.setLastErrorCode(errorCode);
-        institution.setLastErrorMessage(errorMessage);
+        institution.setLastErrorMessage(errorMessage != null && errorMessage.length() > 1000
+                ? errorMessage.substring(0, 1000) : errorMessage);
         connectedInstitutionMapper.updateSyncResult(institution);
 
         return InstitutionSyncResult.builder()

--- a/src/main/java/com/team/independence/external/codef/CodefClient.java
+++ b/src/main/java/com/team/independence/external/codef/CodefClient.java
@@ -3,6 +3,7 @@ package com.team.independence.external.codef;
 import com.team.independence.external.codef.dto.CodefAccountRequest;
 import com.team.independence.external.codef.dto.CodefApiResponse;
 import com.team.independence.external.codef.dto.CodefBankAccountResponse;
+import com.team.independence.external.codef.dto.CodefCardResponse;
 import com.team.independence.external.codef.dto.CodefStockAccountResponse;
 import com.team.independence.external.codef.dto.CodefStockFinancialAssetsResponse;
 
@@ -13,4 +14,5 @@ public interface CodefClient {
     CodefBankAccountResponse getBankAccountList(String accessToken, String connectedId, String organization, String birthDate);
     CodefStockAccountResponse getStockAccountList(String accessToken, String connectedId, String organization);
     CodefStockFinancialAssetsResponse getStockFinancialAssets(String accessToken, String connectedId, String organization, String account);
+    CodefCardResponse getCardList(String accessToken, String connectedId, String organization, String cardNo, String cardPassword, String birthDate);
 }

--- a/src/main/java/com/team/independence/external/codef/CodefMockClient.java
+++ b/src/main/java/com/team/independence/external/codef/CodefMockClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team.independence.external.codef.dto.CodefAccountRequest;
 import com.team.independence.external.codef.dto.CodefApiResponse;
 import com.team.independence.external.codef.dto.CodefBankAccountResponse;
+import com.team.independence.external.codef.dto.CodefCardResponse;
 import com.team.independence.external.codef.dto.CodefStockAccountResponse;
 import com.team.independence.external.codef.dto.CodefStockFinancialAssetsResponse;
 import lombok.RequiredArgsConstructor;
@@ -74,6 +75,13 @@ public class CodefMockClient implements CodefClient {
     public CodefApiResponse deleteAccount(String accessToken, String connectedId,
                                           CodefAccountRequest.CodefAccountItem item) {
         return parse(API_SUCCESS_RESPONSE, CodefApiResponse.class);
+    }
+
+    @Override
+    public CodefCardResponse getCardList(String accessToken, String connectedId, String organization,
+                                         String cardNo, String cardPassword, String birthDate) {
+        log.debug("[Mock] getCardList: org={}", organization);
+        return parse(CARD_RESPONSE, CodefCardResponse.class);
     }
 
     private <T> T parse(String json, Class<T> clazz) {
@@ -155,4 +163,19 @@ public class CodefMockClient implements CodefClient {
             + "\"result\":{\"code\":\"CF-00000\",\"message\":\"성공\"},"
             + "\"data\":{\"connectedId\":\"mock-connected-id\","
             + "\"successList\":[],\"errorList\":[]}}";
+
+    private static final String CARD_RESPONSE = "{"
+            + "\"result\":{\"code\":\"CF-00000\",\"message\":\"성공\"},"
+            + "\"data\":["
+            + "  {\"resCardNo\":\"1234-****-****-5678\",\"resSleepYN\":\"0\","
+            + "   \"resCardName\":\"KB국민 My WE:SH 카드\",\"resCardType\":\"신용\","
+            + "   \"resTrafficYN\":\"1\",\"resImageLink\":\"\","
+            + "   \"resIssueDate\":\"20230101\",\"resValidPeriod\":\"202801\","
+            + "   \"resState\":\"정상\"},"
+            + "  {\"resCardNo\":\"9876-****-****-4321\",\"resSleepYN\":\"0\","
+            + "   \"resCardName\":\"KB국민 노리체크카드\",\"resCardType\":\"체크\","
+            + "   \"resTrafficYN\":\"0\",\"resImageLink\":\"\","
+            + "   \"resIssueDate\":\"20220601\",\"resValidPeriod\":\"202706\","
+            + "   \"resState\":\"정상\"}"
+            + "]}";
 }

--- a/src/main/java/com/team/independence/external/codef/CodefRealClient.java
+++ b/src/main/java/com/team/independence/external/codef/CodefRealClient.java
@@ -1,5 +1,7 @@
 package com.team.independence.external.codef;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
@@ -7,6 +9,8 @@ import com.team.independence.external.codef.dto.CodefAccountRequest;
 import com.team.independence.external.codef.dto.CodefApiResponse;
 import com.team.independence.external.codef.dto.CodefBankAccountResponse;
 import com.team.independence.external.codef.dto.CodefBankInquiryRequest;
+import com.team.independence.external.codef.dto.CodefCardInquiryRequest;
+import com.team.independence.external.codef.dto.CodefCardResponse;
 import com.team.independence.external.codef.dto.CodefStockAccountResponse;
 import com.team.independence.external.codef.dto.CodefStockFinancialAssetsRequest;
 import com.team.independence.external.codef.dto.CodefStockFinancialAssetsResponse;
@@ -34,6 +38,7 @@ public class CodefRealClient implements CodefClient {
     private static final String BANK_ACCOUNT_LIST_PATH = "/v1/kr/bank/p/account/account-list";
     private static final String STOCK_ACCOUNT_LIST_PATH = "/v1/kr/stock/a/account/account-list";
     private static final String STOCK_FINANCIAL_ASSETS_PATH = "/v1/kr/stock/a/account/financial-assets";
+    private static final String CARD_LIST_PATH = "/v1/kr/card/p/account/card-list";
 
     private final CodefProperties properties;
     private final RestTemplate restTemplate;
@@ -139,6 +144,34 @@ public class CodefRealClient implements CodefClient {
             return objectMapper.readValue(decoded, CodefStockFinancialAssetsResponse.class);
         } catch (Exception e) {
             log.error("CODEF 종합자산 조회 실패: org={}", organization, e);
+            throw new BusinessException(ErrorCode.ASSET_CODEF_API_ERROR);
+        }
+    }
+
+    @Override
+    public CodefCardResponse getCardList(String accessToken, String connectedId, String organization,
+                                         String cardNo, String cardPassword, String birthDate) {
+        CodefCardInquiryRequest body = CodefCardInquiryRequest.builder()
+                .connectedId(connectedId)
+                .organization(organization)
+                .cardNo(cardNo != null ? cardNo : "")
+                .cardPassword(cardPassword != null ? cardPassword : "")
+                .birthDate(birthDate != null ? birthDate : "")
+                .build();
+
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(accessToken);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    properties.getApiDomain() + CARD_LIST_PATH,
+                    HttpMethod.POST, new HttpEntity<>(body, headers), String.class
+            );
+            String decoded = URLDecoder.decode(response.getBody(), StandardCharsets.UTF_8);
+            log.debug("CODEF 카드목록 응답: org={}", organization);
+            return objectMapper.readValue(decoded, CodefCardResponse.class);
+        } catch (Exception e)  {
+            log.error("CODEF 카드목록 조회 실패={}", organization, e);
             throw new BusinessException(ErrorCode.ASSET_CODEF_API_ERROR);
         }
     }

--- a/src/main/java/com/team/independence/external/codef/dto/CodefCardInquiryRequest.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefCardInquiryRequest.java
@@ -1,0 +1,23 @@
+package com.team.independence.external.codef.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CodefCardInquiryRequest {
+    private String organization;
+    private String connectedId;
+    @Builder.Default
+    private String cardNo = "";
+    @Builder.Default
+    private String cardPassword = "";
+    @Builder.Default
+    private String birthDate = "";
+    @Builder.Default
+    private String inquiryType = "1";
+}

--- a/src/main/java/com/team/independence/external/codef/dto/CodefCardResponse.java
+++ b/src/main/java/com/team/independence/external/codef/dto/CodefCardResponse.java
@@ -1,0 +1,59 @@
+package com.team.independence.external.codef.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CodefCardResponse {
+
+    private static final String SUCCESS_CODE = "CF-00000";
+
+    private CodefResult result;
+    private List<CodefCardItem> data;
+
+    public boolean isSuccess() {
+        return result != null && SUCCESS_CODE.equals(result.getCode());
+    }
+
+    public String getResultCode() {
+        return result != null ? result.getCode() : null;
+    }
+
+    public String getResultMessage() {
+        return result != null ? result.getMessage() : null;
+    }
+
+    public List<CodefCardItem> getCards() {
+        return data != null ? data : Collections.emptyList();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CodefResult {
+        private String code;
+        private String message;
+        private String transactionId;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CodefCardItem {
+        private String resCardNo;
+        private String resSleepYN;
+        private String resCardName;
+        private String resCardType;
+        private String resTrafficYN;
+        private String resImageLink;
+        private String resIssueDate;
+        private String resValidPeriod;
+        private String resState;
+    }
+}

--- a/src/main/resources/mybatis/mapper/asset/CardAccountMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/CardAccountMapper.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.team.independence.asset.mapper.CardAccountMapper">
+
+    <resultMap id="cardAccountMap" type="com.team.independence.asset.domain.CardAccount">
+        <id     property="id"                       column="id"/>
+        <result property="connectedInstitutionId"   column="connected_institution_id"/>
+        <result property="cardNo"                   column="card_no"/>
+        <result property="isSleep"                  column="is_sleep"/>
+        <result property="cardName"                 column="card_name"/>
+        <result property="cardType"                 column="card_type"/>
+        <result property="isTraffic"                column="is_traffic"/>
+        <result property="imageLink"                column="image_link"/>
+        <result property="issueDate"                column="issue_date"/>
+        <result property="validPeriod"              column="valid_period"/>
+        <result property="state"                    column="state"/>
+        <result property="rawResponse"              column="raw_response"/>
+        <result property="createdAt"                column="created_at"/>
+        <result property="updatedAt"                column="updated_at"/>
+    </resultMap>
+
+    <insert id="insertAll">
+        INSERT INTO card_account
+            (connected_institution_id, card_no, is_sleep, card_name,
+             card_type, is_traffic, image_link, issue_date, valid_period, state, raw_response)
+        VALUES
+        <foreach collection="list" item="c" separator=",">
+            (#{c.connectedInstitutionId}, #{c.cardNo}, #{c.isSleep}, #{c.cardName},
+             #{c.cardType}, #{c.isTraffic}, #{c.imageLink}, #{c.issueDate}, #{c.validPeriod}, #{c.state}, #{c.rawResponse})
+        </foreach>
+    </insert>
+
+    <delete id="deleteByConnectedInstitutionId" parameterType="long">
+        DELETE FROM card_account WHERE connected_institution_id = #{connectedInstitutionId}
+    </delete>
+
+    <select id="findByMemberId" parameterType="long" resultMap="cardAccountMap">
+        SELECT ca.id, ca.connected_institution_id,
+               ca.card_no, ca.is_sleep, ca.card_name, ca.card_type,
+               ca.is_traffic, ca.image_link, ca.issue_date, ca.valid_period,
+               ca.state, ca.created_at, ca.updated_at
+          FROM card_account ca
+          JOIN connected_institution ci ON ca.connected_institution_id = ci.id
+          JOIN connected_account coa ON ci.connected_account_id = coa.id
+         WHERE coa.member_id = #{memberId}
+         ORDER BY ci.institution_code, ca.card_name
+    </select>
+
+</mapper>

--- a/src/test/java/com/team/independence/asset/service/AssetSyncServiceImplTest.java
+++ b/src/test/java/com/team/independence/asset/service/AssetSyncServiceImplTest.java
@@ -10,6 +10,7 @@ import com.team.independence.asset.domain.Institution;
 import com.team.independence.asset.domain.LoanAccount;
 import com.team.independence.asset.mapper.AssetAccountMapper;
 import com.team.independence.asset.mapper.AssetSummaryMapper;
+import com.team.independence.asset.mapper.CardAccountMapper;
 import com.team.independence.asset.mapper.ConnectedAccountMapper;
 import com.team.independence.asset.mapper.ConnectedInstitutionMapper;
 import com.team.independence.asset.mapper.InstitutionMapper;
@@ -53,6 +54,7 @@ class  AssetSyncServiceImplTest {
     @Mock ConnectedInstitutionMapper connectedInstitutionMapper;
     @Mock InstitutionMapper institutionMapper;
     @Mock AssetAccountMapper assetAccountMapper;
+    @Mock CardAccountMapper cardAccountMapper;
     @Mock LoanAccountMapper loanAccountMapper;
     @Mock AssetSummaryMapper assetSummaryMapper;
     @Mock CodefClient codefClient;
@@ -79,7 +81,7 @@ class  AssetSyncServiceImplTest {
         service = new AssetSyncServiceImpl(
                 jobStore,
                 connectedAccountMapper, connectedInstitutionMapper, institutionMapper,
-                assetAccountMapper, loanAccountMapper, assetSummaryMapper,
+                assetAccountMapper, cardAccountMapper, loanAccountMapper, assetSummaryMapper,
                 codefClient, codefTokenManager, aesEncryptor, objectMapper, slackNotifier);
     }
 

--- a/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.team.independence.asset.dto.AssetLinkRequest;
 import com.team.independence.asset.dto.AssetLinkResponse;
 import com.team.independence.asset.dto.AssetNetWorthBreakdown;
+import com.team.independence.asset.dto.CardAccountResponse;
 import com.team.independence.asset.dto.LinkedOrganizationResponse;
 import com.team.independence.asset.dto.UnlinkOrganizationResponse;
 import com.team.independence.asset.service.AssetService;
@@ -502,6 +503,11 @@ class GoalDetailServiceImplTest {
 
         @Override
         public UnlinkOrganizationResponse unlinkOrganization(Long memberId, String organizationCode) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<CardAccountResponse> getCardList(Long memberId) {
             throw new UnsupportedOperationException();
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #55

## 📝작업 내용

 ### CODEF 카드 목록 조회 연동

카드사 계정 연동(POST `/api/v1/assets/link`, `businessType=CD`)과 카드 목록 조회(GET `/api/v1/assets/cards`)를 구현했습니다.
  
 #### 추가된 파일     
  - `CodefCardInquiryRequest`, `CodefCardResponse`: CODEF 카드 API 요청/응답 DTO
  - `CardAccount` 도메인, `CardAccountMapper` 인터페이스 및 XML
  - `CardAccountResponse`: API 응답 DTO (`isSleep`/`isTraffic` Y/N → boolean 변환)

 #### 수정된 파일
- `CodefClient` / `CodefRealClient`: `getCardList()` 추가 (`/v1/kr/card/p/account/card-list`)
- `CodefMockClient`: 카드 더미 응답 2건 추가
- `AssetSyncServiceImpl`: `syncCardInstitution()` 추가, 동기화 시 `businessType=CD` 자동 분기
- `AssetServiceImpl`: `getCardList()` 구현, `unlinkOrganization()` 시 `card_account` 삭제 추가
- `AssetController`: GET `/api/v1/assets/cards` 엔드포인트 추가
  
 #### 스키마 변경     
- `card_account` 테이블 신규 추가
- `institution_master`에 카드사 5개 추가 (KB국민카드/현대카드/삼성카드/신한카드/우리카드), 기관별 추가 입력 항목 `extra_field_schema`에 정의
- `connected_institution.last_error_message` `VARCHAR(255)` → `TEXT`


### 스크린샷
#### 카드사 연동
<img width="1117" height="551" alt="스크린샷 2026-08-06 오후 4 18 21" src="https://github.com/user-attachments/assets/2121fce8-7988-4072-a19e-13b2153e88bd" />

#### 자산 동기화
<img width="1118" height="341" alt="스크린샷 2026-08-06 오후 4 20 28" src="https://github.com/user-attachments/assets/f991a070-fc9d-4146-9172-433f09868849" />

#### 카드 목록 조회
<img width="1118" height="778" alt="스크린샷 2026-08-06 오후 4 22 12" src="https://github.com/user-attachments/assets/a235cc6c-f52b-433e-939d-e159af3b83cc" />


## 💬리뷰 요구사항

> 기능 구현에만 집중하다보니 asset 도메인에 은행, 증권, 이번에 추가한 카드까지 섞여 있는 바람에 현재 도메인 경계가 불명확한 것 같습니다. 완성도 있는 단계가 되면 각각의 도메인에 따른 패키지로 나눠 리팩토링하도록 하겠습니다!