### PR TITLE
feat: 독립 목표 추천 API 인터페이스 설계

### DIFF
--- a/src/main/java/com/team/independence/common/exception/ErrorCode.java
+++ b/src/main/java/com/team/independence/common/exception/ErrorCode.java
@@ -47,6 +47,8 @@ public enum ErrorCode {
     GOAL_FORBIDDEN("GOAL_008", "접근할 수 없는 목표입니다.", HttpStatus.FORBIDDEN),
     GOAL_INVALID_INPUT("GOAL_009", "월 저축액은 0보다 커야 합니다.", HttpStatus.BAD_REQUEST),
     GOAL_NOT_ACTIVE("GOAL_010", "진행 중인 목표가 아닙니다.", HttpStatus.CONFLICT),
+    GOAL_RECOMMENDATION_NO_CANDIDATE("GOAL_011", "추천 가능한 주거 후보가 없습니다.", HttpStatus.NOT_FOUND),
+    GOAL_ASSET_REQUIRED("GOAL_012", "추천을 위해 자산 연동이 필요합니다.", HttpStatus.BAD_REQUEST),
 
     // ===== 또래 비교 COMPARE_xxx =====
     COMPARE_SNAPSHOT_NOT_FOUND("COMPARE_001", "비교할 집계 데이터가 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/team/independence/goal/controller/GoalRecommendationController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalRecommendationController.java
@@ -1,0 +1,28 @@
+package com.team.independence.goal.controller;
+
+import com.team.independence.common.annotation.LoginMember;
+import com.team.independence.common.response.ApiResponse;
+import com.team.independence.goal.dto.GoalRecommendationRequest;
+import com.team.independence.goal.dto.GoalRecommendationResponse;
+import com.team.independence.goal.service.GoalRecommendationService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/goals")
+@RequiredArgsConstructor
+public class GoalRecommendationController {
+
+    private final GoalRecommendationService recommendationService;
+
+    @PostMapping("/recommendations")
+    public ApiResponse<GoalRecommendationResponse> recommend(
+            @LoginMember Long memberId,
+            @Valid @RequestBody GoalRecommendationRequest request) {
+        return ApiResponse.ok(recommendationService.recommend(memberId, request));
+    }
+}

--- a/src/main/java/com/team/independence/goal/dto/CandidateStat.java
+++ b/src/main/java/com/team/independence/goal/dto/CandidateStat.java
@@ -1,0 +1,27 @@
+package com.team.independence.goal.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Getter;
+
+/** RentCandidateStatMapper 조회 결과를 담는 내부 전달 객체. 5평 단위 구간화된 통계. */
+@Getter
+@Builder
+public class CandidateStat {
+    private String regionCode;
+    private HousingType housingType;
+    private DealType dealType;
+    /** 면적 구간 하한 (평, FLOOR(area / 3.3058 / 5) * 5) */
+    private int areaRangeStart;
+    /** 면적 구간 상한 (평, areaRangeStart + 5) */
+    private int areaRangeEnd;
+    private long p25Deposit;
+    private long medianDeposit;
+    private long p75Deposit;
+    /** WOLSE만 의미 있음. JEONSE = 0 */
+    private long medianMonthlyRent;
+    private BigDecimal pricePerPyeong;
+    private int sampleCount;
+}

--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationRequest.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationRequest.java
@@ -11,13 +11,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class GoalRecommendationRequest {
 
-    @NotNull
     private String regionCode;
 
     /** 선택. null이면 전 주거유형 탐색 */
     private HousingType propertyType;
 
-    @NotNull
     private DealType tradeType;
 
     /** 선택. 단위: 평. null이면 10~30평 전 구간 자동 탐색 */
@@ -26,6 +24,5 @@ public class GoalRecommendationRequest {
     /** 선택. 단위: 평. null이면 10~30평 전 구간 자동 탐색 */
     private Integer sizeMax;
 
-    @NotNull
     private YearMonth targetDate;
 }

--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationRequest.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationRequest.java
@@ -1,0 +1,31 @@
+package com.team.independence.goal.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import java.time.YearMonth;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GoalRecommendationRequest {
+
+    @NotNull
+    private String regionCode;
+
+    /** 선택. null이면 전 주거유형 탐색 */
+    private HousingType propertyType;
+
+    @NotNull
+    private DealType tradeType;
+
+    /** 선택. 단위: 평. null이면 10~30평 전 구간 자동 탐색 */
+    private Integer sizeMin;
+
+    /** 선택. 단위: 평. null이면 10~30평 전 구간 자동 탐색 */
+    private Integer sizeMax;
+
+    @NotNull
+    private YearMonth targetDate;
+}

--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
@@ -2,7 +2,6 @@ package com.team.independence.goal.dto;
 
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
-import java.math.BigDecimal;
 import java.time.YearMonth;
 import java.util.List;
 import lombok.Builder;
@@ -12,65 +11,47 @@ import lombok.Getter;
 @Builder
 public class GoalRecommendationResponse {
 
-    /** 최대 4개 (PREFERENCE / REALISTIC / VALUE / HOLD_OUT) */
     private List<RecommendationItem> recommendations;
 
     @Getter
     @Builder
     public static class RecommendationItem {
-        private RecommendationType type;
-        /** 예: "니 맘대로 해 형" */
         private String title;
-        /** 추천 이유 템플릿 문자열 */
         private String reason;
-        private HousingCandidate housing;
-        /** 슬라이더용 — targetDate −12 ~ +36개월, 6개월 단위, 최대 9개 */
-        private List<PeriodPlan> plans;
-        private int score;
+        private Condition condition;
+        /** 대출 없는 플랜 */
+        private LoanXPlan loanX;
+        /** 대출 있는 플랜 */
+        private LoanOPlan loanO;
     }
 
     @Getter
     @Builder
-    public static class HousingCandidate {
+    public static class Condition {
         private String regionCode;
         private String regionName;
         private HousingType housingType;
         private DealType dealType;
-        private int areaRangeStart;
-        private int areaRangeEnd;
-        private long p25;
-        private long median;
-        private long p75;
-        private BigDecimal pricePerPyeong;
-        private int sampleCount;
+        private int areaMin;
+        private int areaMax;
     }
 
     @Getter
     @Builder
-    public static class PeriodPlan {
+    public static class LoanXPlan {
+        private long targetAmount;
         private YearMonth targetDate;
-        /** 해당 시점의 예상 자산 */
-        private long expectedAsset;
-        private WithoutLoanPlan withoutLoan;
-        private WithLoanPlan withLoan;
+        private long monthlySaving;
     }
 
     @Getter
     @Builder
-    public static class WithoutLoanPlan {
-        private long requiredMonthlySaving;
-        /** expectedAsset >= median */
-        private boolean achievable;
-    }
-
-    @Getter
-    @Builder
-    public static class WithLoanPlan {
+    public static class LoanOPlan {
+        /** DSR 기준 최대 대출 가능액 */
         private long loanAmount;
-        private long monthlyRepayment;
-        /** median - loanAmount */
-        private long requiredEquity;
-        private long requiredMonthlySaving;
-        private boolean achievable;
+        /** median - loanAmount (자기 자금으로 모아야 할 금액) */
+        private long targetAmount;
+        private YearMonth targetDate;
+        private long monthlySaving;
     }
 }

--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
@@ -1,0 +1,76 @@
+package com.team.independence.goal.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import java.math.BigDecimal;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GoalRecommendationResponse {
+
+    /** 최대 4개 (PREFERENCE / REALISTIC / VALUE / HOLD_OUT) */
+    private List<RecommendationItem> recommendations;
+
+    @Getter
+    @Builder
+    public static class RecommendationItem {
+        private RecommendationType type;
+        /** 예: "니 맘대로 해 형" */
+        private String title;
+        /** 추천 이유 템플릿 문자열 */
+        private String reason;
+        private HousingCandidate housing;
+        /** 슬라이더용 — targetDate −12 ~ +36개월, 6개월 단위, 최대 9개 */
+        private List<PeriodPlan> plans;
+        private int score;
+    }
+
+    @Getter
+    @Builder
+    public static class HousingCandidate {
+        private String regionCode;
+        private String regionName;
+        private HousingType housingType;
+        private DealType dealType;
+        private int areaRangeStart;
+        private int areaRangeEnd;
+        private long p25;
+        private long median;
+        private long p75;
+        private BigDecimal pricePerPyeong;
+        private int sampleCount;
+    }
+
+    @Getter
+    @Builder
+    public static class PeriodPlan {
+        private YearMonth targetDate;
+        /** 해당 시점의 예상 자산 */
+        private long expectedAsset;
+        private WithoutLoanPlan withoutLoan;
+        private WithLoanPlan withLoan;
+    }
+
+    @Getter
+    @Builder
+    public static class WithoutLoanPlan {
+        private long requiredMonthlySaving;
+        /** expectedAsset >= median */
+        private boolean achievable;
+    }
+
+    @Getter
+    @Builder
+    public static class WithLoanPlan {
+        private long loanAmount;
+        private long monthlyRepayment;
+        /** median - loanAmount */
+        private long requiredEquity;
+        private long requiredMonthlySaving;
+        private boolean achievable;
+    }
+}

--- a/src/main/java/com/team/independence/goal/dto/RecommendationCandidate.java
+++ b/src/main/java/com/team/independence/goal/dto/RecommendationCandidate.java
@@ -6,22 +6,25 @@ import java.math.BigDecimal;
 import lombok.Builder;
 import lombok.Getter;
 
-/** RentCandidateStatMapper 조회 결과를 담는 내부 전달 객체. 5평 단위 구간화된 통계. */
+/**
+ * 스코링 엔진이 각 전략에 넘기는 후보 단위.
+ * DB 조회 결과(시세 통계)와 지역명을 함께 담는다.
+ */
 @Getter
 @Builder
-public class CandidateStat {
+public class RecommendationCandidate {
     private String regionCode;
+    private String regionName;
     private HousingType housingType;
     private DealType dealType;
-    /** 면적 구간 하한 (평, FLOOR(area / 3.3058 / 5) * 5) */
-    private int areaRangeStart;
-    /** 면적 구간 상한 (평, areaRangeStart + 5) */
-    private int areaRangeEnd;
-    private long p25Deposit;
+    private int areaMin;
+    private int areaMax;
+    /** 전세 보증금 or 월세 보증금 중앙값 */
     private long medianDeposit;
-    private long p75Deposit;
     /** WOLSE만 의미 있음. JEONSE = 0 */
     private long medianMonthlyRent;
+    /** VALUE 전략 평수 효율 점수에 사용 */
     private BigDecimal pricePerPyeong;
+    /** 신뢰도 점수에 사용 (최소 3건 필터 통과 후) */
     private int sampleCount;
 }

--- a/src/main/java/com/team/independence/goal/dto/RecommendationCandidate.java
+++ b/src/main/java/com/team/independence/goal/dto/RecommendationCandidate.java
@@ -23,8 +23,4 @@ public class RecommendationCandidate {
     private long medianDeposit;
     /** WOLSE만 의미 있음. JEONSE = 0 */
     private long medianMonthlyRent;
-    /** VALUE 전략 평수 효율 점수에 사용 */
-    private BigDecimal pricePerPyeong;
-    /** 신뢰도 점수에 사용 (최소 3건 필터 통과 후) */
-    private int sampleCount;
 }

--- a/src/main/java/com/team/independence/goal/dto/RecommendationType.java
+++ b/src/main/java/com/team/independence/goal/dto/RecommendationType.java
@@ -1,0 +1,12 @@
+package com.team.independence.goal.dto;
+
+public enum RecommendationType {
+    /** 선호도 최우선 — 입력 조건에 가장 잘 맞는 목표 */
+    PREFERENCE,
+    /** 현실성 최우선 — 소득·자산·달성 가능성을 고려한 현실적 목표 */
+    REALISTIC,
+    /** 가성비 최우선 — 평당 가격이 낮고 표본이 충분한 주거 */
+    VALUE,
+    /** 미래 가능성 최우선 — 더 모은 뒤 도달 가능한 더 좋은 목표 (+24~36개월) */
+    HOLD_OUT
+}

--- a/src/main/java/com/team/independence/goal/dto/ScoringContext.java
+++ b/src/main/java/com/team/independence/goal/dto/ScoringContext.java
@@ -1,0 +1,23 @@
+package com.team.independence.goal.dto;
+
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 각 추천 전략이 스코링에 필요한 모든 입력을 담는 컨텍스트.
+ * GoalRecommendationService가 조립해서 RecommendationScoringEngine에 넘긴다.
+ */
+@Getter
+@Builder
+public class ScoringContext {
+    private GoalRecommendationRequest request;
+    private AssetNetWorthBreakdown netWorth;
+    /** DSR 계산용 세전 월 소득 */
+    private long monthlyIncome;
+    /** 기존 대출의 추정 월 상환액 */
+    private long existingMonthlyRepayment;
+    /** CandidateService가 수집한 전체 후보 목록 */
+    private List<RecommendationCandidate> candidates;
+}

--- a/src/main/java/com/team/independence/goal/service/DsrCalculatorService.java
+++ b/src/main/java/com/team/independence/goal/service/DsrCalculatorService.java
@@ -1,0 +1,25 @@
+package com.team.independence.goal.service;
+
+/**
+ * DSR(총부채원리금상환비율) 기반 대출 한도 및 월 상환액 계산.
+ * 가정: 연 3.5%, 30년 원리금균등상환.
+ */
+public interface DsrCalculatorService {
+
+    /**
+     * DSR 40% 기준으로 최대 대출 가능액을 역산한다.
+     *
+     * @param monthlyIncome          세전 월 소득 (원)
+     * @param existingMonthlyRepayment 기존 대출의 월 상환액 (원)
+     * @return 신규 대출 가능 최대 금액 (원). DSR 한도 초과 시 0.
+     */
+    long calcMaxLoanAmount(long monthlyIncome, long existingMonthlyRepayment);
+
+    /**
+     * 잔여 대출 잔액을 30년 원리금균등상환 조건으로 환산한 월 상환액을 추정한다.
+     *
+     * @param loanBalance 현재 대출 잔액 합계 (원)
+     * @return 추정 월 상환액 (원)
+     */
+    long calcMonthlyRepayment(long loanBalance);
+}

--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationService.java
@@ -12,10 +12,9 @@ import com.team.independence.goal.dto.GoalRecommendationResponse;
  *   <li>순자산 분류 및 자산 요약 조회</li>
  *   <li>회원 소득 정보 조회 (DSR 계산용)</li>
  *   <li>후보군 생성 (빈 결과 → GOAL_RECOMMENDATION_NO_CANDIDATE)</li>
- *   <li>목표 시점 목록 생성 (targetDate −12 ~ +36개월, 6개월 단위)</li>
  *   <li>기존 대출 월 상환액 추정</li>
- *   <li>후보별 PeriodPlan 계산</li>
- *   <li>4전략 스코링 → 각 1개 선정</li>
+ *   <li>{@link com.team.independence.goal.dto.ScoringContext} 조립</li>
+ *   <li>{@link RecommendationScoringEngine#score}로 전략별 추천 실행</li>
  * </ol>
  */
 public interface GoalRecommendationService {

--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationService.java
@@ -1,0 +1,31 @@
+package com.team.independence.goal.service;
+
+import com.team.independence.goal.dto.GoalRecommendationRequest;
+import com.team.independence.goal.dto.GoalRecommendationResponse;
+
+/**
+ * 독립 목표 추천 진입점.
+ *
+ * <p>처리 순서:
+ * <ol>
+ *   <li>자산 연동 검증 (미연동 → GOAL_ASSET_REQUIRED)</li>
+ *   <li>순자산 분류 및 자산 요약 조회</li>
+ *   <li>회원 소득 정보 조회 (DSR 계산용)</li>
+ *   <li>후보군 생성 (빈 결과 → GOAL_RECOMMENDATION_NO_CANDIDATE)</li>
+ *   <li>목표 시점 목록 생성 (targetDate −12 ~ +36개월, 6개월 단위)</li>
+ *   <li>기존 대출 월 상환액 추정</li>
+ *   <li>후보별 PeriodPlan 계산</li>
+ *   <li>4전략 스코링 → 각 1개 선정</li>
+ * </ol>
+ */
+public interface GoalRecommendationService {
+
+    /**
+     * 회원의 재무 상태와 선호 조건을 바탕으로 독립 목표 4가지를 추천한다.
+     *
+     * @param memberId 요청 회원 ID
+     * @param req      추천 요청 파라미터
+     * @return 전략별 추천 결과 (최대 4개)
+     */
+    GoalRecommendationResponse recommend(long memberId, GoalRecommendationRequest req);
+}

--- a/src/main/java/com/team/independence/goal/service/RecommendationCandidateService.java
+++ b/src/main/java/com/team/independence/goal/service/RecommendationCandidateService.java
@@ -1,0 +1,24 @@
+package com.team.independence.goal.service;
+
+import com.team.independence.goal.dto.CandidateStat;
+import com.team.independence.goal.dto.GoalRecommendationRequest;
+import java.util.List;
+
+/**
+ * 추천 후보군 생성 — 요청 조건과 확장 조건으로 CandidateStat 목록을 수집한다.
+ *
+ * <ul>
+ *   <li>사용자 조건 그대로 조회 (PREFERENCE용)</li>
+ *   <li>housingType 제약 제거 (VALUE / REALISTIC용)</li>
+ *   <li>면적 구간 확장 (HOLD_OUT용)</li>
+ *   <li>sizeMin/sizeMax 미입력 시 10~30평 전 구간 자동 탐색</li>
+ * </ul>
+ */
+public interface RecommendationCandidateService {
+
+    /**
+     * 추천 가능한 전체 후보 통계 목록을 반환한다.
+     * 후보가 전혀 없으면 빈 리스트를 반환하고, 호출자가 GOAL_RECOMMENDATION_NO_CANDIDATE를 던진다.
+     */
+    List<CandidateStat> generateCandidates(GoalRecommendationRequest req);
+}

--- a/src/main/java/com/team/independence/goal/service/RecommendationCandidateService.java
+++ b/src/main/java/com/team/independence/goal/service/RecommendationCandidateService.java
@@ -1,11 +1,11 @@
 package com.team.independence.goal.service;
 
-import com.team.independence.goal.dto.CandidateStat;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
+import com.team.independence.goal.dto.RecommendationCandidate;
 import java.util.List;
 
 /**
- * 추천 후보군 생성 — 요청 조건과 확장 조건으로 CandidateStat 목록을 수집한다.
+ * 추천 후보군 생성 — 요청 조건과 확장 조건으로 후보 목록을 수집한다.
  *
  * <ul>
  *   <li>사용자 조건 그대로 조회 (PREFERENCE용)</li>
@@ -17,8 +17,8 @@ import java.util.List;
 public interface RecommendationCandidateService {
 
     /**
-     * 추천 가능한 전체 후보 통계 목록을 반환한다.
+     * 추천 가능한 전체 후보 목록을 반환한다.
      * 후보가 전혀 없으면 빈 리스트를 반환하고, 호출자가 GOAL_RECOMMENDATION_NO_CANDIDATE를 던진다.
      */
-    List<CandidateStat> generateCandidates(GoalRecommendationRequest req);
+    List<RecommendationCandidate> generateCandidates(GoalRecommendationRequest req);
 }

--- a/src/main/java/com/team/independence/goal/service/RecommendationScoringEngine.java
+++ b/src/main/java/com/team/independence/goal/service/RecommendationScoringEngine.java
@@ -1,14 +1,14 @@
 package com.team.independence.goal.service;
 
-import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
-import com.team.independence.goal.dto.CandidateStat;
-import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
-import java.util.List;
-import java.util.Map;
+import com.team.independence.goal.dto.ScoringContext;
 
 /**
- * 6개 지표를 0~100점으로 정규화한 뒤 전략별 가중치를 적용해 4가지 추천을 각각 1개씩 선정한다.
+ * 등록된 모든 {@link RecommendationStrategy}를 실행해 추천 결과를 조립한다.
+ *
+ * <p>구현체는 {@code List<RecommendationStrategy>}를 주입받아 각 전략을 순차 실행하고,
+ * {@link java.util.Optional#empty()}를 반환한 전략은 결과에서 제외한다.
+ * 테마 추가·삭제는 전략 클래스만 추가·제거하면 되며, 이 엔진은 수정하지 않는다.
  *
  * <p>가중치 행렬 (순서: 예산여유도 / 저축부담도 / 평수효율 / 신뢰도 / 달성기간 / 선호도):
  * <pre>
@@ -21,18 +21,10 @@ import java.util.Map;
 public interface RecommendationScoringEngine {
 
     /**
-     * 후보 목록과 각 후보의 시점별 계획을 받아 4전략을 스코링하고 최종 응답을 조립한다.
+     * 컨텍스트를 각 전략에 넘겨 실행하고, 전략별 최고 점수 결과를 모아 응답을 구성한다.
      *
-     * @param candidates 후보군 전체 (RecommendationCandidateService 결과)
-     * @param planMap    후보별 PeriodPlan 목록 (GoalRecommendationService에서 사전 계산)
-     * @param breakdown  회원 순자산 분류 (미래 자산 계산에 사용)
-     * @param req        원본 요청 (선호도 점수 계산에 사용)
-     * @return 전략별 최고 점수 후보 최대 4개
+     * @param context 스코링에 필요한 자산·소득·후보 목록을 담은 컨텍스트
+     * @return 전략별 추천 결과 (적합한 후보가 없는 전략은 결과에서 제외)
      */
-    GoalRecommendationResponse selectTop4(
-            List<CandidateStat> candidates,
-            Map<CandidateStat, List<GoalRecommendationResponse.PeriodPlan>> planMap,
-            AssetNetWorthBreakdown breakdown,
-            GoalRecommendationRequest req
-    );
+    GoalRecommendationResponse score(ScoringContext context);
 }

--- a/src/main/java/com/team/independence/goal/service/RecommendationScoringEngine.java
+++ b/src/main/java/com/team/independence/goal/service/RecommendationScoringEngine.java
@@ -1,0 +1,38 @@
+package com.team.independence.goal.service;
+
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import com.team.independence.goal.dto.CandidateStat;
+import com.team.independence.goal.dto.GoalRecommendationRequest;
+import com.team.independence.goal.dto.GoalRecommendationResponse;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 6개 지표를 0~100점으로 정규화한 뒤 전략별 가중치를 적용해 4가지 추천을 각각 1개씩 선정한다.
+ *
+ * <p>가중치 행렬 (순서: 예산여유도 / 저축부담도 / 평수효율 / 신뢰도 / 달성기간 / 선호도):
+ * <pre>
+ * PREFERENCE  0.10  0.10  0.10  0.15  0.10  0.45
+ * REALISTIC   0.30  0.30  0.10  0.10  0.15  0.05
+ * VALUE       0.10  0.15  0.40  0.25  0.05  0.05
+ * HOLD_OUT    0.25  0.05  0.20  0.10  0.05  0.15  (targetDate+24개월 기준)
+ * </pre>
+ */
+public interface RecommendationScoringEngine {
+
+    /**
+     * 후보 목록과 각 후보의 시점별 계획을 받아 4전략을 스코링하고 최종 응답을 조립한다.
+     *
+     * @param candidates 후보군 전체 (RecommendationCandidateService 결과)
+     * @param planMap    후보별 PeriodPlan 목록 (GoalRecommendationService에서 사전 계산)
+     * @param breakdown  회원 순자산 분류 (미래 자산 계산에 사용)
+     * @param req        원본 요청 (선호도 점수 계산에 사용)
+     * @return 전략별 최고 점수 후보 최대 4개
+     */
+    GoalRecommendationResponse selectTop4(
+            List<CandidateStat> candidates,
+            Map<CandidateStat, List<GoalRecommendationResponse.PeriodPlan>> planMap,
+            AssetNetWorthBreakdown breakdown,
+            GoalRecommendationRequest req
+    );
+}

--- a/src/main/java/com/team/independence/goal/service/RecommendationStrategy.java
+++ b/src/main/java/com/team/independence/goal/service/RecommendationStrategy.java
@@ -1,0 +1,34 @@
+package com.team.independence.goal.service;
+
+import com.team.independence.goal.dto.RecommendationType;
+import com.team.independence.goal.dto.GoalRecommendationResponse;
+import com.team.independence.goal.dto.ScoringContext;
+import java.util.Optional;
+
+/**
+ * 추천 테마 하나를 담당하는 전략 인터페이스.
+ *
+ * <p>새 테마를 추가할 때는 이 인터페이스를 구현한 {@code @Service} 클래스를 추가하면 된다.
+ * {@link RecommendationScoringEngine} 구현체는 {@code List<RecommendationStrategy>}를
+ * 주입받아 등록된 전략을 모두 실행하므로, 기존 코드를 수정할 필요가 없다.
+ *
+ * <p>구현 예시:
+ * <pre>
+ * {@literal @}Service
+ * public class PreferenceStrategy implements RecommendationStrategy {
+ *     public RecommendationType getType() { return RecommendationType.PREFERENCE; }
+ *     public Optional<RecommendationItem> recommend(ScoringContext ctx) { ... }
+ * }
+ * </pre>
+ */
+public interface RecommendationStrategy {
+
+    /** 이 전략이 담당하는 추천 테마 */
+    RecommendationType getType();
+
+    /**
+     * 후보 목록을 스코링해 이 전략의 최고 점수 추천 결과를 반환한다.
+     * 적합한 후보가 없으면 {@link Optional#empty()}를 반환한다.
+     */
+    Optional<GoalRecommendationResponse.RecommendationItem> recommend(ScoringContext context);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #72 

## 📝작업 내용

`POST /api/v1/goals/recommendations` 엔드포인트를 구현하기 위한 인터페이스 뼈대를 설계합니다.
세부 구현(Mapper, ServiceImpl)은 다음 커밋에서 작업자 분담 후 별도 PR로 올라올 예정입니다.

### 추가된 파일

| 레이어 | 파일 | 역할 |
|--------|------|------|
| Controller | `GoalRecommendationController` | `POST /api/v1/goals/recommendations` |
| Service | `GoalRecommendationService` | 추천 진입점 — 자산 검증 → 후보군 → PeriodPlan → 스코링 조립 |
| Service | `RecommendationCandidateService` | 요청 조건 + 확장 조건으로 후보군 수집 |
| Service | `RecommendationScoringEngine` | 6지표 정규화 후 전략별 가중치 적용, Top1 선정 |
| Service | `DsrCalculatorService` | DSR 40% 기준 최대 대출 가능액 역산 및 월 상환액 추정 |
| DTO | `GoalRecommendationRequest` | regionCode(필수), propertyType/sizeMin/sizeMax(선택), tradeType/targetDate(필수) |
| DTO | `GoalRecommendationResponse` | RecommendationItem / HousingCandidate / PeriodPlan / WithoutLoanPlan / WithLoanPlan 중첩 클래스 |
| DTO | `CandidateStat` | DB 조회 결과를 서비스 간에 전달하는 5평 단위 면적 구간 통계 |
| Enum | `RecommendationType` | PREFERENCE / REALISTIC / VALUE / HOLD_OUT |

### 수정된 파일

| 파일 | 변경 내용 |
|------|-----------|
| `ErrorCode.java` | GOAL_011 `GOAL_RECOMMENDATION_NO_CANDIDATE`, GOAL_012 `GOAL_ASSET_REQUIRED` 추가 |

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?