### PR TITLE
chore: CD 파이프라인 구축

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+.idea
+*.iml
+sql/
+docs/
+.env
+README.md

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,44 @@
+name: CD - Build & Push Image
+
+on:
+  push:
+    branches: [ develop ]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 소스 체크아웃
+        uses: actions/checkout@v4
+
+      - name: JDK 17 설정
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: WAR 빌드
+        run: ./mvnw clean package -DskipTests
+
+      - name: 빌드 결과 확인
+        run: ls -lh target/*.war
+
+      - name: Docker Hub 로그인
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: 이미지 빌드 & push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/nagasseum-backend:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/nagasseum-backend:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM tomcat:9-jdk17-temurin
+
+RUN rm -rf /usr/local/tomcat/webapps/*
+
+COPY target/independence-backend.war /usr/local/tomcat/webapps/ROOT.war
+
+ENV TZ=Asia/Seoul
+EXPOSE 8080


### PR DESCRIPTION
## #️⃣연관된 이슈

> #63 

## 📝작업 내용

develop 브랜치에 push가 발생하면 GitHub Actions가 자동으로 WAR을 빌드하고 Docker Hub에 이미지를 푸시하는 CD 파이프라인을 구축했습니다.

**`Dockerfile`**
  - 베이스 이미지: `tomcat:9-jdk17-temurin` (Spring 5.3 + javax.servlet 호환)
  - 기존 webapps 디렉터리를 비우고 빌드된 WAR을 `ROOT.war`로 배포 (컨텍스트 패스 `/` 유지)
  - `TZ=Asia/Seoul` 설정, 8080 포트 노출

  **`.dockerignore`**
  - `.git`, `.github`, `.idea`, `*.iml`, `sql/`, `docs/`, `.env`, `README.md` 제외
  - 빌드 컨텍스트에 소스 관련 파일만 포함해 이미지 크기 최소화

  **`.github/workflows/cd.yml`**
  - 트리거: `develop` 브랜치 push 및 `workflow_dispatch` (수동 실행)
  - Step 1: 소스 체크아웃 (`actions/checkout@v4`)
  - Step 2: JDK 17 설치 (`actions/setup-java@v4`, temurin 배포판, Maven 캐시)
  - Step 3: `./mvnw clean package -DskipTests` 로 WAR 빌드
  - Step 4: Docker Hub 로그인 (`docker/login-action@v3`)
  - Step 5: 이미지 빌드 & 푸시 (`docker/build-push-action@v6`)
    - 태그: `:latest` + `:${{ github.sha }}` (SHA 태그로 롤백 지원)
    - GitHub Actions 레이어 캐시 적용 (`cache-from/cache-to: type=gha`)

### 로컬 검증 완료
- `./mvnw clean package -DskipTests` → WAR 빌드 성공
- `docker build` → 이미지 빌드 성공
- `docker run --env-file .env` → Tomcat 기동, 헬스체크 200 응답 확인


### 스크린샷
<img width="1416" height="312" alt="스크린샷 2026-08-07 오전 11 41 37" src="https://github.com/user-attachments/assets/5a29b015-5e94-4a66-aba6-3981923dc3c6" />

<img width="777" height="252" alt="스크린샷 2026-08-07 오전 11 16 57" src="https://github.com/user-attachments/assets/0a363d7e-6ea4-44dc-a800-246b11d828ed" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?