### PR TITLE
feat: 추천 알고리즘 (HoldOut) 구현

### DIFF
--- a/src/main/java/com/team/independence/goal/service/BudgetCalculator.java
+++ b/src/main/java/com/team/independence/goal/service/BudgetCalculator.java
@@ -1,0 +1,39 @@
+package com.team.independence.goal.service;
+
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+
+/**
+ * n개월 후 예상 예산 계산 — HoldOut 알고리즘 등 추천 영역에서 공유하는 계산기.
+ *
+ * <p>GoalServiceImpl 내부의 동일한 공식을 추출한 것이다.
+ * GoalServiceImpl은 아직 이 인터페이스를 참조하지 않으며, 추후 협의 후 전환한다.
+ *
+ * <p>계산 가정
+ * <ul>
+ *   <li>예적금(interestBearingAssets): 연 5% 복리 거치식 성장</li>
+ *   <li>기타 자산(flatRecognizedAssets): 원금 그대로 인정</li>
+ *   <li>월 저축: 연 5% 복리 적립식 미래가치 (ordinary annuity)</li>
+ * </ul>
+ */
+public interface BudgetCalculator {
+
+    /**
+     * n개월 후 예상 총 예산을 계산한다.
+     *
+     * @param netWorth      순자산 구성 (예적금 / 기타 자산)
+     * @param monthlySaving 월 저축액 (원)
+     * @param months        현재로부터 경과 개월수
+     * @return 예상 총 예산 (원)
+     */
+    long calculate(AssetNetWorthBreakdown netWorth, long monthlySaving, long months);
+
+    /**
+     * 예산이 목표 금액에 도달하는 최소 개월수를 탐색한다.
+     *
+     * @param netWorth      순자산 구성
+     * @param monthlySaving 월 저축액 (원)
+     * @param targetAmount  목표 금액 (원)
+     * @return 도달 최소 개월수. 저축액이 0 이하이거나 상한 내에 도달하지 못하면 null
+     */
+    Long monthsToReach(AssetNetWorthBreakdown netWorth, long monthlySaving, long targetAmount);
+}

