### PR TITLE
fix: 드라이버 설정 추가로 GHA 캐시 오류 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Buildx 설정
+        uses: docker/setup-buildx-action@v3
+
       - name: 이미지 빌드 & push
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## #️⃣연관된 이슈

> #64

## 📝작업 내용

GHA 캐시는 docker 드라이버에서 지원되지 않아 docker-container 드라이버를 먼저 세팅했습니다.

### 스크린샷
<img width="977" height="491" alt="스크린샷 2026-08-07 오전 11 49 30" src="https://github.com/user-attachments/assets/dd499e19-dcad-4722-8f5e-5d8f5868870d" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?