### PR TITLE
chore: CD 파이프라인 배포 job 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: CD - Build & Push Image
+name: CD - Build, Push & Deploy
 
 on:
   push:
@@ -39,9 +39,45 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/nagasseum-backend:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/nagasseum-backend:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: AWS 자격증명 설정
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: API 서버 배포
+        run: |
+          aws ssm send-command \
+            --targets "Key=tag:Role,Values=api" \
+            --document-name "AWS-RunShellScript" \
+            --comment "deploy ${{ github.sha }}" \
+            --parameters 'commands=["cd /home/ssm-user/nagasseum && docker compose pull && docker compose up -d && docker image prune -f"]'
+
+      - name: Batch 서버 배포
+        run: |
+          aws ssm send-command \
+            --targets "Key=tag:Role,Values=batch" \
+            --document-name "AWS-RunShellScript" \
+            --comment "deploy ${{ github.sha }}" \
+            --parameters 'commands=["cd /home/ssm-user/nagasseum && docker compose pull && docker compose up -d && docker image prune -f"]'
+
+      - name: 배포 결과 확인
+        run: |
+          sleep 60
+          curl -f https://api.nagasseum.com/api/v1/members/health
+          echo ""
+          echo "배포 성공"


### PR DESCRIPTION
## #️⃣연관된 이슈

> #76 

## 📝작업 내용

기존 `cd.yml`은 빌드 → Docker Hub push까지만 수행했습니다. AWS SSM을 통해 EC2에 자동 배포하는 `deploy` job을 추가해 전체 CD 파이프라인을 완성했습니다.

  - 워크플로 이름 변경: `CD - Build & Push Image` → `CD - Build, Push & Deploy`
  - `이미지 빌드 & push` 스텝에 `platforms: linux/amd64` 명시
  - `deploy` job 추가 (`needs: build-and-push`)
    - AWS 자격증명 설정 (`aws-actions/configure-aws-credentials@v4`)
    - API 서버 배포: SSM send-command → `tag:Role=api` 타겟
    - Batch 서버 배포: SSM send-command → `tag:Role=batch` 타겟
    - 배포 후 헬스체크(`/api/v1/members/health`)로 결과 검증

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?