--- a/src/main/java/com/team/independence/goal/service/BudgetCalculatorImpl.java
+++ b/src/main/java/com/team/independence/goal/service/BudgetCalculatorImpl.java
@@ -1,0 +1,66 @@
+package com.team.independence.goal.service;
+
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import org.springframework.stereotype.Service;
+
+/**
+ * GoalServiceImpl의 예산 계산 공식을 그대로 옮긴 구현체.
+ *
+ * <p>GoalServiceImpl.ANNUAL_INTEREST_RATE(0.05)와 MAX_FORECAST_MONTHS(1200)를
+ * 동일하게 유지한다. 상수가 바뀌면 두 곳을 같이 바꿔야 한다.
+ * GoalServiceImpl가 이 클래스를 참조하도록 전환되면 이 주석을 제거한다.
+ */
+@Service
+public class BudgetCalculatorImpl implements BudgetCalculator {
+
+    private static final double ANNUAL_INTEREST_RATE = 0.05;
+    private static final long MAX_FORECAST_MONTHS = 1200;
+
+    @Override
+    public long calculate(AssetNetWorthBreakdown netWorth, long monthlySaving, long months) {
+        return calculateGrownAmount(netWorth.getInterestBearingAssets(), months)
+                + netWorth.getFlatRecognizedAssets()
+                + calculateProjectedSavings(monthlySaving, months);
+    }
+
+    @Override
+    public Long monthsToReach(AssetNetWorthBreakdown netWorth, long monthlySaving, long targetAmount) {
+        long growingAssets = netWorth.getInterestBearingAssets();
+        long fixedAssets   = netWorth.getFlatRecognizedAssets();
+
+        if (growingAssets + fixedAssets >= targetAmount) {
+            return 0L;
+        }
+        if (monthlySaving <= 0) {
+            return null;
+        }
+
+        for (long m = 1; m <= MAX_FORECAST_MONTHS; m++) {
+            long budget = calculateGrownAmount(growingAssets, m) + fixedAssets
+                    + calculateProjectedSavings(monthlySaving, m);
+            if (budget >= targetAmount) {
+                return m;
+            }
+        }
+        return null;
+    }
+
+    private double monthlyInterestRate() {
+        return Math.pow(1 + ANNUAL_INTEREST_RATE, 1.0 / 12) - 1;
+    }
+
+    private long calculateGrownAmount(long principal, long months) {
+        if (months == 0) {
+            return principal;
+        }
+        return Math.round(principal * Math.pow(1 + monthlyInterestRate(), months));
+    }
+
+    private long calculateProjectedSavings(long monthlySaving, long months) {
+        if (months == 0) {
+            return 0L;
+        }
+        double r = monthlyInterestRate();
+        return Math.round(monthlySaving * (Math.pow(1 + r, months) - 1) / r);
+    }
+}

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -1,0 +1,389 @@
+package com.team.independence.goal.service.algorithm;
+
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import com.team.independence.asset.service.AssetSummaryService;
+import com.team.independence.goal.domain.Goal;
+import com.team.independence.goal.domain.GoalHousing;
+import com.team.independence.goal.dto.AlgorithmType;
+import com.team.independence.goal.dto.GoalRecommendationRequest;
+import com.team.independence.goal.dto.GoalRecommendationResponse;
+import com.team.independence.goal.dto.LoanPlans;
+import com.team.independence.goal.mapper.GoalHousingMapper;
+import com.team.independence.goal.mapper.GoalMapper;
+import com.team.independence.goal.service.BudgetCalculator;
+import com.team.independence.goal.service.LoanPlanCalculator;
+import com.team.independence.goal.service.RecommendationAlgorithm;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.RentMedianRequest;
+import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.service.RentMedianService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * "극한 저축으로 존버하면 원하는 조건을 얼마나 맞출 수 있는가"를 계산하는 HoldOut 추천 알고리즘.
+ *
+ * <p>지역을 기준으로 주거유형·거래유형·면적 버킷의 조합으로 후보를 생성한다.
+ * 각 후보에 대해 실거래 Q3 시세와 예산 도달 개월을 구한 뒤
+ * 조건 일치(cMS)·대기 패널티(WP)·여유 자산(AM) 스코어로 비교해 가장 높은 점수의 후보를 추천한다.
+ *
+ * <p>기준 조건 결정 우선순위:
+ * <ol>
+ *   <li>request에 조건이 있으면 사용 (regionCode만 필수, 나머지는 null 허용)</li>
+ *   <li>없으면 활성 목표의 GoalHousing 사용</li>
+ *   <li>regionCode마저 없으면 Optional.empty()</li>
+ * </ol>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HoldOutAlgorithm implements RecommendationAlgorithm {
+
+    private static final int  MIN_SAMPLE_COUNT = 10;
+    private static final int  AREA_STEP        = 5;
+    private static final long WIDE_DEPOSIT_MAX = 1_000_000_000_000L;
+
+    /**
+     * 추가 대기 허용 범위 (개월).
+     * n=0이어도 최소 24개월(2년)까지는 HoldOut 후보로 허용하고,
+     * 어떤 상황에서도 36개월(3년)을 초과하는 대기는 추천하지 않는다.
+     */
+    private static final long MIN_EXTRA_MONTHS = 24;
+    private static final long MAX_EXTRA_MONTHS = 36;
+
+    /** housingType/dealType/면적 조건이 없을 때의 탐색 기본값 */
+    private static final int  DEFAULT_AREA_MIN = 10;
+    private static final int  DEFAULT_AREA_MAX = 30;
+    private static final long DEFAULT_RENT_MAX = 2_000_000L;
+
+    /**
+     * 후보 탐색 면적 확장 범위.
+     * 기준 areaMin 아래 한 버킷, areaMax 위 20평까지 넓힌다.
+     * 사용자가 지정한 범위 외에도 가까운 가격대의 매물을 발견하기 위함이다.
+     */
+    private static final int AREA_EXPAND_BELOW = AREA_STEP;
+    private static final int AREA_EXPAND_ABOVE = 20;
+
+    private final LoanPlanCalculator  loanPlanCalculator;
+    private final BudgetCalculator    budgetCalculator;
+    private final GoalMapper          goalMapper;
+    private final GoalHousingMapper   goalHousingMapper;
+    private final AssetSummaryService assetSummaryService;
+    private final RentMedianService   rentMedianService;
+
+    @Override
+    public Optional<GoalRecommendationResponse.RecommendationItem> recommend(
+            long memberId, GoalRecommendationRequest request) {
+
+        Goal activeGoal = goalMapper.findActiveByMemberId(memberId);
+        GoalHousing housing = (activeGoal != null)
+                ? goalHousingMapper.findByGoalId(activeGoal.getId())
+                : null;
+
+        BaseCondition base = resolveCondition(request, housing);
+        if (base == null) return Optional.empty();
+
+        YearMonth now = YearMonth.now(); // 기준 시점 통일 — 이후 계산에서 재사용
+        AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
+        long monthlySaving = resolveMonthlySaving(memberId);
+        long n = calcRemainingMonths(request, activeGoal, now);
+
+        long maxExtra = Math.min(Math.max(n, MIN_EXTRA_MONTHS), MAX_EXTRA_MONTHS);
+
+        List<String> evalLogs = new ArrayList<>();
+        ScoredCandidate best = null;
+        ScoredCandidate bestAlreadyAchievable = null;
+        for (HousingCondition candidate : generateCandidates(base)) {
+            ScoredCandidate scored = evaluate(candidate, base, netWorth, monthlySaving, n, maxExtra, evalLogs);
+            if (scored == null) continue;
+            if (scored.m == 0) {
+                if (bestAlreadyAchievable == null || scored.score > bestAlreadyAchievable.score) bestAlreadyAchievable = scored;
+            } else {
+                if (best == null || scored.score > best.score) best = scored;
+            }
+        }
+
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder("\n[HoldOut] 후보 평가 요약 memberId=").append(memberId);
+            evalLogs.forEach(line -> sb.append("\n  ").append(line));
+            log.debug(sb.toString());
+        }
+
+        // HoldOut 범위(1~maxExtra) 후보가 없으면 현재 계획으로 이미 달성 가능한 후보로 대체
+        boolean isAlreadyAchievable = (best == null);
+        if (isAlreadyAchievable) {
+            best = bestAlreadyAchievable;
+        }
+        if (best == null) {
+            return Optional.empty();
+        }
+
+        log.info("[HoldOut] 최종 선택 memberId={} {}/{} area=[{},{}] futurePrice={} m={}개월 score={} alreadyAchievable={}",
+                memberId,
+                best.candidate.housingType, best.candidate.dealType,
+                best.candidate.areaMin, best.candidate.areaMax,
+                best.futurePrice, best.m, String.format("%.4f", best.score), isAlreadyAchievable);
+
+        YearMonth targetDate = now.plusMonths(best.totalMonths);
+        LoanPlans plans = loanPlanCalculator.calculate(memberId, best.futurePrice, targetDate);
+
+        String title = isAlreadyAchievable
+                ? "현재 계획대로면 원하는 조건을 달성할 수 있어요"
+                : "더 기다리면 원하는 조건을 맞출 수 있어요";
+
+        return Optional.of(GoalRecommendationResponse.RecommendationItem.builder()
+                .type(AlgorithmType.HOLD_OUT)
+                .title(title)
+                .reason(buildReason(best.m))
+                .condition(GoalRecommendationResponse.Condition.builder()
+                        .regionCode(best.median.getRegionCode())
+                        .regionName(best.median.getRegionName())
+                        .housingType(best.candidate.housingType)
+                        .dealType(best.candidate.dealType)
+                        .areaMin(best.candidate.areaMin)
+                        .areaMax(best.candidate.areaMax)
+                        .build())
+                .loanX(plans.getLoanX())
+                .loanO(plans.getLoanO())
+                .build());
+    }
+
+    /**
+     * 기준 조건에서 5평 단위 면적 버킷 후보 목록을 생성한다.
+     * housingType/dealType이 null이면 가능한 모든 타입 조합을 탐색한다.
+     * 보증금 범위는 시장 전체 시세를 발견하기 위해 0~1조로 고정한다.
+     */
+    private List<HousingCondition> generateCandidates(BaseCondition base) {
+        List<HousingType> types = base.housingType != null
+                ? List.of(base.housingType)
+                : Arrays.asList(HousingType.values());
+        List<DealType> deals = base.dealType != null
+                ? List.of(base.dealType)
+                : Arrays.asList(DealType.values());
+
+        int areaMin = base.areaMin != null ? base.areaMin : DEFAULT_AREA_MIN;
+        int areaMax = base.areaMax != null ? base.areaMax : DEFAULT_AREA_MAX;
+        int start = Math.max(AREA_STEP, areaMin - AREA_EXPAND_BELOW);
+        int end   = areaMax + AREA_EXPAND_ABOVE;
+
+        List<HousingCondition> candidates = new ArrayList<>();
+        for (HousingType ht : types) {
+            for (DealType dt : deals) {
+                boolean isJeonse = dt == DealType.JEONSE;
+                Long rentMin = isJeonse ? null : base.rentMin;
+                Long rentMax = isJeonse ? null : (base.rentMax != null ? base.rentMax : DEFAULT_RENT_MAX);
+                for (int lo = start; lo < end; lo += AREA_STEP) {
+                    candidates.add(new HousingCondition(
+                            base.regionCode, ht, dt,
+                            lo, lo + AREA_STEP,
+                            0L, WIDE_DEPOSIT_MAX,
+                            rentMin, rentMax));
+                }
+            }
+        }
+        return candidates;
+    }
+
+    /**
+     * 후보 하나를 평가해 스코어를 계산한다. 필터 탈락 시 null 반환. 평가 내역은 evalLogs에 누적.
+     * 필터 순서: 표본 수 → 보증금 Q3 → 달성 가능 여부 → 추가 대기(m) 범위
+     * 스코어: 0.40×cMS + 0.35×WP + 0.25×AM
+     */
+    private ScoredCandidate evaluate(HousingCondition candidate, BaseCondition base,
+                                     AssetNetWorthBreakdown netWorth, long monthlySaving, long n,
+                                     long maxExtra, List<String> evalLogs) {
+        String label = candidate.housingType + "/" + candidate.dealType
+                + " area=[" + candidate.areaMin + "," + candidate.areaMax + "]";
+
+        RentMedianResponse median;
+        try {
+            median = rentMedianService.getMedian(candidate.toMedianRequest());
+        } catch (Exception e) {
+            evalLogs.add(label + " → 제외 (가격 조회 실패: " + e.getMessage() + ")");
+            return null;
+        }
+
+        if (median.getSampleCount() < MIN_SAMPLE_COUNT) {
+            evalLogs.add(label + " → 제외 (표본 부족: " + median.getSampleCount() + "건)");
+            return null;
+        }
+        Long depositQ3 = median.getDeposit().getQ3();
+        if (depositQ3 == null) {
+            evalLogs.add(label + " → 제외 (보증금 Q3 없음)");
+            return null;
+        }
+        long futurePrice = depositQ3;
+
+        // 월세 후보: 월세만큼 실질 저축 여력이 줄어드는 것으로 반영
+        long effectiveSaving = monthlySaving;
+        if (candidate.dealType == DealType.WOLSE) {
+            Long rentQ3 = median.getMonthlyRent() != null ? median.getMonthlyRent().getQ3() : null;
+            if (rentQ3 != null) {
+                effectiveSaving = Math.max(0, monthlySaving - rentQ3);
+            }
+        }
+
+        Long totalMonths = budgetCalculator.monthsToReach(netWorth, effectiveSaving, futurePrice);
+        if (totalMonths == null) {
+            evalLogs.add(String.format("%s → 제외 (달성 불가: deposit=%,d effectiveSaving=%,d)",
+                    label, futurePrice, effectiveSaving));
+            return null;
+        }
+
+        long futureBudget = budgetCalculator.calculate(netWorth, effectiveSaving, totalMonths);
+        if (futureBudget < futurePrice) {
+            evalLogs.add(String.format("%s → 제외 (예산 부족: budget=%,d price=%,d)", label, futureBudget, futurePrice));
+            return null;
+        }
+
+        long m = Math.max(0, totalMonths - n);
+
+        // m>maxExtra: 너무 긴 대기 → 현실적이지 않음 (m=0은 bestAlreadyAchievable 후보로 올려보냄)
+        if (m > maxExtra) {
+            evalLogs.add(String.format("%s → 제외 (m=%d, 허용범위 0~%d)", label, m, maxExtra));
+            return null;
+        }
+
+        // AM: n+maxExtra 시점의 최대 예산 대비 여유 — 후보 가격이 쌀수록 높아져 변별력 있음
+        // totalMonths <= n+maxExtra 이므로 maxBudget >= futureBudget >= futurePrice → AM >= 0
+        long maxBudget = budgetCalculator.calculate(netWorth, effectiveSaving, n + maxExtra);
+        double affordabilityMargin = (double)(maxBudget - futurePrice) / maxBudget;
+
+        double condMatchScore = calcConditionMatchScore(base, candidate);
+        double waitPenalty    = 1.0 / (1.0 + m / 12.0);
+
+        double score = 0.40 * condMatchScore
+                     + 0.35 * waitPenalty
+                     + 0.25 * affordabilityMargin;
+
+        evalLogs.add(String.format(
+                "%s deposit=%,d effectiveSaving=%,d totalMonths=%d m=%d cMS=%.2f WP=%.3f AM=%.3f score=%.4f",
+                label, futurePrice, effectiveSaving, totalMonths, m,
+                condMatchScore, waitPenalty, affordabilityMargin, score));
+
+        return new ScoredCandidate(candidate, median, futurePrice, totalMonths, m, score);
+    }
+
+    /**
+     * 후보 조건이 기준 조건(BaseCondition)과 얼마나 일치하는지 0.0~1.0으로 계산한다.
+     * 조건이 null이면 무관심으로 간주해 만점 처리한다.
+     *
+     * <p>주거유형(0.5) + 면적 겹침 비율(0.5). 지역은 모든 후보가 동일 지역이므로 포함하지 않는다.
+     * 면적은 희망 범위[areaMin, areaMax]와 후보 버킷의 겹치는 구간 비율로 부분 점수를 부여한다.
+     */
+    private double calcConditionMatchScore(BaseCondition base, HousingCondition candidate) {
+        double score = 0.0;
+
+        // 주거 유형 (0.5)
+        if (base.housingType == null || base.housingType == candidate.housingType) {
+            score += 0.5;
+        }
+
+        // 면적 겹침 비율 (0.5) — binary 판정 대신 겹치는 구간으로 부분 점수 부여
+        if (base.areaMin == null && base.areaMax == null) {
+            score += 0.5;
+        } else {
+            int bMin = base.areaMin != null ? base.areaMin : 0;
+            int bMax = base.areaMax != null ? base.areaMax : 999;
+            int overlapStart = Math.max(candidate.areaMin, bMin);
+            int overlapEnd   = Math.min(candidate.areaMax, bMax);
+            if (overlapStart < overlapEnd) {
+                score += 0.5 * (double)(overlapEnd - overlapStart) / AREA_STEP;
+            }
+        }
+
+        return score;
+    }
+
+    /**
+     * request → housing 순으로 기준 조건을 병합해 BaseCondition을 반환한다.
+     * regionCode만 필수이며, 나머지가 null이면 generateCandidates에서 기본값 또는 전체 탐색으로 보완한다.
+     * regionCode를 확보할 수 없으면 null 반환.
+     */
+    private BaseCondition resolveCondition(GoalRecommendationRequest req, GoalHousing housing) {
+        String regionCode = pick(req.getRegionCode(), housing != null ? housing.getRegionCode() : null);
+        if (regionCode == null) return null;
+
+        return new BaseCondition(
+                regionCode,
+                pick(req.getPropertyType(),  housing != null ? housing.getHousingType()    : null),
+                pick(req.getTradeType(),      housing != null ? housing.getDealType()       : null),
+                pick(req.getSizeMin(),        housing != null ? housing.getAreaMin()        : null),
+                pick(req.getSizeMax(),        housing != null ? housing.getAreaMax()        : null),
+                pick(req.getMonthlyRentMin(), housing != null ? housing.getMonthlyRentMin() : null),
+                pick(req.getMonthlyRentMax(), housing != null ? housing.getMonthlyRentMax() : null));
+    }
+
+    /** 현재 자산 연동 기반의 월 저축액. 0이면 기존 자산만으로 달성 가능한 후보만 살아남는다. */
+    private long resolveMonthlySaving(long memberId) {
+        Long savings = assetSummaryService.getSummary(memberId).getMonthlySavings();
+        return savings != null ? savings : 0L;
+    }
+
+    /**
+     * 현재 시점(now)으로부터 목표 시점까지 남은 개월 수(n)를 반환한다.
+     * 우선순위: request.targetDate > 활성 목표의 targetDate > 0
+     */
+    private long calcRemainingMonths(GoalRecommendationRequest request, Goal activeGoal, YearMonth now) {
+        if (request.getTargetDate() != null) {
+            return Math.max(0, ChronoUnit.MONTHS.between(now, request.getTargetDate()));
+        }
+        if (activeGoal != null && activeGoal.getTargetDate() != null) {
+            return Math.max(0, ChronoUnit.MONTHS.between(now, YearMonth.from(activeGoal.getTargetDate())));
+        }
+        return 0;
+    }
+
+    private String buildReason(long extraMonths) {
+        if (extraMonths == 0) return "현재 계획대로 저축하면 원하는 조건에 도달할 수 있어요.";
+        long years  = extraMonths / 12;
+        long months = extraMonths % 12;
+        if (years == 0)  return extraMonths + "개월 더 기다리면 원하는 조건의 집을 구할 수 있어요.";
+        if (months == 0) return years + "년 더 기다리면 원하는 조건의 집을 구할 수 있어요.";
+        return years + "년 " + months + "개월 더 기다리면 원하는 조건의 집을 구할 수 있어요.";
+    }
+
+    private <T> T pick(T primary, T fallback) {
+        return primary != null ? primary : fallback;
+    }
+
+    /** resolveCondition 결과 — regionCode 이외 필드는 null 허용 */
+    private record BaseCondition(
+            String regionCode, HousingType housingType, DealType dealType,
+            Integer areaMin, Integer areaMax, Long rentMin, Long rentMax) { }
+
+    private record HousingCondition(
+            String regionCode, HousingType housingType, DealType dealType, int areaMin,
+            int areaMax, long depositMin, long depositMax, Long monthlyRentMin,
+            Long monthlyRentMax
+    ) {
+        RentMedianRequest toMedianRequest() {
+            RentMedianRequest r = new RentMedianRequest();
+            r.setRegionCode(regionCode);
+            r.setHousingType(housingType);
+            r.setDealType(dealType);
+            r.setAreaMin(areaMin);
+            r.setAreaMax(areaMax);
+            r.setDepositMin(depositMin);
+            r.setDepositMax(depositMax);
+            if (dealType == DealType.WOLSE) {
+                r.setMonthlyRentMin(monthlyRentMin);
+                r.setMonthlyRentMax(monthlyRentMax);
+            }
+            return r;
+        }
+    }
+
+    private record ScoredCandidate(
+            HousingCondition candidate, RentMedianResponse median, long futurePrice,
+            long totalMonths, long m, double score) { }
+}

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmIntegrationTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.team.independence.goal.service.algorithm;
+
+import com.team.independence.config.RootConfig;
+import com.team.independence.goal.dto.GoalRecommendationRequest;
+import com.team.independence.goal.dto.GoalRecommendationResponse;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.YearMonth;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * HoldOut 알고리즘 로컬 수동 실행용 통합 테스트.
+ *
+ * <p>사전 조건:
+ * <ul>
+ *   <li>docker compose up -d (MySQL, Redis)</li>
+ *   <li>테스트에 쓸 memberId의 connected_account, asset_account, asset_summary.monthly_savings 존재</li>
+ *   <li>rent_transaction에 해당 region/type/deal 최근 6개월 데이터 10건 이상</li>
+ * </ul>
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = RootConfig.class)
+class HoldOutAlgorithmIntegrationTest {
+
+    /** 테스트에 쓸 회원 ID — 로컬 DB에 맞게 변경 */
+    private static final long TEST_MEMBER_ID = 1L;
+
+    @Autowired
+    private HoldOutAlgorithm holdOutAlgorithm;
+
+    /**
+     * request에 조건을 직접 넣어서 실행.
+     * regionCode, propertyType, tradeType, sizeMin, sizeMax는 rent_transaction에 실제로 있는 값으로 변경.
+     */
+    @Test
+    void request_조건_직접_지정() {
+        GoalRecommendationRequest request = new GoalRecommendationRequest();
+        request.setRegionCode("11680");
+        request.setPropertyType(HousingType.APT);
+        request.setTradeType(DealType.JEONSE);
+        request.setSizeMin(20);
+        request.setSizeMax(30);
+        request.setTargetDate(YearMonth.now().plusMonths(24)); // n=24개월 기준
+
+        Optional<GoalRecommendationResponse.RecommendationItem> result =
+                holdOutAlgorithm.recommend(TEST_MEMBER_ID, request);
+
+        System.out.println("=== HoldOut 결과 ===");
+        if (result.isPresent()) {
+            GoalRecommendationResponse.RecommendationItem item = result.get();
+            System.out.println("type   : " + item.getType());
+            System.out.println("title  : " + item.getTitle());
+            System.out.println("reason : " + item.getReason());
+            System.out.println("조건   : " + item.getCondition().getRegionName()
+                    + " / " + item.getCondition().getHousingType()
+                    + " / " + item.getCondition().getDealType()
+                    + " / " + item.getCondition().getAreaMin()
+                    + "~" + item.getCondition().getAreaMax() + "평");
+            System.out.println("loanX  : " + item.getLoanX());
+            System.out.println("loanO  : " + item.getLoanO());
+        } else {
+            System.out.println("추천 결과 없음 (Optional.empty)");
+        }
+
+        // 데이터가 충분하면 결과가 있어야 함 (로컬 DB 데이터에 따라 달라짐)
+        result.ifPresent(item -> assertNotNull(item.getCondition()));
+    }
+
+    /**
+     * request 조건 없이 active goal 기반으로 실행.
+     * TEST_MEMBER_ID에 ACTIVE 목표와 GoalHousing이 있어야 함.
+     */
+    @Test
+    void goal_fallback() {
+        GoalRecommendationRequest request = new GoalRecommendationRequest();
+        // 조건 미입력 → active goal의 housing 조건 사용
+
+        Optional<GoalRecommendationResponse.RecommendationItem> result =
+                holdOutAlgorithm.recommend(TEST_MEMBER_ID, request);
+
+        System.out.println("=== HoldOut (goal fallback) 결과 ===");
+        if (result.isPresent()) {
+            GoalRecommendationResponse.RecommendationItem item = result.get();
+            System.out.println("reason : " + item.getReason());
+            System.out.println("조건   : " + item.getCondition().getRegionName()
+                    + " " + item.getCondition().getAreaMin()
+                    + "~" + item.getCondition().getAreaMax() + "평");
+        } else {
+            System.out.println("추천 결과 없음 (active goal 없거나 데이터 부족)");
+        }
+    }
+}

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmIntegrationTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmIntegrationTest.java
@@ -5,6 +5,7 @@ import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * HoldOut 알고리즘 로컬 수동 실행용 통합 테스트.
  *
