### PR TITLE
feat(goal): 목표 수정 API 구현

### DIFF
--- a/src/main/java/com/team/independence/goal/controller/GoalController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalController.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -42,6 +43,14 @@ public class GoalController {
             @LoginMember Long memberId,
             @Valid @RequestBody GoalSaveRequest request) {
         return ApiResponse.ok(goalService.createGoal(memberId, request));
+    }
+
+    @PutMapping("/{goalId}")
+    public ApiResponse<GoalResponse> updateGoal(
+            @LoginMember Long memberId,
+            @PathVariable Long goalId,
+            @Valid @RequestBody GoalSaveRequest request) {
+        return ApiResponse.ok(goalService.updateGoal(memberId, goalId, request));
     }
 
     @GetMapping("/{goalId}/detail")

--- a/src/main/java/com/team/independence/goal/controller/GoalController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalController.java
@@ -2,13 +2,13 @@ package com.team.independence.goal.controller;
 
 import com.team.independence.common.annotation.LoginMember;
 import com.team.independence.common.response.ApiResponse;
-import com.team.independence.goal.dto.GoalCreateRequest;
 import com.team.independence.goal.dto.GoalDetailResponse;
 import com.team.independence.goal.dto.GoalDiagnosisRequest;
 import com.team.independence.goal.dto.GoalDiagnosisResponse;
 import com.team.independence.goal.dto.GoalMarketTrendResponse;
 import com.team.independence.goal.dto.GoalForecastResponse;
 import com.team.independence.goal.dto.GoalResponse;
+import com.team.independence.goal.dto.GoalSaveRequest;
 import com.team.independence.goal.dto.GoalSummaryResponse;
 import com.team.independence.goal.service.GoalDetailService;
 import com.team.independence.goal.service.GoalService;
