### PR TITLE
feat(goal): 목표 삭제 API 구현

### DIFF
--- a/src/main/java/com/team/independence/goal/controller/GoalController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalController.java
@@ -14,6 +14,7 @@ import com.team.independence.goal.service.GoalDetailService;
 import com.team.independence.goal.service.GoalService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -51,6 +52,14 @@ public class GoalController {
             @PathVariable Long goalId,
             @Valid @RequestBody GoalSaveRequest request) {
         return ApiResponse.ok(goalService.updateGoal(memberId, goalId, request));
+    }
+
+    @DeleteMapping("/{goalId}")
+    public ApiResponse<Void> deleteGoal(
+            @LoginMember Long memberId,
+            @PathVariable Long goalId) {
+        goalService.deleteGoal(memberId, goalId);
+        return ApiResponse.ok(null);
     }
 
     @GetMapping("/{goalId}/detail")

--- a/src/main/java/com/team/independence/goal/mapper/GoalMapper.java
+++ b/src/main/java/com/team/independence/goal/mapper/GoalMapper.java
@@ -15,6 +15,13 @@ public interface GoalMapper {
      */
     int update(Goal goal);
 
+    /**
+     * 목표를 ARCHIVED로 내린다(소프트 삭제). 행을 지우지 않는 이유는 goal을 참조하는 FK 세 개에
+     * ON DELETE CASCADE가 없고, 그중 goal_snapshot은 지우면 과거 또래 비교 집계가 소급해서 바뀌기 때문이다.
+     * member_id와 status를 조건에 함께 걸어 소유자가 아니거나 이미 ACTIVE가 아니면 0건이 된다.
+     */
+    int archive(@Param("goalId") Long goalId, @Param("memberId") Long memberId);
+
     /** 회원에게 ACTIVE 목표가 이미 있는지 확인한다(동시 ACTIVE 목표는 1개만 허용). */
     boolean existsActiveByMemberId(@Param("memberId") Long memberId);
 

--- a/src/main/java/com/team/independence/goal/service/GoalService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalService.java
@@ -24,6 +24,13 @@ public interface GoalService {
     GoalResponse updateGoal(Long memberId, Long goalId, GoalSaveRequest request);
 
     /**
+     * 목표를 삭제한다. 실제로는 status를 ARCHIVED로 내리는 소프트 삭제라 저축 기록과 또래 비교
+     * 스냅샷은 그대로 남는다. 목표가 없으면 GOAL_NOT_FOUND, 다른 회원의 목표면 GOAL_FORBIDDEN,
+     * 이미 삭제했거나 달성한 목표면 GOAL_NOT_ACTIVE.
+     */
+    void deleteGoal(Long memberId, Long goalId);
+
+    /**
      * 목표를 찾고 요청자가 소유자인지 확인한다.
      * 목표가 없으면 GOAL_NOT_FOUND, 다른 회원의 목표면 GOAL_FORBIDDEN.
      */

--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -247,6 +247,31 @@ public class GoalServiceImpl implements GoalService {
     }
 
     /**
+     * 목표를 삭제한다. 행을 지우지 않고 status만 ARCHIVED로 내린다.
+     *
+     * <p>goal을 참조하는 FK 세 개(goal_housing, saving_record, goal_snapshot)에 ON DELETE CASCADE가
+     * 없어 물리 삭제는 제약 위반이고, 특히 goal_snapshot은 또래 비교 집계가 회원 구분 없이
+     * 기준월·순자산·나이로만 묶여 있어 지우면 과거 통계가 소급해서 바뀐다.
+     *
+     * <p>ARCHIVED가 되면 목표 생성을 막는 조건(ACTIVE 목표 존재)에서 빠지므로 새 목표를 만들 수 있다.
+     * asset_summary.monthly_savings는 건드리지 않는다 — 목표가 없으면 화면에 쓰이지 않고
+     * 새 목표를 만들면 그때 덮어쓴다.
+     */
+    @Override
+    @Transactional
+    public void deleteGoal(Long memberId, Long goalId) {
+        Goal goal = findOwnedGoal(memberId, goalId);
+        if (!GOAL_STATUS_ACTIVE.equals(goal.getStatus())) {
+            throw new BusinessException(ErrorCode.GOAL_NOT_ACTIVE);
+        }
+
+        goalMapper.archive(goalId, memberId);
+
+        // 시세 변화 캐시는 TTL이 35일이라 지우지 않으면 삭제한 목표의 데이터가 한 달 넘게 남는다
+        goalMarketTrendCacheStore.delete(goalId);
+    }
+
+    /**
      * 생성·수정 공통. 희망 조건을 진단과 같은 규칙으로 검증하고 goal_housing 저장 형태로 정규화한다.
      * goalId는 아직 모르거나(생성) 호출부가 이미 아는 값(수정)이라 여기서 채우지 않는다.
      */

--- a/src/main/resources/mybatis/mapper/goal/GoalMapper.xml
+++ b/src/main/resources/mybatis/mapper/goal/GoalMapper.xml
@@ -39,6 +39,14 @@
          WHERE id = #{id} AND member_id = #{memberId}
     </update>
 
+    <update id="archive">
+        UPDATE goal
+           SET status = 'ARCHIVED'
+         WHERE id        = #{goalId}
+           AND member_id = #{memberId}
+           AND status    = 'ACTIVE'
+    </update>
+
     <select id="existsActiveByMemberId" resultType="boolean">
         SELECT EXISTS(
             SELECT 1 FROM goal WHERE member_id = #{memberId} AND status = 'ACTIVE'

--- a/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
@@ -436,6 +436,11 @@ class GoalDetailServiceImplTest {
         public int update(Goal goal) {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public int archive(Long goalId, Long memberId) {
+            throw new UnsupportedOperationException();
+        }
     }
 
     private static class FakeGoalHousingMapper implements GoalHousingMapper {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #60 

close #60 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 상세하게 설명해주세요(이미지 첨부 가능)

**`DELETE /api/v1/goals/{goalId}`** 를 추가했습니다.

**행을 지우지 않고 `status`를 `ARCHIVED`로 내리는 소프트 삭제입니다.** 이 PR에서 제일 중요한 판단이라 근거를 먼저 적습니다.

`goal(id)`를 참조하는 FK가 세 개인데(`goal_housing`, `saving_record`, `goal_snapshot`) 셋 다 `ON DELETE CASCADE`가 없어서, `goal` 행만 지우면 제약 위반으로 실패합니다. 자식까지 지우면 되지 않느냐가 문제인데 **`goal_snapshot`을 지우면 안 됩니다.** 또래 비교 집계 쿼리(`GoalSnapshotMapper.xml`의 `cohortWhere`)가 회원 구분 없이 `snapshot_ym` + 순자산 + 나이로만 묶기 때문에, 한 사람의 스냅샷을 지우면 **이미 확정된 과거 달의 또래 평균·달성률 분포·인기 지역 TOP 3가 소급해서 바뀝니다.** 내 목표를 지웠는데 남의 통계가 흔들리는 셈입니다. `saving_record`(월별 저축 기록)도 같은 이유로 남깁니다.

소프트 삭제로 기능이 부족하지도 않습니다. 목표 생성을 막는 조건은 `existsActiveByMemberId`(= `status = 'ACTIVE'`) 하나뿐이라 **`ARCHIVED`가 된 목표는 새 목표 생성을 막지 않고**, 또래 비교의 `findLiveByMember`도 이미 `g.status = 'ACTIVE'` 조건을 걸고 있어 **별도 처리 없이 자동으로 빠집니다.**

### 메인 로직 (`GoalServiceImpl.deleteGoal`)

**1) 인가와 상태 확인**

`findOwnedGoal(memberId, goalId)`로 목표를 가져옵니다. 없으면 `GOAL_NOT_FOUND`(404), 다른 회원 것이면 `GOAL_FORBIDDEN`(403). 수정·시뮬레이션 API와 같은 메서드를 그대로 씁니다.

이어서 `status`가 `ACTIVE`가 아니면 `GOAL_NOT_ACTIVE`(409)입니다. 두 경우를 막습니다 — **이미 삭제한 목표를 다시 삭제**하는 것과, **`ACHIEVED` 목표를 삭제**하는 것. 후자는 달성 기록이라 지울 대상이 아니라고 봤습니다.

재삭제를 멱등하게 200으로 넘기지 않고 409로 둔 건, 이 API가 확인 모달을 거쳐 호출되는 동작이라 자동 재시도가 드물고 프론트가 "삭제 실패"와 "이미 삭제됨"을 구분할 수 있는 편이 낫다고 판단해서입니다.

**2) 아카이브 — `goalMapper.archive(goalId, memberId)`**

`UPDATE goal SET status = 'ARCHIVED'`를 `WHERE id = ? AND member_id = ? AND status = 'ACTIVE'`로 겁니다. 서비스에서 이미 소유권과 상태를 확인했지만, 요청이 겹쳐 들어와도 두 번 아카이브되지 않게 조건을 SQL에도 남겼습니다. `updated_at`은 DDL의 `ON UPDATE`가 갱신합니다.

메서드 이름을 `delete`가 아니라 **`archive`** 로 둔 건, 실제 동작이 상태 변경이라 `delete`라고 부르면 호출부에서 행이 사라진다고 오해하기 때문입니다.

**3) 캐시 정리 — `goalMarketTrendCacheStore.delete(goalId)`**

「매물 시세 변화」 캐시(`goal:market-trend:{goalId}`)를 지웁니다. 이 캐시의 갱신 시점이 **매월 1일 배치 아니면 TTL 35일 만료**뿐이라, 안 지우면 삭제된 목표의 시세 데이터가 한 달 넘게 Redis에 남습니다. 수정 PR에서 추가한 메서드를 그대로 씁니다.

### 구현 내용

- **`GoalMapper.archive` 추가** — 소프트 삭제 UPDATE. `WHERE`에 `member_id`와 `status='ACTIVE'`를 함께 검
- **`GoalService.deleteGoal` 추가** — 반환값이 없어 `void`
- **`GoalController`에 `@DeleteMapping("/{goalId}")` 추가** — 반환할 데이터가 없어 `AssetController.deleteManualAsset` 선례대로 `ApiResponse<Void>`

새로 만든 것은 매퍼 메서드 하나뿐입니다. 인가(`findOwnedGoal`)·상태 확인 패턴·캐시 삭제는 모두 기존 코드를 재사용했습니다. 에러코드도 추가하지 않았고 DDL 변경도 없습니다.

응답은 공통 포맷 그대로 `{"success": true, "data": null, "error": null}`입니다. 명세서 초안에 있던 `"message": "목표 삭제 성공"`과 `data: {goalId}`는 **실제 `ApiResponse`에 없는 형태**라 명세서 쪽을 코드에 맞춰 고쳤습니다.

### 스크린샷 (선택)

<img width="623" height="587" alt="image" src="https://github.com/user-attachments/assets/75805ec0-ceae-43c6-89f7-691e7dec26ae" />
