### PR TITLE
feat: 가격 모델(PriceModel) 모듈 구현 - 연간 성장률(μ), 변동성(σ) 산출

### DIFF
--- a/src/main/java/com/team/independence/common/exception/ErrorCode.java
+++ b/src/main/java/com/team/independence/common/exception/ErrorCode.java
@@ -62,7 +62,8 @@ public enum ErrorCode {
     POLICY_NOT_FOUND("POLICY_001", "정책을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // ===== 매물 PROPERTY_xxx =====
-    REGION_NOT_FOUND("PROPERTY_001", "존재하지 않는 지역 코드입니다.", HttpStatus.NOT_FOUND);
+    REGION_NOT_FOUND("PROPERTY_001", "존재하지 않는 지역 코드입니다.", HttpStatus.NOT_FOUND),
+    PROPERTY_INSUFFICIENT_DATA("PROPERTY_002", "해당 조건의 거래 데이터가 충분하지 않습니다.", HttpStatus.UNPROCESSABLE_ENTITY);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/team/independence/property/controller/PropertyController.java
+++ b/src/main/java/com/team/independence/property/controller/PropertyController.java
@@ -1,8 +1,11 @@
 package com.team.independence.property.controller;
 
 import com.team.independence.common.response.ApiResponse;
+import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.property.dto.PriceModelResponse;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.service.PriceModelService;
 import com.team.independence.property.service.RentMedianService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,9 +17,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/properties")
 @RequiredArgsConstructor
-public class   PropertyController {
+public class PropertyController {
 
     private final RentMedianService rentMedianService;
+    private final PriceModelService priceModelService;
 
     /**
      * 실거래 매물 중앙값 조회.
@@ -27,5 +31,10 @@ public class   PropertyController {
     @GetMapping("/median")
     public ApiResponse<RentMedianResponse> getMedian(@Valid @ModelAttribute RentMedianRequest request) {
         return ApiResponse.ok(rentMedianService.getMedian(request));
+    }
+
+    @GetMapping("/price-model")
+    public ApiResponse<PriceModelResponse> getPriceModel(@Valid @ModelAttribute PriceModelRequest request) {
+        return ApiResponse.ok(priceModelService.estimate(request));
     }
 }

--- a/src/main/java/com/team/independence/property/dto/MonthlyPricePoint.java
+++ b/src/main/java/com/team/independence/property/dto/MonthlyPricePoint.java
@@ -1,0 +1,16 @@
+package com.team.independence.property.dto;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 월별 평단가 시계열 산출용 mapper 프로젝션 */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MonthlyPricePoint {
+    private String dealYm;
+    private Long deposit;
+    private BigDecimal area;
+}

--- a/src/main/java/com/team/independence/property/dto/PriceModelRequest.java
+++ b/src/main/java/com/team/independence/property/dto/PriceModelRequest.java
@@ -1,0 +1,45 @@
+package com.team.independence.property.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 가격 모델(μ, σ) 추정 조건
+ *
+ * RentMedianRequest와 달리 보증금, 월세 필터가 없다.
+ * 시장 전체 거래 흐름을 시계열로 분석하므로 사용자 예산 범위로 좁히지 않는다.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class PriceModelRequest {
+
+    @NotBlank(message = "지역 코드는 필수입니다.")
+    private String regionCode;
+
+    @NotNull(message = "주거 형태는 필수입니다.")
+    private HousingType housingType;
+
+    @NotNull(message = "거래 유형은 필수입니다.")
+    private DealType dealType;
+
+    @NotNull(message = "최소 평수는 필수입니다.")
+    @Positive(message = "최소 평수는 0보다 커야 합니다.")
+    private Integer areaMin;
+
+    @NotNull(message = "최대 평수는 필수입니다.")
+    @Positive(message = "최대 평수는 0보다 커야 합니다.")
+    private Integer areaMax;
+
+    @AssertTrue(message = "최소 평수는 최대 평수보다 클 수 없습니다.")
+    public boolean isAreaRangeValid() {
+        return areaMin == null || areaMax == null || areaMin <= areaMax;
+    }
+}

--- a/src/main/java/com/team/independence/property/dto/PriceModelResponse.java
+++ b/src/main/java/com/team/independence/property/dto/PriceModelResponse.java
@@ -1,0 +1,31 @@
+package com.team.independence.property.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PriceModelResponse {
+
+    private String regionCode;
+    private String regionName;
+    private HousingType housingType;
+    private DealType dealType;
+
+    // 연간 연속 성장률(μ): 몬테카를로 drift 입력값
+    private double annualDrift;
+
+    // 표시용 연 상승률: exp(μ) - 1
+    private double cagr;
+
+    // 연율 변동성(σ): 몬테카를로 volatility 입력값
+    private double annualVol;
+
+    // 회귀에 사용된 유효 표본 월 수: 신뢰도 지표
+    private int months;
+
+    private String startYm;
+    private String endYm;
+}

--- a/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
+++ b/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
@@ -1,7 +1,9 @@
 package com.team.independence.property.mapper;
 
+import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.domain.RentTransaction;
+import com.team.independence.property.dto.MonthlyPricePoint;
 import com.team.independence.property.dto.RentMedianAmount;
 import com.team.independence.property.dto.RentMedianRequest;
 import java.util.List;
@@ -30,4 +32,13 @@ public interface RentTransactionMapper {
                                                 @Param("areaMaxSqm") long areaMaxSqm,
                                                 @Param("startYm") String startYm,
                                                 @Param("endYm") String endYm);
+
+    /** 가격 모델(μ, σ) 산출용 월별 (거래연월, 보증금, 면적) 목록. 보증금 0 제외 */
+    List<MonthlyPricePoint> findAmountsForPriceModel(@Param("regionCode") String regionCode,
+                                                     @Param("housingType") HousingType housingType,
+                                                     @Param("dealType") DealType dealType,
+                                                     @Param("areaMinSqm") long areaMinSqm,
+                                                     @Param("areaMaxSqm") long areaMaxSqm,
+                                                     @Param("startYm") String startYm,
+                                                     @Param("endYm") String endYm);
 }

--- a/src/main/java/com/team/independence/property/service/PriceModel.java
+++ b/src/main/java/com/team/independence/property/service/PriceModel.java
@@ -1,0 +1,54 @@
+package com.team.independence.property.service;
+
+import java.util.List;
+
+/**
+ * 월별 평단가 시계열에서 연간 성장률(μ), 연율 변동성(σ)을 추정한다.
+ *
+ * 두 시점 CAGR 대신 ln(price) ~ t OLS 회귀로 기울기를 뽑는다.
+ * 엔드포인트 노이즈에 강하고, μ와 σ를 같은 시계열에서 한 번의 순회로 뽑으므로
+ * 몬테카를로가 이 결과를 그대로 입력으로 쓸 수 있다.
+ *
+ * @param annualDrift 연간 연속 성장률(μ): 몬테카를로 drift 입력값
+ * @param cagr 표시용 연 상승률: Math.exp(annualDrift) - 1
+ * @param annualVol 연율 변동성(σ): 몬테카를로 volatility 입력값
+ * @param months 회귀에 사용된 유효 표본 월 수
+ */
+public record PriceModel(double annualDrift, double cagr, double annualVol, int months) {
+
+    /**
+     * @param pricePerPyeong 시간순 정렬된 월별 평단가 목록. 최소 6개 이상이어야 한다.
+     */
+    public static PriceModel estimate(List<Double> pricePerPyeong) {
+        int n = pricePerPyeong.size();
+
+        // ln(price) ~ t 최소제곱 회귀 → 월간 연속성장률(기울기)
+        double sx = 0, sy = 0, sxx = 0, sxy = 0;
+        for (int t = 0; t < n; t++) {
+            double y = Math.log(pricePerPyeong.get(t));
+            sx += t;
+            sy += y;
+            sxx += (double) t * t;
+            sxy += t * y;
+        }
+        double slope = (n * sxy - sx * sy) / (n * sxx - sx * sx);
+        double annualDrift = slope * 12;
+        double cagr = Math.exp(annualDrift) - 1;
+
+        // 월별 로그수익률 표준편차 → 연율 변동성 σ
+        int k = n - 1;
+        double[] r = new double[k];
+        double mean = 0;
+        for (int t = 1; t < n; t++) {
+            r[t - 1] = Math.log(pricePerPyeong.get(t) / pricePerPyeong.get(t - 1));
+            mean += r[t - 1];
+        }
+        mean /= k;
+        double var = 0;
+        for (double x : r) var += (x - mean) * (x - mean);
+        var /= (k - 1);
+        double annualVol = Math.sqrt(var) * Math.sqrt(12);
+
+        return new PriceModel(annualDrift, cagr, annualVol, n);
+    }
+}

--- a/src/main/java/com/team/independence/property/service/PriceModelService.java
+++ b/src/main/java/com/team/independence/property/service/PriceModelService.java
@@ -1,0 +1,12 @@
+package com.team.independence.property.service;
+
+import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.property.dto.PriceModelResponse;
+
+public interface PriceModelService {
+
+    /**
+     * 지역 / 유형 / 면적 조건에 맞는 최근 36개월 실거래 시계열에서 연간 성장률(μ)과 연율 변동성(σ)을 추정
+     */
+    PriceModelResponse estimate(PriceModelRequest request);
+}

--- a/src/main/java/com/team/independence/property/service/PriceModelServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/PriceModelServiceImpl.java
@@ -1,0 +1,98 @@
+package com.team.independence.property.service;
+
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.property.dto.MonthlyPricePoint;
+import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.property.dto.PriceModelResponse;
+import com.team.independence.property.mapper.RegionMapper;
+import com.team.independence.property.mapper.RentTransactionMapper;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PriceModelServiceImpl implements PriceModelService {
+
+    private static final int WINDOW_MONTHS = 36;
+    private static final int MIN_SAMPLES_PER_MONTH = 5;
+    private static final int MIN_VALID_MONTHS = 6;
+    private static final double PYEONG_TO_SQM = 3.305785;
+    private static final DateTimeFormatter YM = DateTimeFormatter.ofPattern("yyyyMM");
+
+    private final RegionMapper regionMapper;
+    private final RentTransactionMapper rentTransactionMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public PriceModelResponse estimate(PriceModelRequest request) {
+        String regionName = regionMapper.findFullNameByCode(request.getRegionCode());
+        if (regionName == null) {
+            throw new BusinessException(ErrorCode.REGION_NOT_FOUND);
+        }
+
+        YearMonth end = YearMonth.now();
+        YearMonth start = end.minusMonths(WINDOW_MONTHS - 1);
+        String startYm = start.format(YM);
+        String endYm = end.format(YM);
+
+        List<MonthlyPricePoint> raw = rentTransactionMapper.findAmountsForPriceModel(
+                request.getRegionCode(),
+                request.getHousingType(),
+                request.getDealType(),
+                toSqm(request.getAreaMin()),
+                toSqm(request.getAreaMax()),
+                startYm,
+                endYm);
+
+        // 월별 그룹핑 → 표본 부족 월 제외 → 평단가 중앙값 시계열
+        List<Double> monthlyMedians = raw.stream()
+                .collect(Collectors.groupingBy(MonthlyPricePoint::getDealYm))
+                .entrySet().stream()
+                .filter(e -> e.getValue().size() >= MIN_SAMPLES_PER_MONTH)
+                .sorted(Map.Entry.comparingByKey())  // YYYYMM은 사전순 = 시간순
+                .map(e -> medianPerPyeong(e.getValue()))
+                .collect(Collectors.toList());
+
+        if (monthlyMedians.size() < MIN_VALID_MONTHS) {
+            throw new BusinessException(ErrorCode.PROPERTY_INSUFFICIENT_DATA);
+        }
+
+        PriceModel model = PriceModel.estimate(monthlyMedians);
+
+        return PriceModelResponse.builder()
+                .regionCode(request.getRegionCode())
+                .regionName(regionName)
+                .housingType(request.getHousingType())
+                .dealType(request.getDealType())
+                .annualDrift(model.annualDrift())
+                .cagr(model.cagr())
+                .annualVol(model.annualVol())
+                .months(model.months())
+                .startYm(startYm)
+                .endYm(endYm)
+                .build();
+    }
+
+    /** 한 달치 거래 목록에서 평당 보증금(원/평)의 중앙값을 반환 */
+    private double medianPerPyeong(List<MonthlyPricePoint> points) {
+        double[] sorted = points.stream()
+                .mapToDouble(p -> p.getDeposit() / (p.getArea().doubleValue() / PYEONG_TO_SQM))
+                .sorted()
+                .toArray();
+        int mid = sorted.length / 2;
+        return sorted.length % 2 == 0
+                ? (sorted[mid - 1] + sorted[mid]) / 2.0
+                : sorted[mid];
+    }
+
+    private long toSqm(int pyeong) {
+        return (long) Math.floor(pyeong * PYEONG_TO_SQM);
+    }
+}

--- a/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
+++ b/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
@@ -40,6 +40,20 @@
            AND housing_type = #{housingType}
     </delete>
 
+    <!-- 가격 모델(μ, σ) 산출용 월별 (거래연월, 보증금, 면적) 조회
+         deposit = 0 이상치 제외. 월별 그룹핑, 중앙값 산출은 애플리케이션에서 처리 -->
+    <select id="findAmountsForPriceModel" resultType="com.team.independence.property.dto.MonthlyPricePoint">
+        SELECT deal_ym, deposit, area
+          FROM rent_transaction
+         WHERE region_code  = #{regionCode}
+           AND housing_type = #{housingType}
+           AND deal_type = #{dealType}
+           AND deal_ym BETWEEN #{startYm} AND #{endYm}
+           AND area BETWEEN #{areaMinSqm} AND #{areaMaxSqm}
+           AND deposit &gt; 0
+         ORDER BY deal_ym
+    </select>
+
     <!-- 분위값 계산용 금액 조회. 집계는 애플리케이션에서 하므로 원본 금액만 뽑는다.
          deposit = 0 은 보증금 없이 기록된 이상치라 집계에서 제외한다. -->
     <select id="findAmountsForMedian" resultType="com.team.independence.property.dto.RentMedianAmount">

--- a/src/test/java/com/team/independence/property/service/PriceModelIntegrationTest.java
+++ b/src/test/java/com/team/independence/property/service/PriceModelIntegrationTest.java
@@ -32,7 +32,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  *
  * <p>사전 조건: docker compose up -d, 환경변수 MOLIT_SERVICE_KEY
  */
-// @Disabled("로컬 MySQL + 국토부 API 환경 전용")
+@Disabled("로컬 MySQL + 국토부 API 환경 전용")
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = RootConfig.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/src/test/java/com/team/independence/property/service/PriceModelIntegrationTest.java
+++ b/src/test/java/com/team/independence/property/service/PriceModelIntegrationTest.java
@@ -1,0 +1,99 @@
+package com.team.independence.property.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.team.independence.config.RootConfig;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.property.dto.PriceModelResponse;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * PriceModel 실데이터 검증.
+ *
+ * <p>실행 순서:
+ * <ol>
+ *   <li>docker compose up -d</li>
+ *   <li>@Disabled 제거</li>
+ *   <li>backfill_강남구_36개월 먼저 실행 (MOLIT API 36회 호출 — 1~2분 소요)</li>
+ *   <li>priceModel_실데이터_검증 실행 후 콘솔에서 μ·CAGR·σ 값 확인</li>
+ * </ol>
+ *
+ * <p>사전 조건: docker compose up -d, 환경변수 MOLIT_SERVICE_KEY
+ */
+// @Disabled("로컬 MySQL + 국토부 API 환경 전용")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = RootConfig.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class PriceModelIntegrationTest {
+
+    private static final String REGION_CODE = "11680"; // 강남구
+    private static final DateTimeFormatter YM = DateTimeFormatter.ofPattern("yyyyMM");
+
+    @Autowired
+    private RentTransactionSyncService rentTransactionSyncService;
+
+    @Autowired
+    private PriceModelService priceModelService;
+
+    /**
+     * 강남구 아파트 36개월치 데이터를 MOLIT API에서 받아 적재한다.
+     * 이미 적재된 달은 덮어쓴다(재적재 구조).
+     */
+    @Test
+    @Order(1)
+    void backfill_강남구_36개월() {
+        YearMonth base = YearMonth.now();
+        for (int i = 0; i < 36; i++) {
+            String dealYm = base.minusMonths(i).format(YM);
+            rentTransactionSyncService.collectAndSync(REGION_CODE, dealYm, HousingType.APT);
+            System.out.println("적재 완료: " + dealYm);
+        }
+    }
+
+    /**
+     * PriceModel 결과를 출력하고 상식 범위(CAGR -10% ~ +30%)를 검증한다.
+     *
+     * <p>강남구 아파트 전세 기준 시장 감각: CAGR 3~8% 수준이면 정상.
+     * 콘솔 출력을 보고 직접 판단한다.
+     */
+    @Test
+    @Order(2)
+    void priceModel_실데이터_검증() {
+        PriceModelRequest request = new PriceModelRequest();
+        request.setRegionCode(REGION_CODE);
+        request.setHousingType(HousingType.APT);
+        request.setDealType(DealType.JEONSE);
+        request.setAreaMin(15);
+        request.setAreaMax(25);
+
+        PriceModelResponse response = priceModelService.estimate(request);
+
+        System.out.println("=== PriceModel 실데이터 검증 결과 ===");
+        System.out.printf("지역: %s %s%n", response.getRegionCode(), response.getRegionName());
+        System.out.printf("조건: %s / %s%n", response.getHousingType(), response.getDealType());
+        System.out.printf("기간: %s ~ %s (%d개월)%n",
+                response.getStartYm(), response.getEndYm(), response.getMonths());
+        System.out.printf("CAGR: %.2f%%%n", response.getCagr() * 100);
+        System.out.printf("annualDrift: %.4f (μ)%n", response.getAnnualDrift());
+        System.out.printf("annualVol: %.4f (σ)%n", response.getAnnualVol());
+
+        assertTrue(response.getCagr() > -0.10 && response.getCagr() < 0.30,
+                "CAGR이 상식 범위(-10% ~ +30%)를 벗어남: " + response.getCagr() * 100 + "%");
+        assertTrue(response.getAnnualVol() >= 0,
+                "σ가 음수일 수 없음: " + response.getAnnualVol());
+        assertTrue(response.getMonths() >= 6,
+                "유효 월 수가 최소 기준(6) 미만: " + response.getMonths());
+    }
+}

--- a/src/test/java/com/team/independence/property/service/PriceModelServiceImplTest.java
+++ b/src/test/java/com/team/independence/property/service/PriceModelServiceImplTest.java
@@ -1,0 +1,208 @@
+package com.team.independence.property.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.MonthlyPricePoint;
+import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.property.dto.PriceModelResponse;
+import com.team.independence.property.mapper.RegionMapper;
+import com.team.independence.property.mapper.RentTransactionMapper;
+import java.math.BigDecimal;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * PriceModelServiceImpl 서비스 로직 단위 테스트.
+ *
+ * <p>DB 없이 돈다. Mapper를 Mockito로 목 처리해 반환값을 지정하고,
+ * 서비스의 그룹핑·필터링·중앙값 산출 로직만 검증한다.
+ * PriceModel.estimate() 수식 자체는 PriceModelTest에서 별도로 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class PriceModelServiceImplTest {
+
+    private static final String REGION_CODE = "11680";
+    private static final String REGION_NAME = "서울특별시 강남구";
+    /** 20평 = 20 × 3.305785 ㎡ */
+    private static final BigDecimal AREA_20PY = new BigDecimal("66.1157");
+    private static final DateTimeFormatter YM = DateTimeFormatter.ofPattern("yyyyMM");
+
+    @Mock private RegionMapper regionMapper;
+    @Mock private RentTransactionMapper rentTransactionMapper;
+
+    @InjectMocks private PriceModelServiceImpl service;
+
+    private PriceModelRequest request;
+
+    @BeforeEach
+    void setUp() {
+        request = new PriceModelRequest();
+        request.setRegionCode(REGION_CODE);
+        request.setHousingType(HousingType.APT);
+        request.setDealType(DealType.JEONSE);
+        request.setAreaMin(15);
+        request.setAreaMax(25);
+    }
+
+    // ------------------------------------------------------------------
+    // 예외 경로
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("존재하지 않는 지역코드 → REGION_NOT_FOUND")
+    void 존재하지_않는_지역코드() {
+        when(regionMapper.findFullNameByCode(REGION_CODE)).thenReturn(null);
+
+        BusinessException e = assertThrows(BusinessException.class, () -> service.estimate(request));
+
+        assertEquals(ErrorCode.REGION_NOT_FOUND, e.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("유효 월이 6개 미만 → PROPERTY_INSUFFICIENT_DATA")
+    void 유효_월_6개_미만_예외() {
+        when(regionMapper.findFullNameByCode(REGION_CODE)).thenReturn(REGION_NAME);
+        // 5개월치만 5건 이상 → 유효 월 5개, 최소(6) 미달
+        when(rentTransactionMapper.findAmountsForPriceModel(
+                eq(REGION_CODE), any(), any(), anyLong(), anyLong(), anyString(), anyString()))
+                .thenReturn(monthsData(5, 5, 200_000_000L, AREA_20PY));
+
+        BusinessException e = assertThrows(BusinessException.class, () -> service.estimate(request));
+
+        assertEquals(ErrorCode.PROPERTY_INSUFFICIENT_DATA, e.getErrorCode());
+    }
+
+    // ------------------------------------------------------------------
+    // 표본 필터링
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("표본 5건 미만 월은 제외되어 유효 월 수에서 빠진다")
+    void 표본_5건_미만_월_제외() {
+        when(regionMapper.findFullNameByCode(REGION_CODE)).thenReturn(REGION_NAME);
+
+        // 12개월치: 앞 6개월은 표본 4건(미달), 뒤 6개월은 표본 5건(통과)
+        List<MonthlyPricePoint> raw = new ArrayList<>();
+        raw.addAll(monthsData(6, 4, 200_000_000L, AREA_20PY)); // 필터됨
+        raw.addAll(monthsData(6, 5, 200_000_000L, AREA_20PY)); // 유효
+
+        when(rentTransactionMapper.findAmountsForPriceModel(
+                eq(REGION_CODE), any(), any(), anyLong(), anyLong(), anyString(), anyString()))
+                .thenReturn(raw);
+
+        PriceModelResponse response = service.estimate(request);
+
+        assertEquals(6, response.getMonths(), "앞 6개월이 필터되어 유효 월 수는 6이어야 한다.");
+    }
+
+    // ------------------------------------------------------------------
+    // 중앙값 산출 (간접 검증)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("모든 달 가격이 동일 → CAGR ≈ 0, σ ≈ 0")
+    void 가격_고정_시계열_CAGR_0() {
+        when(regionMapper.findFullNameByCode(REGION_CODE)).thenReturn(REGION_NAME);
+        // 12개월, 월별 5건, 동일한 deposit·area → 평단가 매달 같음
+        when(rentTransactionMapper.findAmountsForPriceModel(
+                eq(REGION_CODE), any(), any(), anyLong(), anyLong(), anyString(), anyString()))
+                .thenReturn(monthsData(12, 5, 200_000_000L, AREA_20PY));
+
+        PriceModelResponse response = service.estimate(request);
+
+        assertEquals(0.0, response.getCagr(),    0.01, "가격 고정 → CAGR ≈ 0");
+        assertEquals(0.0, response.getAnnualVol(), 0.01, "가격 고정 → σ ≈ 0");
+    }
+
+    @Test
+    @DisplayName("홀수 개 표본 → 중앙값이 정중앙 값을 반환한다")
+    void 홀수_표본_중앙값() {
+        when(regionMapper.findFullNameByCode(REGION_CODE)).thenReturn(REGION_NAME);
+
+        // 한 달에 5건: 평단가가 각각 다른 deposit으로 만든다.
+        // area=AREA_20PY(20평), deposit=1억/2억/3억/4억/5억 → 평단가=500만/1000만/1500만/2000만/2500만
+        // 중앙값(3번째) = 1500만/평
+        // 12개월 모두 같은 분포 → CAGR ≈ 0
+        List<MonthlyPricePoint> raw = new ArrayList<>();
+        for (int m = 0; m < 12; m++) {
+            String ym = YearMonth.now().minusMonths(11 - m).format(YM);
+            raw.add(new MonthlyPricePoint(ym, 100_000_000L, AREA_20PY));
+            raw.add(new MonthlyPricePoint(ym, 200_000_000L, AREA_20PY));
+            raw.add(new MonthlyPricePoint(ym, 300_000_000L, AREA_20PY));
+            raw.add(new MonthlyPricePoint(ym, 400_000_000L, AREA_20PY));
+            raw.add(new MonthlyPricePoint(ym, 500_000_000L, AREA_20PY));
+        }
+
+        when(rentTransactionMapper.findAmountsForPriceModel(
+                eq(REGION_CODE), any(), any(), anyLong(), anyLong(), anyString(), anyString()))
+                .thenReturn(raw);
+
+        PriceModelResponse response = service.estimate(request);
+
+        // 모든 달 중앙값이 동일 → CAGR ≈ 0
+        assertEquals(0.0, response.getCagr(), 0.01);
+        assertEquals(12, response.getMonths());
+    }
+
+    // ------------------------------------------------------------------
+    // 응답 조립
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("정상 경로 → 응답 필드가 올바르게 조립된다")
+    void 정상_경로_응답_조립() {
+        when(regionMapper.findFullNameByCode(REGION_CODE)).thenReturn(REGION_NAME);
+        when(rentTransactionMapper.findAmountsForPriceModel(
+                eq(REGION_CODE), any(), any(), anyLong(), anyLong(), anyString(), anyString()))
+                .thenReturn(monthsData(12, 5, 200_000_000L, AREA_20PY));
+
+        PriceModelResponse response = service.estimate(request);
+
+        assertEquals(REGION_CODE, response.getRegionCode());
+        assertEquals(REGION_NAME, response.getRegionName());
+        assertEquals(HousingType.APT, response.getHousingType());
+        assertEquals(DealType.JEONSE, response.getDealType());
+        assertNotNull(response.getStartYm());
+        assertNotNull(response.getEndYm());
+    }
+
+    // ------------------------------------------------------------------
+    // 헬퍼
+    // ------------------------------------------------------------------
+
+    /**
+     * months개월치 데이터를 생성한다. 각 달마다 samplesPerMonth건, 동일한 deposit·area.
+     * 월 순서는 현재 월 기준 과거로 계산한다.
+     */
+    private List<MonthlyPricePoint> monthsData(int months, int samplesPerMonth,
+                                                long deposit, BigDecimal area) {
+        List<MonthlyPricePoint> list = new ArrayList<>();
+        for (int m = 0; m < months; m++) {
+            String ym = YearMonth.now().minusMonths(months - 1 - m).format(YM);
+            for (int s = 0; s < samplesPerMonth; s++) {
+                list.add(new MonthlyPricePoint(ym, deposit, area));
+            }
+        }
+        return list;
+    }
+}

--- a/src/test/java/com/team/independence/property/service/PriceModelTest.java
+++ b/src/test/java/com/team/independence/property/service/PriceModelTest.java
@@ -1,0 +1,143 @@
+package com.team.independence.property.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * PriceModel.estimate() 단위 테스트.
+ *
+ * <p>순수 계산이라 Spring 컨텍스트 없이 실행된다.
+ * 기대값은 입력 시계열을 직접 생성할 때 심은 파라미터에서 역산한다.
+ */
+class  PriceModelTest {
+
+    private static final double TOLERANCE = 0.01; // 허용 오차 1%p
+
+    // ------------------------------------------------------------------
+    // CAGR 추정
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("노이즈 없이 연 5% 성장하는 시계열 → CAGR 약 5%")
+    void 연5퍼_성장_시계열_CAGR() {
+        double annualRate = 0.05;
+        List<Double> series = growingSeries(1_000_000, annualRate, 36);
+
+        PriceModel model = PriceModel.estimate(series);
+
+        assertEquals(annualRate, model.cagr(), TOLERANCE);
+    }
+
+    @Test
+    @DisplayName("노이즈 없이 연 10% 성장하는 시계열 → CAGR 약 10%")
+    void 연10퍼_성장_시계열_CAGR() {
+        double annualRate = 0.10;
+        List<Double> series = growingSeries(2_000_000, annualRate, 36);
+
+        PriceModel model = PriceModel.estimate(series);
+
+        assertEquals(annualRate, model.cagr(), TOLERANCE);
+    }
+
+    @Test
+    @DisplayName("가격이 고정된 시계열 → CAGR 약 0%")
+    void 가격_고정_시계열_CAGR_0() {
+        List<Double> series = flatSeries(1_500_000, 36);
+
+        PriceModel model = PriceModel.estimate(series);
+
+        assertEquals(0.0, model.cagr(), TOLERANCE);
+    }
+
+    @Test
+    @DisplayName("연 5% 성장 시계열의 annualDrift → ln(1.05) ≈ 0.0488")
+    void annualDrift_연속복리_검증() {
+        double annualRate = 0.05;
+        List<Double> series = growingSeries(1_000_000, annualRate, 36);
+
+        PriceModel model = PriceModel.estimate(series);
+
+        double expectedDrift = Math.log(1 + annualRate);
+        assertEquals(expectedDrift, model.annualDrift(), TOLERANCE);
+    }
+
+    // ------------------------------------------------------------------
+    // 변동성(σ) 추정
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("노이즈 없는 시계열 → σ ≈ 0")
+    void 노이즈_없는_시계열_변동성_0() {
+        List<Double> series = growingSeries(1_000_000, 0.05, 36);
+
+        PriceModel model = PriceModel.estimate(series);
+
+        assertEquals(0.0, model.annualVol(), TOLERANCE);
+    }
+
+    @Test
+    @DisplayName("노이즈를 심은 시계열 → σ > 0")
+    void 노이즈_있는_시계열_변동성_양수() {
+        List<Double> series = noisySeries(1_000_000, 0.05, 0.10, 36);
+
+        PriceModel model = PriceModel.estimate(series);
+
+        assertTrue(model.annualVol() > 0,
+                "노이즈가 있으면 σ가 0보다 커야 한다. 실제=" + model.annualVol());
+    }
+
+    // ------------------------------------------------------------------
+    // months 필드
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("36개월 시계열 → months = 36")
+    void months_필드_검증() {
+        List<Double> series = growingSeries(1_000_000, 0.05, 36);
+
+        PriceModel model = PriceModel.estimate(series);
+
+        assertEquals(36, model.months());
+    }
+
+    // ------------------------------------------------------------------
+    // 헬퍼
+    // ------------------------------------------------------------------
+
+    /** 초기값에서 연간 annualRate로 복리 성장하는 n개월 시계열 (노이즈 없음). */
+    private List<Double> growingSeries(double initial, double annualRate, int n) {
+        double monthlyRate = Math.pow(1 + annualRate, 1.0 / 12) - 1;
+        List<Double> series = new ArrayList<>(n);
+        for (int t = 0; t < n; t++) {
+            series.add(initial * Math.pow(1 + monthlyRate, t));
+        }
+        return series;
+    }
+
+    /** 모든 월이 동일한 가격인 n개월 시계열. */
+    private List<Double> flatSeries(double price, int n) {
+        List<Double> series = new ArrayList<>(n);
+        for (int i = 0; i < n; i++) series.add(price);
+        return series;
+    }
+
+    /**
+     * 연간 annualRate로 성장하되 월별로 vol 크기의 노이즈를 더한 n개월 시계열.
+     * 노이즈는 결정적(시드 고정 대신 sin 함수)으로 생성해 재현성을 확보한다.
+     */
+    private List<Double> noisySeries(double initial, double annualRate, double vol, int n) {
+        double monthlyRate = Math.pow(1 + annualRate, 1.0 / 12) - 1;
+        List<Double> series = new ArrayList<>(n);
+        for (int t = 0; t < n; t++) {
+            double trend = initial * Math.pow(1 + monthlyRate, t);
+            double noise = trend * vol * Math.sin(t);
+            series.add(trend + noise);
+        }
+        return series;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #81 

## 📝 작업 내용

몬테카를로 시뮬레이션과 추천 알고리즘 모두 연간 성장률(μ)과 연율 변동성(σ)을 입력값으로 필요로 합니다. 두 값 모두 같은 월별 평단가 시계열에서 나오므로, 따로 만들면 시계열 정규화를 두 번 하게 됩니다. 이를 `PriceModel` 하나로 묶어 몬테카를로, 추천 알고리즘이 이 결과를 그대로 입력으로 쓸 수 있습니다.

### 🖋️ 설계 결정
- 두 시점 CAGR 대신 OLS 회귀를 쓰는 이유: `ln(price) ~ t` 회귀로 기울기를 추출하면 엔드포인트(첫 달, 마지막 달) 예외 상황에 강합니다. 특정 달 거래가 우연히 비싸거나 싸게 끝나도 결과가 왜곡되지 않습니다.

- 보증금, 월세 범위 필터를 두지 않는 이유: `RentMedianService`는 사용자 예산 범위로 좁힌 현재 시세를 보고, `PriceModelService`는 시장 전체 흐름을 36개월 시계열로 분석합니다. 목적이 다르므로 사용자 예산으로 시장 흐름을 좁히면 왜곡된 μ, σ가 나올 가능성이 있습니다.

- `RentMedianService`와 교체 관계가 아닌 이유: `HoldOutAlgorithm`은 `RentMedianService`로 현재 Q3 시세를 받아 `futurePrice`로 고정합니다. `PriceModelService`는 μ와 σ를 제공해 미래 가격 투영에 사용합니다. 인터페이스 교체가 아니라 나중에 HoldOut이 `futurePrice = depositQ3 × exp(μ × n/12)`로 바꿀 때 추가로 주입받으면 됩니다.

&nbsp;

### 🛠️ 구현 내용

  **핵심 상수 (PriceModelServiceImpl)**
  
  | 상수 | 값 | 이유 |
  |---|---|---|
  | `WINDOW_MONTHS` | 36 | 3년치 시계열이 있어야 회귀가 의미 있음 |
  | `MIN_SAMPLES_PER_MONTH` | 5 | 표본이 적은 달은 중앙값 노이즈가 크므로 제외 |
  | `MIN_VALID_MONTHS` | 6 | 유효 달이 이 미만이면 회귀 자체가 의미 없음 |

  처리 흐름은 아래와 같습니다.
  
최근 3년 실거래 조회 (dealYm, deposit, area)
    → dealYm 기준 월별 그룹핑
    → 표본 5건 미만 월 제외
    → 남은 달을 시간순 정렬
    → 월별 평단가 중앙값 산출 (deposit / (area ÷ 3.305785))
    → 유효 월 6개 미만이면 PROPERTY_INSUFFICIENT_DATA (422)
    → PriceModel.estimate() 호출
    → { annualDrift(μ), cagr, annualVol(σ), months } 반환
  
 아래는 출력값의 용도입니다.

  | 필드 | 용도 |
  |---|---|
  | `annualDrift` (μ) | 몬테카를로 drift 입력값 |
  | `annualVol` (σ) | 몬테카를로 volatility 입력값 |
  | `cagr` | 화면 표시용. exp(μ) - 1. "연 X% 상승" |
  | `months` | 신뢰도 지표. 유효 표본 월 수 |

&nbsp;

  ### 🤔 테스트

  **PriceModelTest: 단위 7개**
  `PriceModel.estimate()` 순수 함수 검증. Spring 컨텍스트 없음.
  - 연 5%, 10% 성장 시계열 → CAGR 정확도 (±1%p 허용 오차)
  - 가격 고정 시계열 → CAGR ≈ 0%, σ ≈ 0
  - annualDrift = ln(1.05) ≈ 0.0488: μ 단위 수학적 검증
  - 노이즈 유무별 σ 검증
  - months 필드 = 입력 리스트 크기
  
  **PriceModelServiceImplTest: 단위 6개**
  Mockito로 mapper 목 처리. 서비스 로직만 검증.
  - `REGION_NOT_FOUND`·`PROPERTY_INSUFFICIENT_DATA` 예외 경로
  - 표본 5건 미만 월 필터 동작 확인
  - 가격 고정 데이터 → CAGR ≈ 0 (medianPerPyeong 간접 검증)
  - 홀수 표본 5건에서 중앙(3번째) 값 선택 확인
  - 정상 경로 응답 필드 조립
  
  **PriceModelIntegrationTest: @Disabled (실데이터 검증용)**
  `docker compose up -d` + `MOLIT_SERVICE_KEY` 환경에서만 실행.
  강남구(11680) 아파트 36개월 backfill 후 CAGR -10% ~ +30% 상식 범위 검증.
  강남구 아파트 전세 기준 3 ~ 8% 수준이면 정상.




### 스크린샷 (선택)

## 💬리뷰 요구사항
  - `MIN_SAMPLES_PER_MONTH = 5`, `MIN_VALID_MONTHS = 6` 기준이 적절한지 의견 부탁드립니다. 데이터가 희소한 지역, 유형 조합에서는 기준을 낮춰야 할 수도 있습니다.
  - `medianPerPyeong`은 월 내 거래별 `deposit / area_in_pyeong`의 중앙값을 씁니다. `median(deposit) / median(area)`와 결과가 다른데, 전자가 단위 가격의 분포를 더 정확히 반영한다고 판단했습니다.
