### PR TITLE
fix: 국토부 실거래 금액 단위 변환 수정

### DIFF
--- a/src/main/java/com/team/independence/property/service/RentTransactionSyncServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/RentTransactionSyncServiceImpl.java
@@ -246,9 +246,9 @@ public class RentTransactionSyncServiceImpl implements RentTransactionSyncServic
      * API 응답 필드명/형식이 DB 컬럼과 달라서 여기서 정제한다.
      */
     private RentTransaction toRentTransaction(RentItemDto dto, HousingType housingType, String regionCode) {
-        // "24,000" 형태의 금액 → 콤마 제거 후 숫자 문자열로
-        String deposit = parseAmount(dto.getDeposit());
-        long monthlyRent = parseLong(parseAmount(dto.getMonthlyRent()));
+        // "24,000" 형태의 금액 → 콤마 제거 후 원 단위로 변환 (국토부는 만원 단위로 반환)
+        long deposit = parseLong(parseAmount(dto.getDeposit())) * 10_000;
+        long monthlyRent = parseLong(parseAmount(dto.getMonthlyRent())) * 10_000;
 
         // dealYear("2015") + dealMonth("12") → dealYm("201512")
         String dealYm = dto.getDealYear().trim()
@@ -265,7 +265,7 @@ public class RentTransactionSyncServiceImpl implements RentTransactionSyncServic
             .complexName(dto.getComplexName())          // 4종 단지명 헬퍼로 통일
             .area(area != null ? new BigDecimal(area) : BigDecimal.ZERO)
             .dealType(DealType.from(monthlyRent))
-            .deposit(parseLong(deposit))
+            .deposit(deposit)
             .monthlyRent(monthlyRent)
             .floor(parseInteger(dto.getFloor()))
             .buildYear(parseInteger(dto.getBuildYear()))


### PR DESCRIPTION
## #️⃣연관된 이슈

> #70 

## 📝작업 내용

국토부 실거래가 API가 금액을 만원 단위로 반환하지만 `toRentTransaction()`에서 변환 없이 그대로 DB에 저장하고 있었습니다. 목표 진단 쿼리는 원 단위로 필터링하기 때문에 조건을 전혀 통과하지 못해 항상 `GOAL_NO_MARKET_DATA` 에러가 발생했습니다.

### 수정 내용 (`RentTransactionSyncServiceImpl.toRentTransaction`)
  
```java
// 수정 전
String deposit = parseAmount(dto.getDeposit());
long monthlyRent = parseLong(parseAmount(dto.getMonthlyRent()));
  
// 수정 후 — MOLIT은 만원 단위로 반환하므로 × 10,000 하여 원 단위로 변환
long deposit = parseLong(parseAmount(dto.getDeposit())) * 10_000;
long monthlyRent = parseLong(parseAmount(dto.getMonthlyRent())) * 10_000;
```
 
이미 적재된 데이터도 단위 변환이 필요해서 일단 UPDATE 쿼리를 직접 실행했습니다.

```sql
UPDATE rent_transaction
SET deposit = deposit * 10000,
    monthly_rent = monthly_rent * 10000;
```


### 스크린샷
<img width="1005" height="677" alt="스크린샷 2026-08-07 오후 4 59 27" src="https://github.com/user-attachments/assets/6c74d677-afad-4592-bcda-2feb5cb3e2c5" />

<img width="1005" height="747" alt="스크린샷 2026-08-07 오후 5 00 54" src="https://github.com/user-attachments/assets/b29b20f3-fad6-4f06-a695-01be4b73bc17" />

<img width="1006" height="743" alt="스크린샷 2026-08-07 오후 5 01 23" src="https://github.com/user-attachments/assets/766a530c-1710-4a06-8a4a-f35c85ccb526" />

<img width="1006" height="850" alt="스크린샷 2026-08-07 오후 5 01 59" src="https://github.com/user-attachments/assets/74689f53-cc3f-4376-893e-c3fc66c5afdf" />

<img width="999" height="726" alt="스크린샷 2026-08-07 오후 5 03 14" src="https://github.com/user-attachments/assets/c321fcf0-c4bb-481f-87b0-b1688ea97034" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?