### PR TITLE
[REFACTOR] HoldOut 알고리즘 리팩토링 및 스코어링 개선

### DIFF
--- a/src/main/java/com/team/independence/goal/service/BudgetCalculator.java
+++ b/src/main/java/com/team/independence/goal/service/BudgetCalculator.java
@@ -34,6 +34,11 @@ public interface BudgetCalculator {
      * @param monthlySaving 월 저축액 (원)
      * @param targetAmount  목표 금액 (원)
      * @return 도달 최소 개월수. 저축액이 0 이하이거나 상한 내에 도달하지 못하면 null
+     *
+     * TODO: 현재는 targetAmount가 고정값(현재 실거래 Q3)이라 budget(m) >= currentPrice인 m을 탐색한다.
+     *       RentMedianService에 시계열 기반 미래 시세 예측이 추가되면, 목표 금액도 시점에 따라 변해야 한다.
+     *       이때 시그니처를 LongUnaryOperator(m → 예측가격(m)) 형태로 변경하고,
+     *       루프 조건을 budget(m) >= predictedPrice(m)으로 교체해야 한다.
      */
     Long monthsToReach(AssetNetWorthBreakdown netWorth, long monthlySaving, long targetAmount);
 }

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -34,7 +34,7 @@ import java.util.Optional;
  *
  * <p>지역을 기준으로 주거유형·거래유형·면적 버킷의 조합으로 후보를 생성한다.
  * 각 후보에 대해 실거래 Q3 시세와 예산 도달 개월을 구한 뒤
- * 조건 일치(cMS)·대기 패널티(WP)·여유 자산(AM) 스코어로 비교해 가장 높은 점수의 후보를 추천한다.
+ * 조건 개선(cIS)·대기 패널티(WP)·여유 자산(AM) 스코어로 비교해 가장 높은 점수의 후보를 추천한다.
  *
  * <p>기준 조건 결정 우선순위:
  * <ol>