+ * <p>실행 방법: @Disabled 제거 후 로컬에서 실행
+ *
  * <p>사전 조건:
  * <ul>
  *   <li>docker compose up -d (MySQL, Redis)</li>
@@ -26,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  *   <li>rent_transaction에 해당 region/type/deal 최근 6개월 데이터 10건 이상</li>
  * </ul>
  */
+@Disabled("로컬 MySQL + Redis 환경 전용")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = RootConfig.class)
 class HoldOutAlgorithmIntegrationTest {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #78 
- #79 

## 📝작업 내용

### 1. 공통 예산 계산기 추출 (`BudgetCalculator`)

추천 알고리즘에서 공통으로 사용하는 예산 계산 로직을 `GoalServiceImpl` 내부에서 독립 인터페이스·구현체로 분리했습니다.

- `BudgetCalculator.calculate(netWorth, monthlySaving, months)` — n개월 후 예상 예산
- `BudgetCalculator.monthsToReach(netWorth, monthlySaving, targetAmount)` — 목표 금액 도달 최소 개월
- 연 5% 복리, `GoalServiceImpl`과 동일한 공식 유지

### 2. HoldOut 추천 알고리즘 구현 (`HoldOutAlgorithm`)

**테마:** "극한 저축으로 존버하면 원하는 조건을 얼마나 맞출 수 있는가?"

목표 시점(n)보다 더 오래 저축했을 때 달성 가능한 최적 주거 조건을 찾아 추천합니다.

#### 동작 흐름

```
기준 조건 결정 (request → active goal → regionCode 없으면 empty)
  ↓
후보 생성: 5평 단위 면적 버킷 × 주거유형 × 거래유형
  ↓
후보 평가: 실거래 Q3 시세 조회 → 월세 여력 감산 → 예산 도달 개월 계산 → m 필터
  ↓
스코어 계산: 0.40×cMS + 0.35×WP + 0.25×AM
  ↓
최고점 선택 (HoldOut 후보 없으면 현재 계획 달성 가능 후보 fallback)
```

```
기준 조건 결정 (request → active goal → 불가 시 empty)
        ↓
후보 주거 조건 생성 (5평 단위 면적 버킷 × 주거유형 × 거래유형)
        ↓
후보별 평가
  ├─ 실거래 Q3 시세 조회 (RentMedianService)
  ├─ 월세면 실질 저축 여력 감산 (effectiveSaving)
  ├─ 예산 도달 개월 계산 (BudgetCalculator.monthsToReach)
  ├─ 추가 대기 개월(m) 계산 및 필터
  └─ 스코어 계산 (cMS · WP · AM)
        ↓
최고 점수 후보 선택
  └─ HoldOut 범위 후보 없으면 → 현재 계획으로 달성 가능한 후보로 대체
        ↓
LoanPlanCalculator → 추천 결과 반환
```

#### 주요 설계 결정

| 항목 | 결정 내용 |
|---|---|
| 필수 입력 | regionCode만 필수. 나머지 조건 null이면 전체 탐색 |
| 추가 대기 상한 | `maxExtra = min(max(n, 24), 36)` — 절대 상한 3년 |
| 월세 반영 | `effectiveSaving = monthlySaving - monthlyRent.Q3` |
| 스코어 AM | `(maxBudget - futurePrice) / maxBudget` — 가격이 쌀수록 높음 |
| Fallback | m=0 후보(현재 계획 달성 가능) 중 최고점으로 대체 |

#### 스코어 공식 설명

- **cMS** (0.40): 주거유형 일치(0.5) + 희망 면적과의 겹침 비율(0.5)
- **WP** (0.35): `1 / (1 + m/12)` — 짧은 대기일수록 높음
- **AM** (0.25): 최대 허용 기간(`n+maxExtra`)의 예산 대비 여유 — 저렴한 후보에 가점

### 3. 통합 테스트 추가

실제 DB 기반 수동 실행 테스트 (`HoldOutAlgorithmIntegrationTest`)
- `request_조건_직접_지정()`: regionCode, housingType, dealType, 면적, targetDate 직접 설정
- `goal_fallback()`: 조건 없이 active goal 기반 실행

## 💬리뷰 요구사항(선택)

- **AssetSummaryService 이중 호출 문제**: `recommend()` 안에서 `getNetWorthBreakdown()`과 `getSummary()` 를 모두 호출합니다. `monthlySavings` 하나를 위해 `getSummary()`가 계좌·대출 전체를 조회하는 게 낭비인데, `AssetSummaryService`에 `getMonthlySavings(Long memberId)` 메서드 추가를 통해 월 저축액만 가져오는 코드를 추가하는 것을 고려해보면 좋을 것 같습니다.

- **스코어 가중치 조정 여지**: 현재 `0.40×cMS + 0.35×WP + 0.25×AM`이지만, 실제 데이터로 테스트해보며 튜닝이 필요할 수 있습니다.