@@ -40,7 +40,7 @@ public class GoalController {
     @PostMapping
     public ApiResponse<GoalResponse> createGoal(
             @LoginMember Long memberId,
-            @Valid @RequestBody GoalCreateRequest request) {
+            @Valid @RequestBody GoalSaveRequest request) {
         return ApiResponse.ok(goalService.createGoal(memberId, request));
     }
 

--- a/src/main/java/com/team/independence/goal/dto/GoalResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalResponse.java
@@ -24,4 +24,5 @@ public class GoalResponse {
     private Long targetAmount;
     private Long targetRentMiddleAmount;
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/team/independence/goal/dto/GoalSaveRequest.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalSaveRequest.java
@@ -10,13 +10,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 목표 진단 결과를 저장한다. 진단 응답을 그대로 echo해서 받으므로,
+ * 목표 생성·수정 공통 요청. 진단 결과를 그대로 echo해서 받으므로,
  * targetAmount(totalBudget)와 targetRentMiddleAmount(median)는 서버가 재계산하지 않고
  * 프론트가 보내준 값을 "설정 시점" 값으로 그대로 고정한다.
  */
 @Getter
 @NoArgsConstructor
-public class GoalCreateRequest {
+public class GoalSaveRequest {
 
     @NotBlank
     private String regionCode;

--- a/src/main/java/com/team/independence/goal/mapper/GoalHousingMapper.java
+++ b/src/main/java/com/team/independence/goal/mapper/GoalHousingMapper.java
@@ -8,6 +8,9 @@ import org.apache.ibatis.annotations.Param;
 public interface GoalHousingMapper {
     void insert(GoalHousing goalHousing);
 
+    /** 목표의 주거 희망 조건을 통째로 교체한다. 모든 컬럼이 NOT NULL이라 부분 수정은 지원하지 않는다. */
+    int update(GoalHousing goalHousing);
+
     /** 목표의 주거 희망 조건 조회(목표 1 : 1). */
     GoalHousing findByGoalId(@Param("goalId") Long goalId);
 }

--- a/src/main/java/com/team/independence/goal/mapper/GoalMapper.java
+++ b/src/main/java/com/team/independence/goal/mapper/GoalMapper.java
@@ -9,6 +9,12 @@ import org.apache.ibatis.annotations.Param;
 public interface GoalMapper {
     void insert(Goal goal);
 
+    /**
+     * 목표의 금액/시점/월 저축액을 갱신한다. member_id를 조건에 함께 걸어 소유자가 아니면 0건이 된다.
+     * status, goal_type, member_id는 수정 대상이 아니고 updated_at은 DB가 자동 갱신한다.
+     */
+    int update(Goal goal);
+
     /** 회원에게 ACTIVE 목표가 이미 있는지 확인한다(동시 ACTIVE 목표는 1개만 허용). */
     boolean existsActiveByMemberId(@Param("memberId") Long memberId);
 

--- a/src/main/java/com/team/independence/goal/service/GoalMarketTrendCacheStore.java
+++ b/src/main/java/com/team/independence/goal/service/GoalMarketTrendCacheStore.java
@@ -55,6 +55,14 @@ public class GoalMarketTrendCacheStore {
         }
     }
 
+    /**
+     * 캐시된 시세 변화를 지운다. 캐시 값에 목표 금액·최초 중앙값·주거 조건이 모두 들어 있어
+     * 목표가 수정되면 그대로 stale해지므로, 다음 조회 때 새 조건으로 다시 계산되도록 무효화한다.
+     */
+    public void delete(Long goalId) {
+        redisTemplate.delete(key(goalId));
+    }
+
     private String key(Long goalId) {
         return KEY_PREFIX + goalId;
     }

--- a/src/main/java/com/team/independence/goal/service/GoalService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalService.java
@@ -17,6 +17,13 @@ public interface GoalService {
     GoalResponse createGoal(Long memberId, GoalSaveRequest request);
 
     /**
+     * 목표의 금액·시점·월 저축액과 주거 희망 조건을 통째로 교체한다.
+     * 목표가 없으면 GOAL_NOT_FOUND, 다른 회원의 목표면 GOAL_FORBIDDEN,
+     * 진행 중이 아닌 목표면 GOAL_NOT_ACTIVE.
+     */
+    GoalResponse updateGoal(Long memberId, Long goalId, GoalSaveRequest request);
+
+    /**
      * 목표를 찾고 요청자가 소유자인지 확인한다.
      * 목표가 없으면 GOAL_NOT_FOUND, 다른 회원의 목표면 GOAL_FORBIDDEN.
      */

--- a/src/main/java/com/team/independence/goal/service/GoalService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalService.java
@@ -2,19 +2,19 @@ package com.team.independence.goal.service;
 
 import com.team.independence.asset.dto.AssetNetWorthBreakdown;
 import com.team.independence.goal.domain.Goal;
-import com.team.independence.goal.dto.GoalCreateRequest;
 import com.team.independence.goal.dto.GoalDiagnosisRequest;
 import com.team.independence.goal.dto.GoalDiagnosisResponse;
 import com.team.independence.goal.dto.GoalMarketTrendResponse;
 import com.team.independence.goal.dto.GoalForecastResponse;
 import com.team.independence.goal.dto.GoalResponse;
+import com.team.independence.goal.dto.GoalSaveRequest;
 import com.team.independence.goal.dto.GoalSummaryResponse;
 
 public interface GoalService {
     GoalDiagnosisResponse diagnose(Long memberId, GoalDiagnosisRequest request);
 
     /** 진단 결과를 목표로 저장한다. 이미 ACTIVE 목표가 있으면 GOAL_ALREADY_EXISTS로 거부한다. */
-    GoalResponse createGoal(Long memberId, GoalCreateRequest request);
+    GoalResponse createGoal(Long memberId, GoalSaveRequest request);
 
     /**
      * 목표를 찾고 요청자가 소유자인지 확인한다.

--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -8,12 +8,12 @@ import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.goal.domain.Goal;
 import com.team.independence.goal.domain.GoalHousing;
 import com.team.independence.goal.domain.SavingBasis;
-import com.team.independence.goal.dto.GoalCreateRequest;
 import com.team.independence.goal.dto.GoalDiagnosisRequest;
 import com.team.independence.goal.dto.GoalDiagnosisResponse;
 import com.team.independence.goal.dto.GoalForecastResponse;
 import com.team.independence.goal.dto.GoalMarketTrendResponse;
 import com.team.independence.goal.dto.GoalResponse;
+import com.team.independence.goal.dto.GoalSaveRequest;
 import com.team.independence.goal.dto.GoalSummaryResponse;
 import com.team.independence.goal.mapper.GoalHousingMapper;
 import com.team.independence.goal.mapper.GoalMapper;
@@ -181,7 +181,7 @@ public class GoalServiceImpl implements GoalService {
 
     @Override
     @Transactional
-    public GoalResponse createGoal(Long memberId, GoalCreateRequest request) {
+    public GoalResponse createGoal(Long memberId, GoalSaveRequest request) {
         // 희망 조건 범위 검증(진단과 동일 규칙)
         validateMonthlySavings(request.getMonthlySavings());
         validateRange(request.getSizeMin(), request.getSizeMax());

--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -23,7 +23,6 @@ import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.service.RegionQueryService;
 import com.team.independence.property.service.RentMedianService;
-import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
@@ -182,21 +181,7 @@ public class GoalServiceImpl implements GoalService {
     @Override
     @Transactional
     public GoalResponse createGoal(Long memberId, GoalSaveRequest request) {
-        // 희망 조건 범위 검증(진단과 동일 규칙)
-        validateMonthlySavings(request.getMonthlySavings());
-        validateRange(request.getSizeMin(), request.getSizeMax());
-        validateRange(request.getDepositMin(), request.getDepositMax());
-        validateTargetDate(request.getTargetDate());
-
-        HousingType housingType = HousingType.valueOf(request.getPropertyType());
-        DealType dealType = DealType.valueOf(request.getTradeType());
-        validateMonthlyRentRequired(dealType, request.getMonthlyRentMax());
-
-        long monthlyRentMin = normalizeMonthlyRent(dealType, request.getMonthlyRentMin());
-        long monthlyRentMax = normalizeMonthlyRent(dealType, request.getMonthlyRentMax());
-        if (dealType == DealType.WOLSE) {
-            validateRange(monthlyRentMin, monthlyRentMax);
-        }
+        GoalHousing goalHousing = validateAndBuildHousing(request);
 
         assetService.validateConnectedAccountExists(memberId);
 
@@ -219,8 +204,69 @@ public class GoalServiceImpl implements GoalService {
         // assets/summary가 보여주는 monthlySavings는 asset_summary 캐시에서 읽으므로 goal 저장 시점에 함께 갱신한다
         assetSummaryService.updateMonthlySavings(memberId, request.getMonthlySavings());
 
-        GoalHousing goalHousing = GoalHousing.builder()
-                .goalId(goal.getId())
+        goalHousing.setGoalId(goal.getId());
+        goalHousingMapper.insert(goalHousing);
+
+        return toGoalResponse(goalMapper.findById(goal.getId()), goalHousing);
+    }
+
+    /**
+     * 목표의 조건을 통째로 교체한다. 저장 계약은 생성과 같다 — 프론트가 진단을 다시 호출해 받은
+     * targetAmount/targetRentMiddleAmount를 실어 보내면 서버는 재계산 없이 그대로 고정 저장한다.
+     * 이미 끝난(ACHIEVED/ARCHIVED) 목표는 수정할 수 없다.
+     */
+    @Override
+    @Transactional
+    public GoalResponse updateGoal(Long memberId, Long goalId, GoalSaveRequest request) {
+        GoalHousing goalHousing = validateAndBuildHousing(request);
+
+        Goal goal = findOwnedGoal(memberId, goalId);
+        if (!GOAL_STATUS_ACTIVE.equals(goal.getStatus())) {
+            throw new BusinessException(ErrorCode.GOAL_NOT_ACTIVE);
+        }
+
+        assetService.validateConnectedAccountExists(memberId);
+
+        goal.setTargetAmount(request.getTargetAmount());
+        goal.setTargetRentMiddleAmount(request.getTargetRentMiddleAmount());
+        goal.setTargetDate(request.getTargetDate().atDay(1));
+        goal.setMonthlySaving(request.getMonthlySavings());
+        goalMapper.update(goal);
+
+        goalHousing.setGoalId(goalId);
+        goalHousingMapper.update(goalHousing);
+
+        // 생성 때와 같은 이유로 asset_summary 캐시도 함께 갱신한다
+        assetSummaryService.updateMonthlySavings(memberId, request.getMonthlySavings());
+
+        // 시세 변화 캐시는 목표 금액과 주거 조건을 그대로 담고 있어 수정 즉시 stale해진다.
+        // 지워두면 다음 조회 때 캐시 미스 경로가 새 조건으로 다시 계산한다.
+        goalMarketTrendCacheStore.delete(goalId);
+
+        return toGoalResponse(goalMapper.findById(goalId), goalHousing);
+    }
+
+    /**
+     * 생성·수정 공통. 희망 조건을 진단과 같은 규칙으로 검증하고 goal_housing 저장 형태로 정규화한다.
+     * goalId는 아직 모르거나(생성) 호출부가 이미 아는 값(수정)이라 여기서 채우지 않는다.
+     */
+    private GoalHousing validateAndBuildHousing(GoalSaveRequest request) {
+        validateMonthlySavings(request.getMonthlySavings());
+        validateRange(request.getSizeMin(), request.getSizeMax());
+        validateRange(request.getDepositMin(), request.getDepositMax());
+        validateTargetDate(request.getTargetDate());
+
+        HousingType housingType = HousingType.valueOf(request.getPropertyType());
+        DealType dealType = DealType.valueOf(request.getTradeType());
+        validateMonthlyRentRequired(dealType, request.getMonthlyRentMax());
+
+        long monthlyRentMin = normalizeMonthlyRent(dealType, request.getMonthlyRentMin());
+        long monthlyRentMax = normalizeMonthlyRent(dealType, request.getMonthlyRentMax());
+        if (dealType == DealType.WOLSE) {
+            validateRange(monthlyRentMin, monthlyRentMax);
+        }
+
+        return GoalHousing.builder()
                 .regionCode(request.getRegionCode())
                 .housingType(housingType)
                 .dealType(dealType)
@@ -231,25 +277,28 @@ public class GoalServiceImpl implements GoalService {
                 .monthlyRentMin(monthlyRentMin)
                 .monthlyRentMax(monthlyRentMax)
                 .build();
-        goalHousingMapper.insert(goalHousing);
+    }
 
+    /** 생성·수정 공통 응답 조립. createdAt/updatedAt은 DB가 채운 값을 그대로 쓴다. */
+    private GoalResponse toGoalResponse(Goal goal, GoalHousing goalHousing) {
         return GoalResponse.builder()
                 .goalId(goal.getId())
                 .status(goal.getStatus())
-                .regionCode(request.getRegionCode())
-                .propertyType(request.getPropertyType())
-                .tradeType(request.getTradeType())
-                .sizeMin(request.getSizeMin())
-                .sizeMax(request.getSizeMax())
-                .depositMin(request.getDepositMin())
-                .depositMax(request.getDepositMax())
-                .monthlyRentMin(monthlyRentMin)
-                .monthlyRentMax(monthlyRentMax)
-                .monthlySavings(request.getMonthlySavings())
-                .targetDate(request.getTargetDate())
-                .targetAmount(request.getTargetAmount())
-                .targetRentMiddleAmount(request.getTargetRentMiddleAmount())
-                .createdAt(LocalDateTime.now())
+                .regionCode(goalHousing.getRegionCode())
+                .propertyType(goalHousing.getHousingType().name())
+                .tradeType(goalHousing.getDealType().name())
+                .sizeMin(goalHousing.getAreaMin())
+                .sizeMax(goalHousing.getAreaMax())
+                .depositMin(goalHousing.getDepositMin())
+                .depositMax(goalHousing.getDepositMax())
+                .monthlyRentMin(goalHousing.getMonthlyRentMin())
+                .monthlyRentMax(goalHousing.getMonthlyRentMax())
+                .monthlySavings(goal.getMonthlySaving())
+                .targetDate(YearMonth.from(goal.getTargetDate()))
+                .targetAmount(goal.getTargetAmount())
+                .targetRentMiddleAmount(goal.getTargetRentMiddleAmount())
+                .createdAt(goal.getCreatedAt())
+                .updatedAt(goal.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/resources/mybatis/mapper/goal/GoalHousingMapper.xml
+++ b/src/main/resources/mybatis/mapper/goal/GoalHousingMapper.xml
@@ -31,6 +31,20 @@
         )
     </insert>
 
+    <update id="update" parameterType="com.team.independence.goal.domain.GoalHousing">
+        UPDATE goal_housing
+           SET region_code      = #{regionCode},
+               housing_type     = #{housingType},
+               deal_type        = #{dealType},
+               area_min         = #{areaMin},
+               area_max         = #{areaMax},
+               deposit_min      = #{depositMin},
+               deposit_max      = #{depositMax},
+               monthly_rent_min = #{monthlyRentMin},
+               monthly_rent_max = #{monthlyRentMax}
+         WHERE goal_id = #{goalId}
+    </update>
+
     <select id="findByGoalId" resultMap="goalHousingMap">
         SELECT goal_id, region_code, housing_type, deal_type,
                area_min, area_max, deposit_min, deposit_max,

--- a/src/main/resources/mybatis/mapper/goal/GoalMapper.xml
+++ b/src/main/resources/mybatis/mapper/goal/GoalMapper.xml
@@ -30,6 +30,15 @@
         )
     </insert>
 
+    <update id="update" parameterType="com.team.independence.goal.domain.Goal">
+        UPDATE goal
+           SET target_amount             = #{targetAmount},
+               target_rent_middle_amount = #{targetRentMiddleAmount},
+               target_date               = #{targetDate},
+               monthly_saving            = #{monthlySaving}
+         WHERE id = #{id} AND member_id = #{memberId}
+    </update>
+
     <select id="existsActiveByMemberId" resultType="boolean">
         SELECT EXISTS(
             SELECT 1 FROM goal WHERE member_id = #{memberId} AND status = 'ACTIVE'

--- a/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
@@ -431,6 +431,11 @@ class GoalDetailServiceImplTest {
         public List<Long> findAllActiveGoalIds() {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public int update(Goal goal) {
+            throw new UnsupportedOperationException();
+        }
     }
 
     private static class FakeGoalHousingMapper implements GoalHousingMapper {
@@ -455,6 +460,11 @@ class GoalDetailServiceImplTest {
 
         @Override
         public void insert(GoalHousing goalHousing) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int update(GoalHousing goalHousing) {
             throw new UnsupportedOperationException();
         }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #57 

close #57 

## 📝 작업 내용

**`PUT /api/v1/goals/{goalId}`** 를 추가했습니다.

### 메인 로직 (`GoalServiceImpl.updateGoal`)

**1) 입력 검증 — `validateAndBuildHousing(request)`**

DB에 손대기 전에 먼저 돕니다. `validateMonthlySavings` / `validateRange`(평수·보증금) / `validateTargetDate`로 값을 보고, `HousingType.valueOf` · `DealType.valueOf`로 enum을 만든 뒤 `validateMonthlyRentRequired`로 월세 거래인데 상한이 빠졌는지 봅니다. 이어 `normalizeMonthlyRent`가 **전세면 요청값과 무관하게 월세를 0으로 눌러** 저장 형태로 맞추고, 월세일 때만 그 범위를 다시 검증합니다.

이 메서드는 검증 결과를 `GoalHousing`으로 조립해 돌려줍니다. `goalId`는 채우지 않습니다 — 생성은 insert 후에야 id를 알고, 수정은 호출부가 이미 아는 값이기 때문입니다.

**생성과 글자 단위로 같은 로직이라 `createGoal`에서 추출해 둘이 공유합니다.**

**2) 인가와 상태 확인**

`findOwnedGoal(memberId, goalId)`로 목표를 가져옵니다. 없으면 `GOAL_NOT_FOUND`(404), 다른 회원 것이면 `GOAL_FORBIDDEN`(403). 시뮬레이션 API와 같은 메서드입니다. 이어서 `status`가 `ACTIVE`가 아니면 `GOAL_NOT_ACTIVE`(409) — 이미 달성했거나 보관한 목표는 수정 대상이 아닙니다. 마지막으로 `assetService.validateConnectedAccountExists`로 자산 연동을 확인합니다(생성과 동일 전제).

**3) 저장 — 두 테이블 + 캐시 두 개**

목표 하나를 고치는 데 네 곳이 함께 움직입니다.

| 대상 | 하는 일 |
| --- | --- |
| `goal` | `goalMapper.update` — 금액·중앙값·목표 시점·월 저축액만. `status`·`goal_type`·`member_id`는 건드리지 않고, `updated_at`은 DDL의 `ON UPDATE`가 갱신 |
| `goal_housing` | `goalHousingMapper.update` — 주거 조건 통째로 교체 |
| `asset_summary` | `assetSummaryService.updateMonthlySavings` — `assets/summary` 화면이 읽는 월 저축액 캐시 동기화 |
| Redis | `goalMarketTrendCacheStore.delete` — 「매물 시세 변화」 캐시 무효화 |

뒤의 두 개가 이 PR에서 놓치기 쉬운 부분입니다.

`asset_summary.monthly_savings`는 생성 시점에도 같이 갱신하고 있습니다(#52와 같은 이유). 안 하면 목표는 바뀌었는데 자산 요약 화면의 월 저축액만 옛 값으로 남습니다.

시세 변화 캐시(`goal:market-trend:{goalId}`, TTL 35일)는 `computeMarketTrend`가 `goal`과 `goal_housing`을 통째로 입력으로 쓰기 때문에 — `regionCode`→지역명, 조건 전체→실거래 재조회, `targetRentMiddleAmount`→`initialMiddleAmount`, `targetDate`→`maintainEta` — 목표를 고치는 순간 전부 stale해집니다. 갱신 시점이 **매월 1일 배치 아니면 TTL 만료**뿐이라 그냥 두면 최대 한 달 가까이 옛 조건 기준 숫자가 노출됩니다. `refreshMarketTrend`를 다시 부르는 방법도 있었지만 수정 트랜잭션 안으로 국토부 API 호출과 `GOAL_NO_MARKET_DATA`까지 끌고 들어와서, 지우기만 하고 다음 조회의 캐시 미스 경로가 새 조건으로 계산하게 뒀습니다.

**4) 응답 조립 — `toGoalResponse(goal, housing)`**

저장 후 `goalMapper.findById`로 다시 읽어 응답을 만듭니다. `updated_at`이 DB에서 갱신되는 값이라 어차피 재조회가 필요합니다.

요청이 아니라 **저장된 도메인 객체에서** 조립하는 게 포인트입니다. 전세 요청에 월세 값을 실어 보내도 응답에는 정규화된 0이 나가고, 실제로 저장된 것과 응답이 갈라질 수 없습니다.

### 구현 내용

- **`GoalCreateRequest` → `GoalSaveRequest` 리네임** — 생성·수정이 같은 요청 스키마라 DTO를 공용화했습니다. 필드와 검증 애너테이션은 그대로여서 JSON 계약은 바뀌지 않습니다
- **`GoalResponse`에 `updatedAt` 추가**
- **매퍼 2개에 `update` 추가** — `goal`은 4개 컬럼만 SET하고 `WHERE id AND member_id`로 소유권 이중 안전장치를 뒀습니다. `goal_housing`은 전 컬럼 NOT NULL이라 부분 수정이 불가능해 전체 교체입니다(PUT을 택한 이유이기도 합니다)
- **`GoalMarketTrendCacheStore.delete` 추가**
- **`validateAndBuildHousing` / `toGoalResponse` 추출** — 생성·수정 공용. `createGoal` 본문이 72줄에서 30줄로 줄었습니다
- **`createGoal`의 `createdAt`이 DB 값으로 바뀝니다** — 기존에는 `LocalDateTime.now()`(자바 시각)를 응답에 넣고 있었습니다. 수정 응답이 `updatedAt` 때문에 어차피 재조회를 하는데 생성만 자바 시각을 쓰면 같은 DTO에서 시각의 출처가 엔드포인트마다 달라져서, 둘 다 재조회 값으로 통일했습니다. 프론트에서 `createdAt`을 쓰지 않는 것은 확인했습니다. 대신 생성 경로에 PK SELECT가 한 번 늘었습니다
- **`GoalController`에 `@PutMapping("/{goalId}")` 추가** — 기존 `AssetController.updateManualAsset` 선례대로 전체 교체는 PUT

에러코드는 새로 만들지 않았습니다. 명세서 초안의 `GOAL_INVALID_INPUT`(400 한 덩어리) 대신 생성 API가 이미 쓰는 `GOAL_INVALID_RANGE` / `GOAL_INVALID_DATE` / `GOAL_MONTHLY_SAVINGS_ZERO` / `GOAL_MONTHLY_RENT_REQUIRED`를 그대로 씁니다.

### 테스트

기존 106개가 그대로 통과합니다(34개는 DB 필요해서 skip).

**매퍼 인터페이스에 `update`를 추가하면서 테스트 컴파일이 깨졌습니다.** `GoalDetailServiceImplTest`가 Mockito 대신 손으로 구현한 Fake 매퍼를 쓰고 있어서입니다. 다른 미사용 메서드들과 같이 `UnsupportedOperationException`으로 채웠습니다(해당 테스트는 조회만 합니다).

로컬 Tomcat + MySQL + Redis로 Postman 확인을 마쳤습니다. 정상 수정 후 `goal` / `goal_housing` / `asset_summary`가 모두 바뀌는 것, `redis-cli GET goal:market-trend:{goalId}`가 `(nil)`이 되는 것, 그리고 404 · 409(`ACHIEVED`로 바꾼 뒤) · 400 3종을 직접 확인했습니다. `local` 프로필은 `memberId`가 1로 고정이라 403만 재현하지 못했습니다.

Notion 「목표 수정」 명세서도 확정 스펙으로 갱신해뒀습니다.

### 스크린샷 (선택)

<img width="632" height="754" alt="image" src="https://github.com/user-attachments/assets/d5686f21-fc76-44e6-aff8-4da6c1e85a41" />