@@ -186,14 +186,26 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
 
     /**
      * 후보 하나를 평가해 스코어를 계산한다. 필터 탈락 시 null 반환.
-     * 필터 순서: 표본 수 → 보증금 Q3 → 달성 가능 여부 → 추가 대기(m) 범위
-     * 스코어: 0.40×cMS + 0.35×WP + 0.25×AM
+     * 필터 순서: 표본 수 → 보증금 Q3 → 면적 다운그레이드 → 달성 가능 여부 → 추가 대기(m) 범위
+     * 스코어: 0.40×cIS + 0.35×WP + 0.25×AM
      */
     private ScoredCandidate evaluate(HousingCondition candidate, BaseCondition base,
                                      AssetNetWorthBreakdown netWorth, long monthlySaving, long n,
                                      long maxExtra) {
         RentMedianResponse median = fetchAndValidateMedian(candidate);
         if (median == null) return null;
+
+        // Soft filter: 희망 면적 중간값보다 작은 후보(다운그레이드) 제외
+        // Hard Constraint(지역·거래유형·주거유형)는 generateCandidates에서 이미 필터링된 상태
+        int bMin = base.areaMin != null ? base.areaMin : DEFAULT_AREA_MIN;
+        int bMax = base.areaMax != null ? base.areaMax : DEFAULT_AREA_MAX;
+        double baseMidArea      = (bMin + bMax) / 2.0;
+        double candidateMidArea = (candidate.areaMin + candidate.areaMax) / 2.0;
+        if (candidateMidArea < baseMidArea) {
+            log.debug("{} → 제외 (면적 다운그레이드: 후보 {}평 < 기준 {}평)",
+                    candidate.label(), candidateMidArea, baseMidArea);
+            return null;
+        }
 
         BudgetMetrics metrics = calcBudgetMetrics(candidate, median, netWorth, monthlySaving, n);
         if (metrics == null) return null;
@@ -207,15 +219,15 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
         // totalMonths <= n+maxExtra 이므로 maxBudget >= futureBudget >= futurePrice → AM >= 0
         long maxBudget = budgetCalculator.calculate(netWorth, metrics.effectiveSaving, n + maxExtra);
         double affordabilityMargin = (double)(maxBudget - metrics.futurePrice) / maxBudget;
-        double condMatchScore = calcConditionMatchScore(base, candidate);
-        double waitPenalty    = 1.0 / (1.0 + metrics.m / 12.0);
-        double score = 0.40 * condMatchScore
+        double condImprovScore = calcConditionImprovementScore(baseMidArea, candidateMidArea);
+        double waitPenalty     = 1.0 / (1.0 + metrics.m / 12.0);
+        double score = 0.40 * condImprovScore
                      + 0.35 * waitPenalty
                      + 0.25 * affordabilityMargin;
 
-        log.debug("{} deposit={} effectiveSaving={} totalMonths={} m={} cMS={} WP={} AM={} score={}",
+        log.debug("{} deposit={} effectiveSaving={} totalMonths={} m={} cIS={} WP={} AM={} score={}",
                 candidate.label(), metrics.futurePrice, metrics.effectiveSaving, metrics.totalMonths, metrics.m,
-                String.format("%.2f", condMatchScore), String.format("%.3f", waitPenalty),
+                String.format("%.2f", condImprovScore), String.format("%.3f", waitPenalty),
                 String.format("%.3f", affordabilityMargin), String.format("%.4f", score));
 
         return new ScoredCandidate(candidate, median, metrics.futurePrice, metrics.totalMonths, metrics.m, score);
@@ -248,6 +260,10 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
      */
     private BudgetMetrics calcBudgetMetrics(HousingCondition candidate, RentMedianResponse median,
                                              AssetNetWorthBreakdown netWorth, long monthlySaving, long n) {
+        // TODO: 현재는 최근 실거래 Q3를 그대로 사용하지만, totalMonths개월 후 시세는 다를 수 있다.
+        //       RentMedianService에 시계열 기반 미래 시세 예측이 추가되면,
+        //       targetYearMonth(= now.plusMonths(totalMonths))를 candidate에 포함해 예측값을 사용해야 한다.
+        //       현재는 예산(미래값) vs 가격(현재값)의 비대칭이 존재한다.
         long futurePrice = median.getDeposit().getQ3();
 
         long effectiveSaving = monthlySaving;
@@ -272,34 +288,22 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
     }
 
     /**
-     * 후보 조건이 기준 조건(BaseCondition)과 얼마나 일치하는지 0.0~1.0으로 계산한다.
-     * 조건이 null이면 무관심으로 간주해 만점 처리한다.
+     * CIS (Condition Improvement Score): 후보 면적이 기준 조건 대비 얼마나 개선되었는지 0.0~1.0으로 계산한다.
      *
-     * <p>주거유형(0.5) + 면적 겹침 비율(0.5). 지역은 모든 후보가 동일 지역이므로 포함하지 않는다.
-     * 면적은 희망 범위[areaMin, areaMax]와 후보 버킷의 겹치는 구간 비율로 부분 점수를 부여한다.
+     * <p>Hard Constraint(지역·거래유형·주거유형)는 generateCandidates에서 필터링되므로 포함하지 않는다.
+     * 다운그레이드 후보(candidateMidArea &lt; baseMidArea)는 evaluate에서 이미 제외되므로 delta &ge; 0이 보장된다.
+     * 가격 개선(가격 &darr;)은 AM(Affordability Margin)이 담당하므로 여기서는 면적만 평가한다.
+     *
+     * <p>공식: clamp(0.5 + delta / 20.0, 0.0, 1.0)
+     * <ul>
+     *   <li>delta = 0평 (기준과 동일 면적): 0.5</li>
+     *   <li>delta = +5평 (한 버킷 업그레이드): 0.75</li>
+     *   <li>delta = +10평 이상: 1.0 (최대)</li>
+     * </ul>
      */
-    private double calcConditionMatchScore(BaseCondition base, HousingCondition candidate) {
-        double score = 0.0;
-
-        // 주거 유형 (0.5)
-        if (base.housingType == null || base.housingType == candidate.housingType) {
-            score += 0.5;
-        }
-
-        // 면적 겹침 비율 (0.5) — binary 판정 대신 겹치는 구간으로 부분 점수 부여
-        if (base.areaMin == null && base.areaMax == null) {
-            score += 0.5;
-        } else {
-            int bMin = base.areaMin != null ? base.areaMin : 0;
-            int bMax = base.areaMax != null ? base.areaMax : 999;
-            int overlapStart = Math.max(candidate.areaMin, bMin);
-            int overlapEnd   = Math.min(candidate.areaMax, bMax);
-            if (overlapStart < overlapEnd) {
-                score += 0.5 * (double)(overlapEnd - overlapStart) / AREA_STEP;
-            }
-        }
-
-        return score;
+    private double calcConditionImprovementScore(double baseMidArea, double candidateMidArea) {
+        double delta = candidateMidArea - baseMidArea;
+        return Math.min(1.0, Math.max(0.0, 0.5 + delta / 20.0));
     }
 
     /**

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -250,13 +250,14 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
                                              AssetNetWorthBreakdown netWorth, long monthlySaving, long n) {
         long futurePrice = median.getDeposit().getQ3();
 
-        // 월세 후보: 월세만큼 실질 저축 여력이 줄어드는 것으로 반영
         long effectiveSaving = monthlySaving;
         if (candidate.dealType == DealType.WOLSE) {
             Long rentQ3 = median.getMonthlyRent() != null ? median.getMonthlyRent().getQ3() : null;
-            if (rentQ3 != null) {
-                effectiveSaving = Math.max(0, monthlySaving - rentQ3);
+            if (rentQ3 == null) {
+                log.debug("{} → 제외 (월세 Q3 없음 — effectiveSaving 추정 불가)", candidate.label());
+                return null;
             }
+            effectiveSaving = Math.max(0, monthlySaving - rentQ3);
         }
 
         Long totalMonths = budgetCalculator.monthsToReach(netWorth, effectiveSaving, futurePrice);

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -89,33 +89,26 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
                 ? goalHousingMapper.findByGoalId(activeGoal.getId())
                 : null;
 
-        BaseCondition base = resolveCondition(request, housing);
+        BaseCondition base = resolveCondition(request, housing, activeGoal);
         if (base == null) return Optional.empty();
 
-        YearMonth now = YearMonth.now(); // 기준 시점 통일 — 이후 계산에서 재사용
+        YearMonth now = YearMonth.now(); // 기준 시점 통일
         AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
         long monthlySaving = resolveMonthlySaving(memberId);
-        long n = calcRemainingMonths(request, activeGoal, now);
+        long n = base.targetDate != null ? Math.max(0, ChronoUnit.MONTHS.between(now, base.targetDate)) : 0;
 
         long maxExtra = Math.min(Math.max(n, MIN_EXTRA_MONTHS), MAX_EXTRA_MONTHS);
 
-        List<String> evalLogs = new ArrayList<>();
         ScoredCandidate best = null;
         ScoredCandidate bestAlreadyAchievable = null;
         for (HousingCondition candidate : generateCandidates(base)) {
-            ScoredCandidate scored = evaluate(candidate, base, netWorth, monthlySaving, n, maxExtra, evalLogs);
+            ScoredCandidate scored = evaluate(candidate, base, netWorth, monthlySaving, n, maxExtra);
             if (scored == null) continue;
             if (scored.m == 0) {
                 if (bestAlreadyAchievable == null || scored.score > bestAlreadyAchievable.score) bestAlreadyAchievable = scored;
             } else {
                 if (best == null || scored.score > best.score) best = scored;
             }
-        }
-
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder("\n[HoldOut] 후보 평가 요약 memberId=").append(memberId);
-            evalLogs.forEach(line -> sb.append("\n  ").append(line));
-            log.debug(sb.toString());
         }
 
         // HoldOut 범위(1~maxExtra) 후보가 없으면 현재 계획으로 이미 달성 가능한 후보로 대체
@@ -127,10 +120,8 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
             return Optional.empty();
         }
 
-        log.info("[HoldOut] 최종 선택 memberId={} {}/{} area=[{},{}] futurePrice={} m={}개월 score={} alreadyAchievable={}",
-                memberId,
-                best.candidate.housingType, best.candidate.dealType,
-                best.candidate.areaMin, best.candidate.areaMax,
+        log.info("[HoldOut] 최종 선택 memberId={} {} futurePrice={} m={}개월 score={} alreadyAchievable={}",
+                memberId, best.candidate.label(),
                 best.futurePrice, best.m, String.format("%.4f", best.score), isAlreadyAchievable);
 
         YearMonth targetDate = now.plusMonths(best.totalMonths);
@@ -194,34 +185,70 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
     }
 
     /**
-     * 후보 하나를 평가해 스코어를 계산한다. 필터 탈락 시 null 반환. 평가 내역은 evalLogs에 누적.
+     * 후보 하나를 평가해 스코어를 계산한다. 필터 탈락 시 null 반환.
      * 필터 순서: 표본 수 → 보증금 Q3 → 달성 가능 여부 → 추가 대기(m) 범위
      * 스코어: 0.40×cMS + 0.35×WP + 0.25×AM
      */
     private ScoredCandidate evaluate(HousingCondition candidate, BaseCondition base,
                                      AssetNetWorthBreakdown netWorth, long monthlySaving, long n,
-                                     long maxExtra, List<String> evalLogs) {
-        String label = candidate.housingType + "/" + candidate.dealType
-                + " area=[" + candidate.areaMin + "," + candidate.areaMax + "]";
+                                     long maxExtra) {
+        RentMedianResponse median = fetchAndValidateMedian(candidate);
+        if (median == null) return null;
 
+        BudgetMetrics metrics = calcBudgetMetrics(candidate, median, netWorth, monthlySaving, n);
+        if (metrics == null) return null;
+
+        if (metrics.m > maxExtra) {
+            log.debug("{} → 제외 (m={}, 허용범위 0~{})", candidate.label(), metrics.m, maxExtra);
+            return null;
+        }
+
+        // AM: n+maxExtra 시점의 최대 예산 대비 여유 — 후보 가격이 쌀수록 높아져 변별력 있음
+        // totalMonths <= n+maxExtra 이므로 maxBudget >= futureBudget >= futurePrice → AM >= 0
+        long maxBudget = budgetCalculator.calculate(netWorth, metrics.effectiveSaving, n + maxExtra);
+        double affordabilityMargin = (double)(maxBudget - metrics.futurePrice) / maxBudget;
+        double condMatchScore = calcConditionMatchScore(base, candidate);
+        double waitPenalty    = 1.0 / (1.0 + metrics.m / 12.0);
+        double score = 0.40 * condMatchScore
+                     + 0.35 * waitPenalty
+                     + 0.25 * affordabilityMargin;
+
+        log.debug("{} deposit={} effectiveSaving={} totalMonths={} m={} cMS={} WP={} AM={} score={}",
+                candidate.label(), metrics.futurePrice, metrics.effectiveSaving, metrics.totalMonths, metrics.m,
+                String.format("%.2f", condMatchScore), String.format("%.3f", waitPenalty),
+                String.format("%.3f", affordabilityMargin), String.format("%.4f", score));
+
+        return new ScoredCandidate(candidate, median, metrics.futurePrice, metrics.totalMonths, metrics.m, score);
+    }
+
+    /**
+     * 후보의 시세를 조회하고 표본 수·Q3 존재 여부를 검증한다. 탈락 시 null 반환.
+     */
+    private RentMedianResponse fetchAndValidateMedian(HousingCondition candidate) {
         RentMedianResponse median;
         try {
             median = rentMedianService.getMedian(candidate.toMedianRequest());
         } catch (Exception e) {
-            evalLogs.add(label + " → 제외 (가격 조회 실패: " + e.getMessage() + ")");
+            log.debug("{} → 제외 (가격 조회 실패: {})", candidate.label(), e.getMessage());
             return null;
         }
-
         if (median.getSampleCount() < MIN_SAMPLE_COUNT) {
-            evalLogs.add(label + " → 제외 (표본 부족: " + median.getSampleCount() + "건)");
+            log.debug("{} → 제외 (표본 부족: {}건)", candidate.label(), median.getSampleCount());
             return null;
         }
-        Long depositQ3 = median.getDeposit().getQ3();
-        if (depositQ3 == null) {
-            evalLogs.add(label + " → 제외 (보증금 Q3 없음)");
+        if (median.getDeposit().getQ3() == null) {
+            log.debug("{} → 제외 (보증금 Q3 없음)", candidate.label());
             return null;
         }
-        long futurePrice = depositQ3;
+        return median;
+    }
+
+    /**
+     * 시세와 자산 정보를 기반으로 예산 지표를 계산한다. 달성 불가(저축 불충분 등)이면 null 반환.
+     */
+    private BudgetMetrics calcBudgetMetrics(HousingCondition candidate, RentMedianResponse median,
+                                             AssetNetWorthBreakdown netWorth, long monthlySaving, long n) {
+        long futurePrice = median.getDeposit().getQ3();
 
         // 월세 후보: 월세만큼 실질 저축 여력이 줄어드는 것으로 반영
         long effectiveSaving = monthlySaving;
@@ -234,43 +261,13 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
 
         Long totalMonths = budgetCalculator.monthsToReach(netWorth, effectiveSaving, futurePrice);
         if (totalMonths == null) {
-            evalLogs.add(String.format("%s → 제외 (달성 불가: deposit=%,d effectiveSaving=%,d)",
-                    label, futurePrice, effectiveSaving));
-            return null;
-        }
-
-        long futureBudget = budgetCalculator.calculate(netWorth, effectiveSaving, totalMonths);
-        if (futureBudget < futurePrice) {
-            evalLogs.add(String.format("%s → 제외 (예산 부족: budget=%,d price=%,d)", label, futureBudget, futurePrice));
+            log.debug("{} → 제외 (달성 불가: deposit={} effectiveSaving={})",
+                    candidate.label(), futurePrice, effectiveSaving);
             return null;
         }
 
         long m = Math.max(0, totalMonths - n);
-
-        // m>maxExtra: 너무 긴 대기 → 현실적이지 않음 (m=0은 bestAlreadyAchievable 후보로 올려보냄)
-        if (m > maxExtra) {
-            evalLogs.add(String.format("%s → 제외 (m=%d, 허용범위 0~%d)", label, m, maxExtra));
-            return null;
-        }
-
-        // AM: n+maxExtra 시점의 최대 예산 대비 여유 — 후보 가격이 쌀수록 높아져 변별력 있음
-        // totalMonths <= n+maxExtra 이므로 maxBudget >= futureBudget >= futurePrice → AM >= 0
-        long maxBudget = budgetCalculator.calculate(netWorth, effectiveSaving, n + maxExtra);
-        double affordabilityMargin = (double)(maxBudget - futurePrice) / maxBudget;
-
-        double condMatchScore = calcConditionMatchScore(base, candidate);
-        double waitPenalty    = 1.0 / (1.0 + m / 12.0);
-
-        double score = 0.40 * condMatchScore
-                     + 0.35 * waitPenalty
-                     + 0.25 * affordabilityMargin;
-
-        evalLogs.add(String.format(
-                "%s deposit=%,d effectiveSaving=%,d totalMonths=%d m=%d cMS=%.2f WP=%.3f AM=%.3f score=%.4f",
-                label, futurePrice, effectiveSaving, totalMonths, m,
-                condMatchScore, waitPenalty, affordabilityMargin, score));
-
-        return new ScoredCandidate(candidate, median, futurePrice, totalMonths, m, score);
+        return new BudgetMetrics(futurePrice, effectiveSaving, totalMonths, m);
     }
 
     /**
@@ -305,13 +302,17 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
     }
 
     /**
-     * request → housing 순으로 기준 조건을 병합해 BaseCondition을 반환한다.
+     * request → housing 순으로 기준 조건과 목표 시점을 병합해 BaseCondition을 반환한다.
      * regionCode만 필수이며, 나머지가 null이면 generateCandidates에서 기본값 또는 전체 탐색으로 보완한다.
      * regionCode를 확보할 수 없으면 null 반환.
      */
-    private BaseCondition resolveCondition(GoalRecommendationRequest req, GoalHousing housing) {
+    private BaseCondition resolveCondition(GoalRecommendationRequest req, GoalHousing housing, Goal activeGoal) {
         String regionCode = pick(req.getRegionCode(), housing != null ? housing.getRegionCode() : null);
         if (regionCode == null) return null;
+
+        YearMonth targetDate = req.getTargetDate() != null ? req.getTargetDate()
+                : (activeGoal != null && activeGoal.getTargetDate() != null)
+                    ? YearMonth.from(activeGoal.getTargetDate()) : null;
 
         return new BaseCondition(
                 regionCode,
@@ -320,27 +321,14 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
                 pick(req.getSizeMin(),        housing != null ? housing.getAreaMin()        : null),
                 pick(req.getSizeMax(),        housing != null ? housing.getAreaMax()        : null),
                 pick(req.getMonthlyRentMin(), housing != null ? housing.getMonthlyRentMin() : null),
-                pick(req.getMonthlyRentMax(), housing != null ? housing.getMonthlyRentMax() : null));
+                pick(req.getMonthlyRentMax(), housing != null ? housing.getMonthlyRentMax() : null),
+                targetDate);
     }
 
     /** 현재 자산 연동 기반의 월 저축액. 0이면 기존 자산만으로 달성 가능한 후보만 살아남는다. */
     private long resolveMonthlySaving(long memberId) {
         Long savings = assetSummaryService.getSummary(memberId).getMonthlySavings();
         return savings != null ? savings : 0L;
-    }
-
-    /**
-     * 현재 시점(now)으로부터 목표 시점까지 남은 개월 수(n)를 반환한다.
-     * 우선순위: request.targetDate > 활성 목표의 targetDate > 0
-     */
-    private long calcRemainingMonths(GoalRecommendationRequest request, Goal activeGoal, YearMonth now) {
-        if (request.getTargetDate() != null) {
-            return Math.max(0, ChronoUnit.MONTHS.between(now, request.getTargetDate()));
-        }
-        if (activeGoal != null && activeGoal.getTargetDate() != null) {
-            return Math.max(0, ChronoUnit.MONTHS.between(now, YearMonth.from(activeGoal.getTargetDate())));
-        }
-        return 0;
     }
 
     private String buildReason(long extraMonths) {
@@ -359,13 +347,18 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
     /** resolveCondition 결과 — regionCode 이외 필드는 null 허용 */
     private record BaseCondition(
             String regionCode, HousingType housingType, DealType dealType,
-            Integer areaMin, Integer areaMax, Long rentMin, Long rentMax) { }
+            Integer areaMin, Integer areaMax, Long rentMin, Long rentMax,
+            YearMonth targetDate) { }
 
     private record HousingCondition(
             String regionCode, HousingType housingType, DealType dealType, int areaMin,
             int areaMax, long depositMin, long depositMax, Long monthlyRentMin,
             Long monthlyRentMax
     ) {
+        String label() {
+            return housingType + "/" + dealType + " area=[" + areaMin + "," + areaMax + "]";
+        }
+
         RentMedianRequest toMedianRequest() {
             RentMedianRequest r = new RentMedianRequest();
             r.setRegionCode(regionCode);
@@ -382,6 +375,8 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
             return r;
         }
     }
+
+    private record BudgetMetrics(long futurePrice, long effectiveSaving, long totalMonths, long m) {}
 
     private record ScoredCandidate(
             HousingCondition candidate, RentMedianResponse median, long futurePrice,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #83

## 📝 작업 내용

### 1. 데드코드 제거 및 메서드 분리

`evaluate` 메서드가 시세 조회·예산 계산·스코어 계산을 모두 담당하던 구조를 분리했습니다.

- `evalLogs(List<String>)` 제거 → `log.debug`로 대체 (호출자 오염 제거)
- `futureBudget < futurePrice` 체크 제거 — `monthsToReach` 반환 시 `budget >= price` 가 이미 보장됨
- `evaluate` → `fetchAndValidateMedian` + `calcBudgetMetrics`로 분리
- `HousingCondition.label()` 추가, `BudgetMetrics` record 추가
- `calcRemainingMonths` 제거 → `targetDate`를 `BaseCondition`에 포함해 `resolveCondition`에서 통합 처리

### 2. WOLSE 월세 Q3 null 처리 버그 수정

`rentQ3 == null`일 때 월세를 차감하지 않고 조용히 통과시켜, 실질 저축 여력(`effectiveSaving`)이 과대 계산되는 버그를 수정했습니다.

- 변경 전: `if (rentQ3 != null) effectiveSaving -= rentQ3` → null이면 그냥 통과
- 변경 후: `if (rentQ3 == null) return null` → 데이터 없는 WOLSE 후보 제외

### 3. ConditionImprovementScore(cIS) + 면적 다운그레이드 Soft Filter

HoldOut의 핵심 가치("더 기다려서 **더 좋은** 집")가 기존 `ConditionMatchScore(cMS)`에 반영되지 않던 문제를 해결했습니다.

- **Soft Filter 추가**: `candidateMidArea < baseMidArea`인 다운그레이드 후보를 스코어링 전 제외
- **cMS → cIS 교체**: 면적 개선 델타 기반 선형 점수
  - 공식: `clamp(0.5 + delta/20.0, 0, 1)`
  - delta=0평 → 0.5 / +5평 → 0.75 / +10평 이상 → 1.0

| 점수 | 역할 |
|------|------|
| cIS (40%) | 면적 개선 — 얼마나 더 넓은 집인가 |
| WP (35%) | 대기 패널티 — 얼마나 더 기다려야 하나 |
| AM (25%) | 가격 개선 — 예산 여유 |

> Hard Constraint(지역·거래유형·주거유형)는 `generateCandidates`에서 이미 처리되므로 Soft Filter는 면적 방향성만 추가로 보장합니다.

### 4. BudgetCalculator.monthsToReach TODO 추가

실거래가 예측 미지원으로 인한 예산(미래값) vs 가격(현재값) 비대칭 문제와, 이를 해결할 때 필요한 시그니처 변경 방향을 TODO로 명시했습니다.

## 💬리뷰 요구사항(선택)