### PR TITLE
feat: 목표 조회 API 구현

### DIFF
--- a/src/main/java/com/team/independence/goal/controller/GoalController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalController.java
@@ -46,6 +46,13 @@ public class GoalController {
         return ApiResponse.ok(goalService.createGoal(memberId, request));
     }
 
+    @GetMapping("/{goalId}")
+    public ApiResponse<GoalResponse> getGoal(
+            @LoginMember Long memberId,
+            @PathVariable Long goalId) {
+        return ApiResponse.ok(goalService.getGoal(memberId, goalId));
+    }
+
     @PutMapping("/{goalId}")
     public ApiResponse<GoalResponse> updateGoal(
             @LoginMember Long memberId,

--- a/src/main/java/com/team/independence/goal/service/GoalService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalService.java
@@ -17,6 +17,13 @@ public interface GoalService {
     GoalResponse createGoal(Long memberId, GoalSaveRequest request);
 
     /**
+     * 목표 하나를 조회한다. 수정 화면의 폼을 기존 값으로 채우는 용도라 생성·수정과 같은 응답을 쓴다.
+     * 목표가 없으면 GOAL_NOT_FOUND, 다른 회원의 목표면 GOAL_FORBIDDEN.
+     * 상태는 보지 않는다 — 삭제(ARCHIVED)하거나 달성(ACHIEVED)한 목표도 조회된다.
+     */
+    GoalResponse getGoal(Long memberId, Long goalId);
+
+    /**
      * 목표의 금액·시점·월 저축액과 주거 희망 조건을 통째로 교체한다.
      * 목표가 없으면 GOAL_NOT_FOUND, 다른 회원의 목표면 GOAL_FORBIDDEN,
      * 진행 중이 아닌 목표면 GOAL_NOT_ACTIVE.

--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -211,6 +211,18 @@ public class GoalServiceImpl implements GoalService {
     }
 
     /**
+     * 목표 하나를 조회한다. 수정 화면이 폼을 채우는 데 쓰므로 응답은 생성·수정과 같은 GoalResponse다.
+     * 상태로 거르지 않는다 — 삭제는 행을 지우지 않는 소프트 삭제고, 지난 목표 열람을 막을 이유가 없다.
+     * 수정 가능 여부는 updateGoal의 GOAL_NOT_ACTIVE가 판정한다.
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public GoalResponse getGoal(Long memberId, Long goalId) {
+        Goal goal = findOwnedGoal(memberId, goalId);
+        return toGoalResponse(goal, goalHousingMapper.findByGoalId(goalId));
+    }
+
+    /**
      * 목표의 조건을 통째로 교체한다. 저장 계약은 생성과 같다 — 프론트가 진단을 다시 호출해 받은
      * targetAmount/targetRentMiddleAmount를 실어 보내면 서버는 재계산 없이 그대로 고정 저장한다.
      * 이미 끝난(ACHIEVED/ARCHIVED) 목표는 수정할 수 없다.


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #67 

close #67 

## 📝 작업 내용

**`GET /api/v1/goals/{goalId}`** 를 추가했습니다.

**1) 조회 전용 DTO를 만들지 않고 기존 `GoalResponse`를 그대로 씁니다.**

**2) `status`로 거르지 않습니다. `ARCHIVED`·`ACHIEVED` 목표도 조회됩니다.**

### 메인 로직 (`GoalServiceImpl.getGoal`)

**1) 인가 — `findOwnedGoal(memberId, goalId)`**

목표를 가져오면서 소유권까지 확인합니다. 목표가 없으면 `GOAL_NOT_FOUND`(404), 다른 회원 것이면 `GOAL_FORBIDDEN`(403). 수정·삭제·시뮬레이션과 **같은 메서드**라 인가 규칙이 한 곳에만 있습니다.

`goalId`가 URL에 그대로 드러나는 API라 이 검사가 없으면 남의 목표(지역·보증금·월 저축액)가 그대로 노출됩니다. 없는 목표를 404, 남의 목표를 403으로 구분하는 건 기존 API들과 맞춘 것입니다.

**2) 주거 조건 조회 — `goalHousingMapper.findByGoalId(goalId)`**

`goal`과 `goal_housing`이 1:1이라 두 번 조회해 합칩니다. 조인 쿼리를 새로 만들지 않은 건, `findByGoalId`가 이미 있는데 같은 데이터를 읽는 SQL을 하나 더 두면 컬럼이 늘 때마다 두 곳을 고쳐야 하기 때문입니다. 조회 2회는 단건 PK 조회라 비용이 문제 되는 구간이 아닙니다.

**3) 응답 조립 — `toGoalResponse(goal, goalHousing)`**

생성·수정이 쓰던 private 메서드를 그대로 재사용합니다. 여기서 `goal.targetDate`(DB는 `DATE`, 매달 1일로 저장)가 `YearMonth`로 바뀌어 `"2029-07"`로 내려가고, `HousingType`·`DealType` enum이 `name()`으로 문자열이 됩니다. 즉 **응답 형태가 세 API에서 자동으로 같습니다** — 나중에 필드를 추가해도 세 곳이 함께 따라옵니다.

전세(`JEONSE`) 목표의 `monthlyRentMin`/`monthlyRentMax`는 `null`이 아니라 `0`입니다. 저장할 때 `normalizeMonthlyRent`가 0으로 정규화하고 이 API는 저장된 값을 그대로 읽기 때문입니다.

`@Transactional(readOnly = true)`를 붙였습니다. 쓰기가 없는 경로라 다른 조회 서비스들과 맞췄습니다.

### 구현 내용

- **`GoalService.getGoal` 추가** — 반환 타입은 생성·수정과 같은 `GoalResponse`
- **`GoalServiceImpl.getGoal` 구현** — `findOwnedGoal` → `findByGoalId` → `toGoalResponse` 3줄
- **`GoalController`에 `@GetMapping("/{goalId}")` 추가** — `@LoginMember`로 회원을 받아 `ApiResponse.ok`로 감쌈

같은 클래스의 `GET /summary`, `GET /market-trend`와 경로 패턴이 겹치지만, Spring이 리터럴 패턴을 경로 변수보다 먼저 매칭하므로 기존 두 엔드포인트는 그대로 동작합니다.

### 스크린샷 (선택)

<img width="514" height="772" alt="image" src="https://github.com/user-attachments/assets/cb248e02-2313-4d49-99d5-bacd7526c183" />
