### PR TITLE
feat(goal): 현실 우선(REALISTIC) 추천 알고리즘 구현

### DIFF
--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationRequest.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationRequest.java
@@ -4,6 +4,8 @@ import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import java.time.YearMonth;
 import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
 import lombok.Getter;
@@ -24,7 +26,15 @@ import lombok.Setter;
 @NoArgsConstructor
 public class GoalRecommendationRequest {
 
-    /** 법정동코드 앞 5자리(시군구) 또는 시도 2자리 */
+    /**
+     * 법정동코드 앞 5자리(시군구) 또는 시도 2자리. 유일한 필수 조건이다.
+     *
+     * <p>추천이 사용자가 지정한 시도를 벗어나지 않기 때문에 탐색 범위를 여는 기준점이 되고,
+     * 지역 없이는 어떤 알고리즘도 실거래를 조회할 수 없어 필수로 둔다.
+     * 시도 2자리면 시군구는 알고리즘이 정하고, 5자리면 그 시군구로 고정된다.
+     */
+    @NotBlank(message = "지역 코드는 필수입니다.")
+    @Pattern(regexp = "\\d{2}|\\d{5}", message = "지역 코드는 시도 2자리 또는 시군구 5자리여야 합니다.")
     private String regionCode;
 
     /** 선택. null이면 전 주거유형 탐색 */

--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
@@ -36,6 +36,15 @@ public class GoalRecommendationResponse {
         private DealType dealType;
         private int areaMin;
         private int areaMax;
+
+        /**
+         * 월세 중앙값 (원). 전세({@code dealType=JEONSE})면 0.
+         *
+         * <p>월세는 보증금과 함께 봐야 조건이 완성되는데 플랜 쪽에는 목돈만 담기므로 여기에 둔다.
+         * 알고리즘 내부에서는 월세를 전세 환산 금액으로 바꿔 비교하지만, 여기 담기는 값은
+         * 환산값이 아니라 사용자가 실제로 매달 내는 금액이다.
+         */
+        private long monthlyRent;
     }
 
     @Getter

--- a/src/main/java/com/team/independence/goal/service/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/RealisticAlgorithm.java
@@ -16,6 +16,7 @@ import com.team.independence.property.service.RentMedianService;
 import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -30,13 +31,22 @@ import org.springframework.stereotype.Service;
  * 2년을 그대로 두고 "그 안에 도달 가능한 조건은 여기까지"를 답한다. 조건을 고정하고 시점을 늘리는
  * {@code HOLD_OUT}과 정확히 반대 방향이며, 같은 사람에게 같은 데이터로 상반된 답을 주는 한 쌍이다.
  *
- * <h3>지역만 지키고 나머지는 조정한다</h3>
- * 사용자가 지정한 <b>지역은 어떤 경우에도 벗어나지 않는다.</b> 반면 주거유형·평수·거래유형은
- * 사용자가 값을 줬더라도 조정 대상이다. 예산이 남으면 올려 잡고 모자라면 내려 잡는다.
+ * <h3>사용자 조건에서 출발해, 안 될 때만 푼다</h3>
+ * 탐색의 시작점은 기본값이 아니라 <b>사용자가 입력한 조건</b>이다. 빈 칸만 기본값으로 채운다.
  *
- * <p>입력 조건을 그대로 지키지 않는 이유는, 그 역할이 {@code PREFERENCE} 카드의 것이기 때문이다.
- * 두 카드가 같은 조건을 가리키면 REALISTIC은 "현실적인 대안"을 주는 대신 진단만 하게 된다.
- * 조건을 전부 지정한 사용자에게도 조정된 대안을 내려면 지역 외에는 열어 두어야 한다.
+ * <ol>
+ *   <li><b>1차</b> — 사용자가 준 조건을 지킨 채, 주지 않은 항목만 움직여 본다.
+ *       목표 시점 안에 되는 것이 있으면 <b>거기서 끝낸다.</b> 갈 수 있는 사람의 조건을
+ *       마음대로 바꾸지 않는다</li>
+ *   <li><b>2차</b> — 1차로는 목표 시점을 못 지킬 때만 사용자가 준 조건까지 풀고 다시 찾는다.
+ *       "그 조건으로는 어려우니 이런 대안은 어떠냐"에 해당한다</li>
+ * </ol>
+ *
+ * <p>지역은 2차에서도 풀지 않는다. 사는 곳을 옮기는 것은 조건을 조정하는 것과 성격이 다르다.
+ *
+ * <p>2차까지 가는 이유는, 조건을 전부 지정한 사용자에게 조정 여지가 없다고 "입력하신 조건은
+ * 108개월 걸립니다"라고만 답하면 대안을 주는 카드가 아니라 진단만 하는 카드가 되기 때문이다.
+ * 입력 그대로의 결과는 {@code PREFERENCE} 카드가 이미 보여준다.
  *
  * <h3>전세와 월세를 같은 저울에 올리는 방법</h3>
  * 월세는 "보증금이 작으니 싸다"가 아니다. 전세도 보증금이 묶여 이자를 못 버는 만큼 비용이 있다.
@@ -145,15 +155,32 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
             return Optional.empty();
         }
 
-        // 2단계: 그 시군구 안에서 조건 최적화
-        List<Candidate> candidates = evaluateConditions(regionCode, request, budget);
-        if (candidates.isEmpty()) {
+        // 2단계: 사용자가 준 조건을 지킨 채, 주지 않은 항목만 움직여 본다
+        List<Candidate> asRequested = evaluateConditions(regionCode, request, budget, true);
+        Optional<Candidate> keepingInput = bestWithinTarget(asRequested);
+        if (keepingInput.isPresent()) {
+            return Optional.of(assemble(memberId, keepingInput.get(), targetDate, desiredMonths, false));
+        }
+
+        // 3단계: 입력한 조건으로는 목표 시점을 못 지킨다. 그때만 조건을 풀고 다시 찾는다.
+        // 준 조건이 하나도 없으면 1차가 이미 전 범위 탐색이라 다시 조회하지 않는다.
+        List<Candidate> relaxed = hasInputCondition(request)
+                ? evaluateConditions(regionCode, request, budget, false)
+                : asRequested;
+        if (relaxed.isEmpty()) {
             log.warn("실거래 표본이 있는 조합이 없습니다. memberId={}, regionCode={}", memberId, regionCode);
             return Optional.empty();
         }
 
-        Candidate chosen = choose(candidates);
-        return Optional.of(assemble(memberId, chosen, targetDate, desiredMonths, request));
+        Candidate chosen = bestWithinTarget(relaxed).orElseGet(() -> cheapest(relaxed));
+        return Optional.of(assemble(memberId, chosen, targetDate, desiredMonths, true));
+    }
+
+    /** 사용자가 지역 외에 조정 가능한 조건을 하나라도 줬는가 */
+    private boolean hasInputCondition(GoalRecommendationRequest request) {
+        return request.getPropertyType() != null
+                || request.getTradeType() != null
+                || (request.getSizeMin() != null && request.getSizeMax() != null);
     }
 
     // ===== 1단계: 지역 =====
@@ -179,11 +206,17 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
             return null;
         }
 
-        // 지역끼리 비교하려면 같은 잣대여야 하므로 기준 조합은 요청과 무관하게 고정한다.
-        int[] size = SIZE_BUCKETS[REFERENCE_SIZE_BUCKET];
+        // 지역끼리 비교하려면 같은 잣대여야 하므로 조합 하나를 고정하는데, 그 조합은 기본값이 아니라
+        // 사용자가 입력한 조건이다. 빈 칸만 기본값으로 채운다.
+        HousingType housingType = request.getPropertyType() != null
+                ? request.getPropertyType() : REFERENCE_HOUSING_TYPE;
+        DealType dealType = request.getTradeType() != null
+                ? request.getTradeType() : REFERENCE_DEAL_TYPE;
+        int[] size = inputSize(request) != null ? inputSize(request) : SIZE_BUCKETS[REFERENCE_SIZE_BUCKET];
+
         List<Candidate> ranked = new ArrayList<>();
         for (String code : sigunguCodes) {
-            evaluate(code, REFERENCE_HOUSING_TYPE, REFERENCE_DEAL_TYPE, size[0], size[1], request, budget)
+            evaluate(code, housingType, dealType, size[0], size[1], request, budget)
                     .ifPresent(ranked::add);
         }
         if (ranked.isEmpty()) {
@@ -203,18 +236,18 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
     // ===== 2단계: 조건 =====
 
     /**
-     * 확정된 시군구 안에서 평수·주거유형·거래유형의 모든 조합을 평가한다.
+     * 확정된 시군구 안에서 조합들을 평가한다.
      *
-     * <p>사용자가 지정한 값이 있어도 후보를 좁히지 않는다. 좁히면 조정할 여지가 사라져 입력을 그대로
-     * 되돌려주게 되는데, 그건 {@code PREFERENCE} 카드가 할 일이다.
+     * @param keepInput true면 사용자가 준 항목은 그 값으로 고정하고 주지 않은 항목만 펼친다.
+     *                  false면 사용자가 준 항목까지 전부 펼친다.
      */
     private List<Candidate> evaluateConditions(
-            String regionCode, GoalRecommendationRequest request, Budget budget) {
+            String regionCode, GoalRecommendationRequest request, Budget budget, boolean keepInput) {
 
         List<Candidate> candidates = new ArrayList<>();
-        for (int[] size : SIZE_BUCKETS) {
-            for (HousingType housingType : HousingType.values()) {
-                for (DealType dealType : DealType.values()) {
+        for (int[] size : sizeCandidates(request, keepInput)) {
+            for (HousingType housingType : housingTypeCandidates(request, keepInput)) {
+                for (DealType dealType : dealTypeCandidates(request, keepInput)) {
                     evaluate(regionCode, housingType, dealType, size[0], size[1], request, budget)
                             .ifPresent(candidates::add);
                 }
@@ -224,22 +257,55 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
     }
 
     /**
-     * 최종 추천을 고른다.
+     * 목표 시점 안에 도달 가능한 것 중 <b>가장 비싼</b> 것.
      *
-     * <p>목표 시점 안에 도달 가능한 것 중 <b>가장 비싼</b> 것을 고른다. 가격이 곧 주거 수준의 대리
-     * 지표라, 예산을 남기지 않고 쓰는 쪽이 사용자에게 더 나은 집이다. 이 규칙 하나로 "여유로우면 상향,
-     * 모자라면 하향"이 모두 처리된다.
-     *
-     * <p>도달 가능한 것이 하나도 없으면 가장 싼 것을 고른다. 그것이 이 조건에서 목표 시점에 가장 가까운
-     * 후보이며, 카드는 "여기까지가 가능하다" 대신 "가장 가까운 것이 이것이고 N개월 걸린다"고 말한다.
+     * <p>가격이 곧 주거 수준의 대리 지표라, 예산을 남기지 않고 쓰는 쪽이 더 나은 집이다.
+     * 이 규칙 하나로 "여유로우면 더 좋은 조건, 모자라면 낮은 조건"이 모두 처리되어
+     * 상향·하향을 따로 구현하지 않아도 된다.
      */
-    private Candidate choose(List<Candidate> candidates) {
+    private Optional<Candidate> bestWithinTarget(List<Candidate> candidates) {
         return candidates.stream()
                 .filter(Candidate::withinTarget)
-                .max(Comparator.comparingLong(Candidate::getComparableAmount))
-                .orElseGet(() -> candidates.stream()
-                        .min(Comparator.comparingLong(Candidate::getComparableAmount))
-                        .orElseThrow(IllegalStateException::new));
+                .max(Comparator.comparingLong(Candidate::getComparableAmount));
+    }
+
+    /**
+     * 가장 싼 것. 목표 시점 안에 되는 것이 하나도 없을 때 쓴다.
+     *
+     * <p>예산이 고정이므로 가장 싼 것이 곧 목표 시점에 가장 가까운 후보다. 카드는 이때
+     * "여기까지 가능하다" 대신 "가장 가까운 것이 이것이고 N개월 걸린다"고 말한다.
+     */
+    private Candidate cheapest(List<Candidate> candidates) {
+        return candidates.stream()
+                .min(Comparator.comparingLong(Candidate::getComparableAmount))
+                .orElseThrow(IllegalStateException::new);
+    }
+
+    // ===== 후보군 산출 =====
+
+    private List<int[]> sizeCandidates(GoalRecommendationRequest request, boolean keepInput) {
+        int[] input = inputSize(request);
+        return keepInput && input != null ? List.of(input) : Arrays.asList(SIZE_BUCKETS);
+    }
+
+    private List<HousingType> housingTypeCandidates(GoalRecommendationRequest request, boolean keepInput) {
+        return keepInput && request.getPropertyType() != null
+                ? List.of(request.getPropertyType())
+                : Arrays.asList(HousingType.values());
+    }
+
+    private List<DealType> dealTypeCandidates(GoalRecommendationRequest request, boolean keepInput) {
+        return keepInput && request.getTradeType() != null
+                ? List.of(request.getTradeType())
+                : Arrays.asList(DealType.values());
+    }
+
+    /** 사용자가 준 평수. 하한·상한 중 하나라도 없으면 범위가 성립하지 않아 없는 것으로 본다. */
+    private int[] inputSize(GoalRecommendationRequest request) {
+        if (request.getSizeMin() == null || request.getSizeMax() == null) {
+            return null;
+        }
+        return new int[]{request.getSizeMin(), request.getSizeMax()};
     }
 
     // ===== 후보 평가 =====
@@ -313,7 +379,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
 
     private GoalRecommendationResponse.RecommendationItem assemble(
             long memberId, Candidate chosen, YearMonth targetDate,
-            long desiredMonths, GoalRecommendationRequest request) {
+            long desiredMonths, boolean adjusted) {
 
         // 화면에 나가는 목표 금액은 환산값이 아니라 실제로 모아야 하는 보증금이다.
         LoanPlans plans = loanPlanCalculator.calculate(memberId, chosen.getDeposit(), targetDate);
@@ -331,7 +397,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         return GoalRecommendationResponse.RecommendationItem.builder()
                 .type(AlgorithmType.REALISTIC)
                 .title(buildTitle(chosen, desiredMonths))
-                .reason(buildReason(chosen, desiredMonths))
+                .reason(buildReason(chosen, desiredMonths, adjusted))
                 .condition(condition)
                 .loanX(plans.getLoanX())
                 .loanO(plans.getLoanO())
@@ -352,7 +418,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
      * <p>목표 시점 안에 되는 경우와 못 되는 경우는 카드가 하는 말 자체가 다르므로 문구를 갈라 쓴다.
      * 후자는 조건을 조정해도 시점을 못 지킨다는 뜻이라, 가능하다고 말하면 거짓이 된다.
      */
-    private String buildReason(Candidate chosen, long desiredMonths) {
+    private String buildReason(Candidate chosen, long desiredMonths, boolean adjusted) {
         String condition = String.format("%s %s %d~%d평 %s",
                 chosen.getRegionName(), label(chosen.getHousingType()),
                 chosen.getAreaMin(), chosen.getAreaMax(), label(chosen.getDealType()));
@@ -366,7 +432,12 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
                     "%d개월 안에 가능한 조건은 찾지 못했습니다. %s가 가장 가까우며 %d개월이 필요합니다.",
                     desiredMonths, condition, chosen.getReachMonths());
         }
-        return String.format("%d개월을 지키면서 갈 수 있는 가장 나은 조건은 %s입니다.", desiredMonths, condition);
+        if (adjusted) {
+            return String.format(
+                    "입력하신 조건으로는 %d개월을 지키기 어렵습니다. %s로 바꾸면 그 안에 도달할 수 있습니다.",
+                    desiredMonths, condition);
+        }
+        return String.format("%s로 %d개월 안에 도달할 수 있습니다.", condition, desiredMonths);
     }
 
     private static String label(HousingType housingType) {

--- a/src/main/java/com/team/independence/goal/service/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/RealisticAlgorithm.java
@@ -18,7 +18,9 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -60,17 +62,24 @@ import org.springframework.stereotype.Service;
  * 보증금이다. 월세 매물을 추천하면서 환산값을 목표 금액으로 보여주면 실제보다 몇 배 큰 금액을
  * 모으라는 말이 되기 때문이다.
  *
- * <h3>탐색 순서</h3>
- * <ol>
- *   <li>시군구 선정 — 기준 조합 하나로 시도 내 시군구 시세를 훑어 예산에 맞는 가장 좋은 곳을 고른다</li>
- *   <li>조건 최적화 — 그 시군구 안에서 평수·주거유형·거래유형 조합을 평가해 예산 이하 최선을 고른다</li>
- * </ol>
- * 주거유형과 시군구의 우열은 우리가 정하지 않고 <b>실거래 가격이 정한다</b>. 임의로 정한 선호 순서를
- * 만들지 않기 위해서다.
+ * <h3>조건을 내리는 순서는 없다</h3>
+ * 평수를 먼저 깎고 안 되면 유형을 깎는 식의 순서를 두지 않았다. 그런 순서는 우리가 정할 근거가 없고,
+ * 무엇보다 <b>한 방향으로 내려가면 처음 걸린 곳에서 멈춰 더 나은 답을 놓친다</b>. "아파트 4~9평"에서
+ * 예산이 맞았다고 멈추면 "오피스텔 15~19평"이 더 나은 선택인데도 확인조차 하지 않게 된다.
  *
- * <p><b>알려진 한계</b>: 시군구를 1단계에서 확정하므로, "지역을 더 낮추면 더 좋은 평수·유형이
- * 가능한" 조합은 놓칠 수 있다. 전 조합 탐색은 시군구 수 × 유형 × 평수 × 거래유형이라 요청 한 번에
- * 수백 번의 실거래 집계 쿼리가 필요해 의도적으로 포기한 범위다. 사전집계 테이블이 생기면 넓힐 수 있다.
+ * <p>대신 후보를 <b>전부 평가한 뒤 예산에 맞는 것 중 가장 비싼 것</b>을 고른다. 가격이 곧 주거 수준의
+ * 대리 지표라, 이 규칙 하나가 "여유로우면 더 좋은 조건, 모자라면 낮은 조건"을 모두 처리한다.
+ * 주거유형과 시군구의 우열도 우리가 정하지 않고 실거래 가격이 정한다.
+ *
+ * <h3>지역은 한 번만 정하고 다시 내리지 않는다</h3>
+ * 시군구는 조건 탐색보다 <b>먼저</b> 확정한다. 이때 예산에 맞는 시군구가 하나도 없으면 가장 싼
+ * 시군구를 고르므로, 지역을 낮추는 일은 이 시점에 이미 끝난다. 조건을 다 풀어도 목표 시점을 못
+ * 지키는 경우에도 지역을 다시 건드리지 않는다. 더 내릴 지역이 남아 있지 않기 때문이다.
+ *
+ * <p><b>알려진 한계</b>: 여기서 고르는 "가장 싼 시군구"는 어디까지나 <b>시작 조합 기준</b>이다.
+ * 다른 유형·평수로 보면 더 싼 시군구가 있을 수 있는데, 지역과 조건을 함께 훑으려면
+ * 시군구 수 × 유형 × 평수 × 거래유형이라 요청 한 번에 수백 번의 집계 쿼리가 필요해
+ * 의도적으로 포기한 범위다. 사전집계 테이블이 생기면 넓힐 수 있다.
  */
 @Slf4j
 @Service
@@ -145,10 +154,10 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
         long monthlySaving = resolveMonthlySaving(memberId);
 
-        Budget budget = new Budget(netWorth, monthlySaving, desiredMonths);
+        Search search = new Search(netWorth, monthlySaving, desiredMonths);
 
         // 1단계: 시군구 확정
-        String regionCode = selectRegion(request, budget);
+        String regionCode = selectRegion(request, search);
         if (regionCode == null) {
             log.warn("추천 가능한 시군구를 찾지 못했습니다. memberId={}, regionCode={}",
                     memberId, request.getRegionCode());
@@ -156,7 +165,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         }
 
         // 2단계: 사용자가 준 조건을 지킨 채, 주지 않은 항목만 움직여 본다
-        List<Candidate> asRequested = evaluateConditions(regionCode, request, budget, true);
+        List<Candidate> asRequested = evaluateConditions(regionCode, request, search, true);
         Optional<Candidate> keepingInput = bestWithinTarget(asRequested);
         if (keepingInput.isPresent()) {
             return Optional.of(assemble(memberId, keepingInput.get(), targetDate, desiredMonths, false));
@@ -165,7 +174,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         // 3단계: 입력한 조건으로는 목표 시점을 못 지킨다. 그때만 조건을 풀고 다시 찾는다.
         // 준 조건이 하나도 없으면 1차가 이미 전 범위 탐색이라 다시 조회하지 않는다.
         List<Candidate> relaxed = hasInputCondition(request)
-                ? evaluateConditions(regionCode, request, budget, false)
+                ? evaluateConditions(regionCode, request, search, false)
                 : asRequested;
         if (relaxed.isEmpty()) {
             log.warn("실거래 표본이 있는 조합이 없습니다. memberId={}, regionCode={}", memberId, regionCode);
@@ -195,7 +204,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
      *
      * @return 시군구 코드. 시도에 조회 가능한 시군구가 아예 없으면 null
      */
-    private String selectRegion(GoalRecommendationRequest request, Budget budget) {
+    private String selectRegion(GoalRecommendationRequest request, Search search) {
         String requested = request.getRegionCode();
         if (requested.length() == 5) {
             return requested; // 사용자가 지정한 시군구는 보호 대상
@@ -216,7 +225,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
 
         List<Candidate> ranked = new ArrayList<>();
         for (String code : sigunguCodes) {
-            evaluate(code, housingType, dealType, size[0], size[1], request, budget)
+            evaluate(code, housingType, dealType, size[0], size[1], request, search)
                     .ifPresent(ranked::add);
         }
         if (ranked.isEmpty()) {
@@ -242,13 +251,13 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
      *                  false면 사용자가 준 항목까지 전부 펼친다.
      */
     private List<Candidate> evaluateConditions(
-            String regionCode, GoalRecommendationRequest request, Budget budget, boolean keepInput) {
+            String regionCode, GoalRecommendationRequest request, Search search, boolean keepInput) {
 
         List<Candidate> candidates = new ArrayList<>();
         for (int[] size : sizeCandidates(request, keepInput)) {
             for (HousingType housingType : housingTypeCandidates(request, keepInput)) {
                 for (DealType dealType : dealTypeCandidates(request, keepInput)) {
-                    evaluate(regionCode, housingType, dealType, size[0], size[1], request, budget)
+                    evaluate(regionCode, housingType, dealType, size[0], size[1], request, search)
                             .ifPresent(candidates::add);
                 }
             }
@@ -310,10 +319,30 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
 
     // ===== 후보 평가 =====
 
-    /** 조합 하나의 실거래 median을 조회해 환산보증금과 도달 개월까지 계산한다. */
+    /**
+     * 조합 하나의 실거래 median을 조회해 환산보증금과 도달 개월까지 계산한다.
+     *
+     * <p>이미 확인한 조합은 다시 조회하지 않는다. 1차(입력 조건 유지)에서 본 조합은 2차(조건 해제)의
+     * 후보에 그대로 포함되고, 시군구를 고를 때 쓴 조합도 1차 후보와 겹칠 수 있다. 실거래 집계는
+     * 6개월치를 훑는 쿼리라 중복 조회가 그대로 응답 시간이 된다.
+     */
     private Optional<Candidate> evaluate(
             String regionCode, HousingType housingType, DealType dealType,
-            int areaMin, int areaMax, GoalRecommendationRequest request, Budget budget) {
+            int areaMin, int areaMax, GoalRecommendationRequest request, Search search) {
+
+        String key = regionCode + "|" + housingType + "|" + dealType + "|" + areaMin + "|" + areaMax;
+        Optional<Candidate> cached = search.evaluated.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        Optional<Candidate> result = lookUp(regionCode, housingType, dealType, areaMin, areaMax, request, search);
+        search.evaluated.put(key, result);
+        return result;
+    }
+
+    private Optional<Candidate> lookUp(
+            String regionCode, HousingType housingType, DealType dealType,
+            int areaMin, int areaMax, GoalRecommendationRequest request, Search search) {
 
         RentMedianResponse median;
         try {
@@ -336,12 +365,12 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         long comparableAmount = toComparableAmount(deposit, monthlyRent);
 
         Long reachMonths = goalService.calculateMonthToReach(
-                budget.netWorth, budget.monthlySaving, comparableAmount);
+                search.netWorth, search.monthlySaving, comparableAmount);
 
         return Optional.of(new Candidate(
                 regionCode, median.getRegionName(), housingType, dealType,
                 areaMin, areaMax, deposit, monthlyRent, comparableAmount,
-                reachMonths, budget.desiredMonths));
+                reachMonths, search.desiredMonths));
     }
 
     /**
@@ -484,13 +513,20 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         return summary.getMonthlySavings() != null ? summary.getMonthlySavings() : 0L;
     }
 
-    /** 목표 시점이 고정이라 후보마다 다시 계산할 필요가 없는 값들 */
-    private static class Budget {
+    /**
+     * 추천 한 번을 처리하는 동안 바뀌지 않는 값들과, 그동안 이미 확인한 조합.
+     *
+     * <p>목표 시점을 절대 바꾸지 않는 카드라서 예산 계산의 재료가 후보와 무관하게 고정된다.
+     * 같은 이유로 조합별 조회 결과도 한 번의 추천 안에서는 언제 조회하든 같은 값이라 재사용할 수 있다.
+     */
+    private static class Search {
         private final AssetNetWorthBreakdown netWorth;
         private final long monthlySaving;
         private final long desiredMonths;
+        /** 조합 키 → 평가 결과. 표본이 없어 후보가 되지 못한 조합도 담아 재조회를 막는다. */
+        private final Map<String, Optional<Candidate>> evaluated = new HashMap<>();
 
-        private Budget(AssetNetWorthBreakdown netWorth, long monthlySaving, long desiredMonths) {
+        private Search(AssetNetWorthBreakdown netWorth, long monthlySaving, long desiredMonths) {
             this.netWorth = netWorth;
             this.monthlySaving = monthlySaving;
             this.desiredMonths = desiredMonths;

--- a/src/main/java/com/team/independence/goal/service/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/RealisticAlgorithm.java
@@ -1,0 +1,550 @@
+package com.team.independence.goal.service;
+
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import com.team.independence.asset.dto.summary.AssetSummaryResponse;
+import com.team.independence.asset.service.AssetSummaryService;
+import com.team.independence.goal.dto.AlgorithmType;
+import com.team.independence.goal.dto.GoalRecommendationRequest;
+import com.team.independence.goal.dto.GoalRecommendationResponse;
+import com.team.independence.goal.dto.LoanPlans;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.RentMedianRequest;
+import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.mapper.RegionMapper;
+import com.team.independence.property.service.RentMedianService;
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 현실 우선 추천 — 목표 시점을 고정한 채 조건을 맞춘다.
+ *
+ * <p>이 카드의 정체성은 <b>시점을 절대 늘리지 않는 것</b>이다. 사용자가 "2년 안에"라고 하면
+ * 2년을 그대로 두고 "그 안에 도달 가능한 조건은 여기까지"를 답한다. 조건을 고정하고 시점을 늘리는
+ * {@code HOLD_OUT}과 정확히 반대 방향이며, 같은 사람에게 같은 데이터로 상반된 답을 주는 한 쌍이다.
+ *
+ * <h3>보호 필드와 자유 필드</h3>
+ * 사용자가 값을 준 조건은 <b>방향과 무관하게 건드리지 않는다</b>(보호). 값을 주지 않은 조건만
+ * 알고리즘이 위아래로 움직인다(자유). 예산이 남으면 자유 필드를 올려 더 나은 집을 잡고,
+ * 모자라면 내려 잡는다. 지역(시도)은 필수 입력이며 어떤 경우에도 벗어나지 않는다.
+ *
+ * <h3>전세와 월세를 같은 저울에 올리는 방법</h3>
+ * 월세는 "보증금이 작으니 싸다"가 아니다. 전세도 보증금이 묶여 이자를 못 버는 만큼 비용이 있다.
+ * 그래서 월세를 전세 환산 보증금으로 바꿔 비교한다.
+ * <pre>환산보증금 = 보증금 + (월세 × 12 ÷ 이자율)</pre>
+ * 이때 쓰는 이자율은 외부 전월세전환율 통계가 아니라 이 서비스가 이미 쓰고 있는 연 5%
+ * ({@code GoalServiceImpl.ANNUAL_INTEREST_RATE})다. 자산이 5%로 불어난다고 계산해 놓고 기회비용은
+ * 다른 이율로 잡으면 모순이라, 모델 내부에서 일관된 값을 쓴다.
+ *
+ * <p>환산보증금은 <b>비교·판정에만</b> 쓴다. 화면에 나가는 목표 금액은 사용자가 실제로 모아야 하는
+ * 보증금이다. 월세 매물을 추천하면서 환산값을 목표 금액으로 보여주면 실제보다 몇 배 큰 금액을
+ * 모으라는 말이 되기 때문이다.
+ *
+ * <h3>탐색 순서</h3>
+ * <ol>
+ *   <li>시군구 선정 — 기준 조합 하나로 시도 내 시군구 시세를 훑어 예산에 맞는 가장 좋은 곳을 고른다</li>
+ *   <li>조건 최적화 — 그 시군구 안에서 평수·주거유형·거래유형 조합을 평가해 예산 이하 최선을 고른다</li>
+ * </ol>
+ * 주거유형과 시군구의 우열은 우리가 정하지 않고 <b>실거래 가격이 정한다</b>. 임의로 정한 선호 순서를
+ * 만들지 않기 위해서다.
+ *
+ * <p><b>알려진 한계</b>: 시군구를 1단계에서 확정하므로, "지역을 더 낮추면 더 좋은 평수·유형이
+ * 가능한" 조합은 놓칠 수 있다. 전 조합 탐색은 시군구 수 × 유형 × 평수 × 거래유형이라 요청 한 번에
+ * 수백 번의 실거래 집계 쿼리가 필요해 의도적으로 포기한 범위다. 사전집계 테이블이 생기면 넓힐 수 있다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RealisticAlgorithm implements RecommendationAlgorithm {
+
+    /**
+     * 허용 배수 상한. (도달 개월 ÷ 희망 개월)이 이 값 이하인 후보만 "목표 시점 안에 가능"으로 본다.
+     *
+     * <p>1.0은 목표 시점을 정확히 지킨다는 뜻이다. 올리면 그만큼 목표 시점을 넘긴 후보도 받아들이게
+     * 되므로, 이 카드가 "시점을 지킨다"고 한 약속을 얼마나 느슨하게 볼지의 값이다.
+     */
+    private static final double MAX_REACH_RATIO = 1.0;
+
+    /**
+     * 목표 시점 미지정 시 기본값(개월).
+     *
+     * <p>주택임대차보호법상 기본 임대차 기간이 2년이라, 사용자가 정하지 않았을 때 다음 계약 주기를
+     * 목표로 잡는 것이 자연스럽다.
+     */
+    private static final int DEFAULT_TARGET_MONTHS = 24;
+
+    /**
+     * 평수 구간(평). 넓은 쪽이 앞이다.
+     *
+     * <p>사용자가 평수를 지정하지 않았을 때 이 구간들을 후보로 쓴다. 구간을 끊어 쓰는 이유는,
+     * 범위를 넓게 잡으면 성격이 다른 매물이 한 median에 섞여 대표값의 의미가 흐려지기 때문이다.
+     */
+    private static final int[][] SIZE_BUCKETS = {{20, 25}, {15, 19}, {10, 14}, {4, 9}};
+
+    /** 시군구 시세를 서로 비교할 때 기준으로 삼는 평수 구간 (15~19평) */
+    private static final int REFERENCE_SIZE_BUCKET = 1;
+
+    /** 시군구 비교 기준 주거유형. 실거래 표본이 가장 많아 빈 지역이 생길 확률이 낮다. */
+    private static final HousingType REFERENCE_HOUSING_TYPE = HousingType.APT;
+
+    /** 시군구 비교 기준 거래유형. 환산 없이 그대로 목돈으로 비교되는 쪽이다. */
+    private static final DealType REFERENCE_DEAL_TYPE = DealType.JEONSE;
+
+    /**
+     * 이보다 표본이 적은 조합은 median을 신뢰하지 않고 건너뛴다.
+     *
+     * <p>단독다가구나 비수도권처럼 거래가 드문 조건에서 한두 건짜리 median이 추천을 좌우하는 것을 막는다.
+     */
+    private static final int MIN_SAMPLE_COUNT = 3;
+
+    /** 보증금 필터 미지정 시 사용할 상한(원). 사실상 무제한. */
+    private static final long DEPOSIT_MAX_DEFAULT = 100_000_000_000L;
+
+    /**
+     * 월세를 목돈으로 환산할 때 쓰는 연 이자율.
+     *
+     * <p>{@code GoalServiceImpl.ANNUAL_INTEREST_RATE}와 같은 값이어야 한다. 자산 성장률과 기회비용률이
+     * 어긋나면 "전세가 유리한지 월세가 유리한지"의 판단이 모델 내부에서 모순된다.
+     */
+    private static final double ANNUAL_INTEREST_RATE = 0.05;
+
+    private final AssetSummaryService assetSummaryService;
+    private final RentMedianService rentMedianService;
+    private final RegionMapper regionMapper;
+    private final LoanPlanCalculator loanPlanCalculator;
+    /** 저축 복리 계산을 재사용하기 위한 의존. 같은 식을 두 곳에 두지 않으려는 것이다. */
+    private final GoalService goalService;
+
+    @Override
+    public Optional<GoalRecommendationResponse.RecommendationItem> recommend(
+            long memberId, GoalRecommendationRequest request) {
+
+        YearMonth targetDate = resolveTargetDate(request);
+        long desiredMonths = monthsUntil(targetDate);
+
+        AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
+        long monthlySaving = resolveMonthlySaving(memberId);
+
+        Budget budget = new Budget(netWorth, monthlySaving, desiredMonths);
+
+        // 1단계: 시군구 확정
+        String regionCode = selectRegion(request, budget);
+        if (regionCode == null) {
+            log.warn("추천 가능한 시군구를 찾지 못했습니다. memberId={}, regionCode={}",
+                    memberId, request.getRegionCode());
+            return Optional.empty();
+        }
+
+        // 2단계: 그 시군구 안에서 조건 최적화
+        List<Candidate> candidates = evaluateConditions(regionCode, request, budget);
+        if (candidates.isEmpty()) {
+            log.warn("실거래 표본이 있는 조합이 없습니다. memberId={}, regionCode={}", memberId, regionCode);
+            return Optional.empty();
+        }
+
+        Candidate chosen = choose(candidates);
+        return Optional.of(assemble(memberId, chosen, targetDate, desiredMonths, request));
+    }
+
+    // ===== 1단계: 지역 =====
+
+    /**
+     * 추천할 시군구를 정한다. 사용자가 시군구(5자리)를 줬으면 그대로 쓰고, 시도(2자리)만 줬으면
+     * 기준 조합 하나로 시도 내 시군구를 훑어 예산에 맞는 가장 좋은 곳을 고른다.
+     *
+     * <p>예산에 맞는 곳이 하나도 없으면 가장 싼 시군구를 돌려준다. 여기서 포기하지 않는 이유는,
+     * 그 경우에도 "이 시도에서 가장 가까운 조건은 이것이고 N개월이 필요하다"고 답하는 편이
+     * 빈손보다 낫기 때문이다.
+     *
+     * @return 시군구 코드. 시도에 조회 가능한 시군구가 아예 없으면 null
+     */
+    private String selectRegion(GoalRecommendationRequest request, Budget budget) {
+        String requested = request.getRegionCode();
+        if (requested.length() == 5) {
+            return requested; // 사용자가 지정한 시군구는 보호 대상
+        }
+
+        List<String> sigunguCodes = regionMapper.findCodesBySidoPrefix(requested);
+        if (sigunguCodes.isEmpty()) {
+            return null;
+        }
+
+        HousingType housingType = request.getPropertyType() != null
+                ? request.getPropertyType() : REFERENCE_HOUSING_TYPE;
+        DealType dealType = request.getTradeType() != null
+                ? request.getTradeType() : REFERENCE_DEAL_TYPE;
+        int[] size = resolveReferenceSize(request);
+
+        List<Candidate> ranked = new ArrayList<>();
+        for (String code : sigunguCodes) {
+            evaluate(code, housingType, dealType, size[0], size[1], request, budget)
+                    .ifPresent(ranked::add);
+        }
+        if (ranked.isEmpty()) {
+            return null;
+        }
+
+        // 예산에 맞는 곳 중 가장 좋은(비싼) 곳. 없으면 가장 싼 곳.
+        return ranked.stream()
+                .filter(Candidate::withinTarget)
+                .max(Comparator.comparingLong(Candidate::getComparableAmount))
+                .orElseGet(() -> ranked.stream()
+                        .min(Comparator.comparingLong(Candidate::getComparableAmount))
+                        .orElseThrow(IllegalStateException::new))
+                .getRegionCode();
+    }
+
+    // ===== 2단계: 조건 =====
+
+    /**
+     * 확정된 시군구 안에서 평수·주거유형·거래유형의 모든 조합을 평가한다.
+     * 사용자가 지정한 항목은 후보가 하나로 고정되므로 그만큼 조합 수가 줄어든다.
+     */
+    private List<Candidate> evaluateConditions(
+            String regionCode, GoalRecommendationRequest request, Budget budget) {
+
+        List<Candidate> candidates = new ArrayList<>();
+        for (int[] size : resolveSizeCandidates(request)) {
+            for (HousingType housingType : resolveHousingTypeCandidates(request)) {
+                for (DealType dealType : resolveDealTypeCandidates(request)) {
+                    evaluate(regionCode, housingType, dealType, size[0], size[1], request, budget)
+                            .ifPresent(candidates::add);
+                }
+            }
+        }
+        return candidates;
+    }
+
+    /**
+     * 최종 추천을 고른다.
+     *
+     * <p>목표 시점 안에 도달 가능한 것 중 <b>가장 비싼</b> 것을 고른다. 가격이 곧 주거 수준의 대리
+     * 지표라, 예산을 남기지 않고 쓰는 쪽이 사용자에게 더 나은 집이다. 이 규칙 하나로 "여유로우면 상향,
+     * 모자라면 하향"이 모두 처리된다.
+     *
+     * <p>도달 가능한 것이 하나도 없으면 가장 싼 것을 고른다. 그것이 이 조건에서 목표 시점에 가장 가까운
+     * 후보이며, 카드는 "여기까지가 가능하다" 대신 "가장 가까운 것이 이것이고 N개월 걸린다"고 말한다.
+     */
+    private Candidate choose(List<Candidate> candidates) {
+        return candidates.stream()
+                .filter(Candidate::withinTarget)
+                .max(Comparator.comparingLong(Candidate::getComparableAmount))
+                .orElseGet(() -> candidates.stream()
+                        .min(Comparator.comparingLong(Candidate::getComparableAmount))
+                        .orElseThrow(IllegalStateException::new));
+    }
+
+    // ===== 후보 평가 =====
+
+    /** 조합 하나의 실거래 median을 조회해 환산보증금과 도달 개월까지 계산한다. */
+    private Optional<Candidate> evaluate(
+            String regionCode, HousingType housingType, DealType dealType,
+            int areaMin, int areaMax, GoalRecommendationRequest request, Budget budget) {
+
+        RentMedianResponse median;
+        try {
+            median = rentMedianService.getMedian(
+                    buildMedianRequest(regionCode, housingType, dealType, areaMin, areaMax, request));
+        } catch (RuntimeException e) {
+            // 지역 코드 오류 등으로 한 조합이 실패해도 나머지 탐색은 계속한다.
+            log.debug("실거래 조회 실패로 조합을 건너뜁니다. regionCode={}, housingType={}, dealType={}",
+                    regionCode, housingType, dealType, e);
+            return Optional.empty();
+        }
+
+        if (median.getSampleCount() < MIN_SAMPLE_COUNT || median.getDeposit().getMedian() == null) {
+            return Optional.empty();
+        }
+
+        long deposit = median.getDeposit().getMedian();
+        long monthlyRent = dealType == DealType.WOLSE && median.getMonthlyRent().getMedian() != null
+                ? median.getMonthlyRent().getMedian() : 0L;
+        long comparableAmount = toComparableAmount(deposit, monthlyRent);
+
+        Long reachMonths = goalService.calculateMonthToReach(
+                budget.netWorth, budget.monthlySaving, comparableAmount);
+
+        return Optional.of(new Candidate(
+                regionCode, median.getRegionName(), housingType, dealType,
+                areaMin, areaMax, deposit, monthlyRent, comparableAmount,
+                reachMonths, budget.desiredMonths));
+    }
+
+    /**
+     * 월세를 전세 환산 보증금으로 바꾼다. 전세는 이미 목돈이라 그대로 둔다.
+     *
+     * <p>월세 × 12를 이자율로 나눈 값은 "그 월세만큼의 이자를 낳는 원금"이다. 즉 이 금액을 보증금으로
+     * 묶어 두는 것과 매달 그 월세를 내는 것이 같은 부담이라는 뜻이다.
+     */
+    private long toComparableAmount(long deposit, long monthlyRent) {
+        if (monthlyRent <= 0) {
+            return deposit;
+        }
+        return deposit + Math.round(monthlyRent * 12 / ANNUAL_INTEREST_RATE);
+    }
+
+    private RentMedianRequest buildMedianRequest(
+            String regionCode, HousingType housingType, DealType dealType,
+            int areaMin, int areaMax, GoalRecommendationRequest request) {
+
+        RentMedianRequest median = new RentMedianRequest();
+        median.setRegionCode(regionCode);
+        median.setHousingType(housingType);
+        median.setDealType(dealType);
+        median.setAreaMin(areaMin);
+        median.setAreaMax(areaMax);
+        // 사용자가 준 금액 범위는 보호 대상이므로 조회 필터로 그대로 넘긴다.
+        median.setDepositMin(request.getDepositMin() != null ? request.getDepositMin() : 0L);
+        median.setDepositMax(request.getDepositMax() != null ? request.getDepositMax() : DEPOSIT_MAX_DEFAULT);
+        median.setMonthlyRentMin(request.getMonthlyRentMin());
+        median.setMonthlyRentMax(request.getMonthlyRentMax());
+        return median;
+    }
+
+    // ===== 후보군 산출 (보호 필드는 후보가 하나로 고정된다) =====
+
+    private List<int[]> resolveSizeCandidates(GoalRecommendationRequest request) {
+        if (request.getSizeMin() != null && request.getSizeMax() != null) {
+            return List.of(new int[]{request.getSizeMin(), request.getSizeMax()});
+        }
+        return Arrays.asList(SIZE_BUCKETS);
+    }
+
+    private List<HousingType> resolveHousingTypeCandidates(GoalRecommendationRequest request) {
+        return request.getPropertyType() != null
+                ? List.of(request.getPropertyType())
+                : Arrays.asList(HousingType.values());
+    }
+
+    private List<DealType> resolveDealTypeCandidates(GoalRecommendationRequest request) {
+        return request.getTradeType() != null
+                ? List.of(request.getTradeType())
+                : Arrays.asList(DealType.values());
+    }
+
+    /** 시군구 비교에 쓸 평수. 사용자가 지정했으면 그 값으로 비교해야 순위가 사용자 기준이 된다. */
+    private int[] resolveReferenceSize(GoalRecommendationRequest request) {
+        if (request.getSizeMin() != null && request.getSizeMax() != null) {
+            return new int[]{request.getSizeMin(), request.getSizeMax()};
+        }
+        return SIZE_BUCKETS[REFERENCE_SIZE_BUCKET];
+    }
+
+    // ===== 응답 조립 =====
+
+    private GoalRecommendationResponse.RecommendationItem assemble(
+            long memberId, Candidate chosen, YearMonth targetDate,
+            long desiredMonths, GoalRecommendationRequest request) {
+
+        // 화면에 나가는 목표 금액은 환산값이 아니라 실제로 모아야 하는 보증금이다.
+        LoanPlans plans = loanPlanCalculator.calculate(memberId, chosen.getDeposit(), targetDate);
+
+        GoalRecommendationResponse.Condition condition = GoalRecommendationResponse.Condition.builder()
+                .regionCode(chosen.getRegionCode())
+                .regionName(chosen.getRegionName())
+                .housingType(chosen.getHousingType())
+                .dealType(chosen.getDealType())
+                .areaMin(chosen.getAreaMin())
+                .areaMax(chosen.getAreaMax())
+                .monthlyRent(chosen.getMonthlyRent())
+                .build();
+
+        return GoalRecommendationResponse.RecommendationItem.builder()
+                .type(AlgorithmType.REALISTIC)
+                .title(buildTitle(chosen, desiredMonths))
+                .reason(buildReason(chosen, desiredMonths, request))
+                .condition(condition)
+                .loanX(plans.getLoanX())
+                .loanO(plans.getLoanO())
+                .build();
+    }
+
+    private String buildTitle(Candidate chosen, long desiredMonths) {
+        if (chosen.withinTarget()) {
+            return String.format("%d개월 안에 갈 수 있는 %s %s",
+                    desiredMonths, chosen.getRegionName(), label(chosen.getHousingType()));
+        }
+        return String.format("%s에서 가장 가까운 %s", chosen.getRegionName(), label(chosen.getHousingType()));
+    }
+
+    /**
+     * 무엇을 왜 그렇게 정했는지 서술한다.
+     *
+     * <p>목표 시점 안에 되는 경우와 못 되는 경우는 카드가 하는 말 자체가 다르므로 문구를 갈라 쓴다.
+     * 후자는 조건을 조정해도 시점을 못 지킨다는 뜻이라, 가능하다고 말하면 거짓이 된다.
+     */
+    private String buildReason(Candidate chosen, long desiredMonths, GoalRecommendationRequest request) {
+        String condition = String.format("%s %s %d~%d평 %s",
+                chosen.getRegionName(), label(chosen.getHousingType()),
+                chosen.getAreaMin(), chosen.getAreaMax(), label(chosen.getDealType()));
+
+        if (!chosen.withinTarget()) {
+            if (chosen.getReachMonths() == null) {
+                return String.format(
+                        "지금 저축 속도로는 %s 조건에 도달하기 어렵습니다. 저축액을 늘리면 목표가 잡힙니다.", condition);
+            }
+            return String.format(
+                    "%d개월 안에 가능한 조건은 찾지 못했습니다. %s가 가장 가까우며 %d개월이 필요합니다.",
+                    desiredMonths, condition, chosen.getReachMonths());
+        }
+
+        if (isUnchanged(chosen, request)) {
+            return String.format("입력하신 조건 그대로 %d개월 안에 도달할 수 있습니다. (%s)", desiredMonths, condition);
+        }
+        return String.format("%d개월을 지키면서 갈 수 있는 가장 나은 조건은 %s입니다.", desiredMonths, condition);
+    }
+
+    /** 사용자가 조건을 모두 지정해 알고리즘이 정한 것이 없는 경우 */
+    private boolean isUnchanged(Candidate chosen, GoalRecommendationRequest request) {
+        return request.getRegionCode().equals(chosen.getRegionCode())
+                && request.getPropertyType() != null
+                && request.getTradeType() != null
+                && request.getSizeMin() != null
+                && request.getSizeMax() != null;
+    }
+
+    private static String label(HousingType housingType) {
+        switch (housingType) {
+            case APT:
+                return "아파트";
+            case ROW_HOUSE:
+                return "연립다세대";
+            case OFFICETEL:
+                return "오피스텔";
+            case DETACHED:
+                return "단독다가구";
+            default:
+                return housingType.name();
+        }
+    }
+
+    private static String label(DealType dealType) {
+        return dealType == DealType.JEONSE ? "전세" : "월세";
+    }
+
+    // ===== 입력 정규화 =====
+
+    private YearMonth resolveTargetDate(GoalRecommendationRequest request) {
+        return request.getTargetDate() != null
+                ? request.getTargetDate()
+                : YearMonth.now().plusMonths(DEFAULT_TARGET_MONTHS);
+    }
+
+    /** 배수의 분모다. 0이 되면 나눗셈이 깨지므로 최소 1개월로 본다. */
+    private long monthsUntil(YearMonth targetDate) {
+        long months = YearMonth.now().until(targetDate, ChronoUnit.MONTHS);
+        return Math.max(months, 1);
+    }
+
+    /**
+     * 월 저축액을 자산 요약에서 가져온다. 추천 요청이 받는 값이 아니라 이미 등록돼 있는 값이다.
+     *
+     * <p>미등록(null)이면 0으로 본다. 0이면 도달 개월이 계산되지 않아 자연히 "목표 시점 안에 불가"로
+     * 흘러가므로, 별도로 막지 않고 결과가 스스로 말하게 둔다.
+     */
+    private long resolveMonthlySaving(long memberId) {
+        AssetSummaryResponse summary = assetSummaryService.getSummary(memberId);
+        return summary.getMonthlySavings() != null ? summary.getMonthlySavings() : 0L;
+    }
+
+    /** 목표 시점이 고정이라 후보마다 다시 계산할 필요가 없는 값들 */
+    private static class Budget {
+        private final AssetNetWorthBreakdown netWorth;
+        private final long monthlySaving;
+        private final long desiredMonths;
+
+        private Budget(AssetNetWorthBreakdown netWorth, long monthlySaving, long desiredMonths) {
+            this.netWorth = netWorth;
+            this.monthlySaving = monthlySaving;
+            this.desiredMonths = desiredMonths;
+        }
+    }
+
+    /** 평가가 끝난 조합 하나 */
+    private static class Candidate {
+        private final String regionCode;
+        private final String regionName;
+        private final HousingType housingType;
+        private final DealType dealType;
+        private final int areaMin;
+        private final int areaMax;
+        /** 실거래 보증금 중앙값 — 사용자가 실제로 모아야 하는 금액 */
+        private final long deposit;
+        /** 실거래 월세 중앙값 — 전세면 0 */
+        private final long monthlyRent;
+        /** 전세 환산 보증금 — 후보끼리 비교할 때만 쓰는 내부 저울 */
+        private final long comparableAmount;
+        /** 도달까지 걸리는 개월. null이면 탐색 상한 안에 도달 불가 */
+        private final Long reachMonths;
+        private final long desiredMonths;
+
+        private Candidate(String regionCode, String regionName, HousingType housingType, DealType dealType,
+                int areaMin, int areaMax, long deposit, long monthlyRent, long comparableAmount,
+                Long reachMonths, long desiredMonths) {
+            this.regionCode = regionCode;
+            this.regionName = regionName;
+            this.housingType = housingType;
+            this.dealType = dealType;
+            this.areaMin = areaMin;
+            this.areaMax = areaMax;
+            this.deposit = deposit;
+            this.monthlyRent = monthlyRent;
+            this.comparableAmount = comparableAmount;
+            this.reachMonths = reachMonths;
+            this.desiredMonths = desiredMonths;
+        }
+
+        /** 목표 시점 안에 도달 가능한가 */
+        private boolean withinTarget() {
+            return reachMonths != null && (double) reachMonths / desiredMonths <= MAX_REACH_RATIO;
+        }
+
+        private String getRegionCode() {
+            return regionCode;
+        }
+
+        private String getRegionName() {
+            return regionName;
+        }
+
+        private HousingType getHousingType() {
+            return housingType;
+        }
+
+        private DealType getDealType() {
+            return dealType;
+        }
+
+        private int getAreaMin() {
+            return areaMin;
+        }
+
+        private int getAreaMax() {
+            return areaMax;
+        }
+
+        private long getDeposit() {
+            return deposit;
+        }
+
+        private long getMonthlyRent() {
+            return monthlyRent;
+        }
+
+        private long getComparableAmount() {
+            return comparableAmount;
+        }
+
+        private Long getReachMonths() {
+            return reachMonths;
+        }
+    }
+}

--- a/src/main/java/com/team/independence/goal/service/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/RealisticAlgorithm.java
@@ -16,7 +16,6 @@ import com.team.independence.property.service.RentMedianService;
 import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -31,10 +30,13 @@ import org.springframework.stereotype.Service;
  * 2년을 그대로 두고 "그 안에 도달 가능한 조건은 여기까지"를 답한다. 조건을 고정하고 시점을 늘리는
  * {@code HOLD_OUT}과 정확히 반대 방향이며, 같은 사람에게 같은 데이터로 상반된 답을 주는 한 쌍이다.
  *
- * <h3>보호 필드와 자유 필드</h3>
- * 사용자가 값을 준 조건은 <b>방향과 무관하게 건드리지 않는다</b>(보호). 값을 주지 않은 조건만
- * 알고리즘이 위아래로 움직인다(자유). 예산이 남으면 자유 필드를 올려 더 나은 집을 잡고,
- * 모자라면 내려 잡는다. 지역(시도)은 필수 입력이며 어떤 경우에도 벗어나지 않는다.
+ * <h3>지역만 지키고 나머지는 조정한다</h3>
+ * 사용자가 지정한 <b>지역은 어떤 경우에도 벗어나지 않는다.</b> 반면 주거유형·평수·거래유형은
+ * 사용자가 값을 줬더라도 조정 대상이다. 예산이 남으면 올려 잡고 모자라면 내려 잡는다.
+ *
+ * <p>입력 조건을 그대로 지키지 않는 이유는, 그 역할이 {@code PREFERENCE} 카드의 것이기 때문이다.
+ * 두 카드가 같은 조건을 가리키면 REALISTIC은 "현실적인 대안"을 주는 대신 진단만 하게 된다.
+ * 조건을 전부 지정한 사용자에게도 조정된 대안을 내려면 지역 외에는 열어 두어야 한다.
  *
  * <h3>전세와 월세를 같은 저울에 올리는 방법</h3>
  * 월세는 "보증금이 작으니 싸다"가 아니다. 전세도 보증금이 묶여 이자를 못 버는 만큼 비용이 있다.
@@ -177,15 +179,11 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
             return null;
         }
 
-        HousingType housingType = request.getPropertyType() != null
-                ? request.getPropertyType() : REFERENCE_HOUSING_TYPE;
-        DealType dealType = request.getTradeType() != null
-                ? request.getTradeType() : REFERENCE_DEAL_TYPE;
-        int[] size = resolveReferenceSize(request);
-
+        // 지역끼리 비교하려면 같은 잣대여야 하므로 기준 조합은 요청과 무관하게 고정한다.
+        int[] size = SIZE_BUCKETS[REFERENCE_SIZE_BUCKET];
         List<Candidate> ranked = new ArrayList<>();
         for (String code : sigunguCodes) {
-            evaluate(code, housingType, dealType, size[0], size[1], request, budget)
+            evaluate(code, REFERENCE_HOUSING_TYPE, REFERENCE_DEAL_TYPE, size[0], size[1], request, budget)
                     .ifPresent(ranked::add);
         }
         if (ranked.isEmpty()) {
@@ -206,15 +204,17 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
 
     /**
      * 확정된 시군구 안에서 평수·주거유형·거래유형의 모든 조합을 평가한다.
-     * 사용자가 지정한 항목은 후보가 하나로 고정되므로 그만큼 조합 수가 줄어든다.
+     *
+     * <p>사용자가 지정한 값이 있어도 후보를 좁히지 않는다. 좁히면 조정할 여지가 사라져 입력을 그대로
+     * 되돌려주게 되는데, 그건 {@code PREFERENCE} 카드가 할 일이다.
      */
     private List<Candidate> evaluateConditions(
             String regionCode, GoalRecommendationRequest request, Budget budget) {
 
         List<Candidate> candidates = new ArrayList<>();
-        for (int[] size : resolveSizeCandidates(request)) {
-            for (HousingType housingType : resolveHousingTypeCandidates(request)) {
-                for (DealType dealType : resolveDealTypeCandidates(request)) {
+        for (int[] size : SIZE_BUCKETS) {
+            for (HousingType housingType : HousingType.values()) {
+                for (DealType dealType : DealType.values()) {
                     evaluate(regionCode, housingType, dealType, size[0], size[1], request, budget)
                             .ifPresent(candidates::add);
                 }
@@ -309,35 +309,6 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         return median;
     }
 
-    // ===== 후보군 산출 (보호 필드는 후보가 하나로 고정된다) =====
-
-    private List<int[]> resolveSizeCandidates(GoalRecommendationRequest request) {
-        if (request.getSizeMin() != null && request.getSizeMax() != null) {
-            return List.of(new int[]{request.getSizeMin(), request.getSizeMax()});
-        }
-        return Arrays.asList(SIZE_BUCKETS);
-    }
-
-    private List<HousingType> resolveHousingTypeCandidates(GoalRecommendationRequest request) {
-        return request.getPropertyType() != null
-                ? List.of(request.getPropertyType())
-                : Arrays.asList(HousingType.values());
-    }
-
-    private List<DealType> resolveDealTypeCandidates(GoalRecommendationRequest request) {
-        return request.getTradeType() != null
-                ? List.of(request.getTradeType())
-                : Arrays.asList(DealType.values());
-    }
-
-    /** 시군구 비교에 쓸 평수. 사용자가 지정했으면 그 값으로 비교해야 순위가 사용자 기준이 된다. */
-    private int[] resolveReferenceSize(GoalRecommendationRequest request) {
-        if (request.getSizeMin() != null && request.getSizeMax() != null) {
-            return new int[]{request.getSizeMin(), request.getSizeMax()};
-        }
-        return SIZE_BUCKETS[REFERENCE_SIZE_BUCKET];
-    }
-
     // ===== 응답 조립 =====
 
     private GoalRecommendationResponse.RecommendationItem assemble(
@@ -360,7 +331,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         return GoalRecommendationResponse.RecommendationItem.builder()
                 .type(AlgorithmType.REALISTIC)
                 .title(buildTitle(chosen, desiredMonths))
-                .reason(buildReason(chosen, desiredMonths, request))
+                .reason(buildReason(chosen, desiredMonths))
                 .condition(condition)
                 .loanX(plans.getLoanX())
                 .loanO(plans.getLoanO())
@@ -381,7 +352,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
      * <p>목표 시점 안에 되는 경우와 못 되는 경우는 카드가 하는 말 자체가 다르므로 문구를 갈라 쓴다.
      * 후자는 조건을 조정해도 시점을 못 지킨다는 뜻이라, 가능하다고 말하면 거짓이 된다.
      */
-    private String buildReason(Candidate chosen, long desiredMonths, GoalRecommendationRequest request) {
+    private String buildReason(Candidate chosen, long desiredMonths) {
         String condition = String.format("%s %s %d~%d평 %s",
                 chosen.getRegionName(), label(chosen.getHousingType()),
                 chosen.getAreaMin(), chosen.getAreaMax(), label(chosen.getDealType()));
@@ -395,20 +366,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
                     "%d개월 안에 가능한 조건은 찾지 못했습니다. %s가 가장 가까우며 %d개월이 필요합니다.",
                     desiredMonths, condition, chosen.getReachMonths());
         }
-
-        if (isUnchanged(chosen, request)) {
-            return String.format("입력하신 조건 그대로 %d개월 안에 도달할 수 있습니다. (%s)", desiredMonths, condition);
-        }
         return String.format("%d개월을 지키면서 갈 수 있는 가장 나은 조건은 %s입니다.", desiredMonths, condition);
-    }
-
-    /** 사용자가 조건을 모두 지정해 알고리즘이 정한 것이 없는 경우 */
-    private boolean isUnchanged(Candidate chosen, GoalRecommendationRequest request) {
-        return request.getRegionCode().equals(chosen.getRegionCode())
-                && request.getPropertyType() != null
-                && request.getTradeType() != null
-                && request.getSizeMin() != null
-                && request.getSizeMax() != null;
     }
 
     private static String label(HousingType housingType) {

--- a/src/main/java/com/team/independence/property/mapper/RegionMapper.java
+++ b/src/main/java/com/team/independence/property/mapper/RegionMapper.java
@@ -13,5 +13,13 @@ public interface RegionMapper {
     /** 시/도 + 군/구 이름으로 region_code 조회. 없으면 null. */
     String findCodeBySidoAndSigungu(@Param("sido") String sido, @Param("sigungu") String sigungu);
 
+    /**
+     * 시도 코드(법정동코드 앞 2자리)로 그 시도에 속한 시군구 코드를 모두 조회한다.
+     *
+     * <p>region 테이블은 시군구 단위로만 존재해 시도 자체를 가리키는 행이 없다.
+     * 시도 범위로 무언가를 훑어야 하는 쪽에서 대상 시군구를 먼저 확보하는 용도다.
+     */
+    List<String> findCodesBySidoPrefix(@Param("sidoPrefix") String sidoPrefix);
+
     String findFullNameByCode(@Param("code") String code);
 }

--- a/src/main/resources/mybatis/mapper/property/RegionMapper.xml
+++ b/src/main/resources/mybatis/mapper/property/RegionMapper.xml
@@ -14,6 +14,14 @@
            AND sigungu = #{sigungu}
     </select>
 
+    <!-- code가 PK라 프리픽스 검색이 인덱스 레인지 스캔으로 처리된다. -->
+    <select id="findCodesBySidoPrefix" resultType="string">
+        SELECT code
+        FROM region
+        WHERE code LIKE CONCAT(#{sidoPrefix}, '%')
+        ORDER BY code
+    </select>
+
     <select id="findFullNameByCode" resultType="string">
         SELECT full_name
         FROM region

--- a/src/test/java/com/team/independence/goal/service/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/RealisticAlgorithmTest.java
@@ -241,6 +241,27 @@ class RealisticAlgorithmTest {
     }
 
     @Test
+    @DisplayName("조건을 전부 지정해도 지역만 지키고 나머지는 조정한다")
+    void adjustsEverythingExceptRegion() {
+        // 사용자가 원한 조건(아파트 20~25평 전세)은 예산 2.4억을 훨씬 넘는다.
+        put("11110", HousingType.APT, DealType.JEONSE, 20, 9 * 억, 0);
+        // 같은 구의 더 작은 오피스텔이면 들어온다.
+        put("11110", HousingType.OFFICETEL, DealType.JEONSE, 10, 2 * 억, 0);
+
+        GoalRecommendationRequest request = request("11110", HousingType.APT, DealType.JEONSE);
+        request.setSizeMin(20);
+        request.setSizeMax(25);
+
+        RecommendationItem item = recommend(request);
+
+        // 지역은 그대로, 유형·평수는 조정됐다.
+        assertThat(item.getCondition().getRegionCode()).isEqualTo("11110");
+        assertThat(item.getCondition().getHousingType()).isEqualTo(HousingType.OFFICETEL);
+        assertThat(item.getCondition().getAreaMin()).isEqualTo(10);
+        assertThat(item.getReason()).contains("24개월을 지키면서");
+    }
+
+    @Test
     @DisplayName("실거래 표본이 아무 조합에도 없으면 추천하지 않는다")
     void returnsEmptyWhenNoMarketData() {
         Optional<RecommendationItem> result = algorithm.recommend(

--- a/src/test/java/com/team/independence/goal/service/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/RealisticAlgorithmTest.java
@@ -22,6 +22,7 @@ import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.dto.RentMedianResponse.Quartile;
 import com.team.independence.property.mapper.RegionMapper;
 import com.team.independence.property.service.RentMedianService;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,11 +71,15 @@ class RealisticAlgorithmTest {
     /** "지역|주거유형|거래유형|최소평수" → {보증금, 월세, 표본수} */
     private Map<String, long[]> market;
 
+    /** 실거래 조회가 실제로 일어난 조합. 중복 조회를 잡기 위해 순서대로 쌓는다. */
+    private List<String> lookedUp;
+
     @BeforeEach
     void setUp() {
         algorithm = new RealisticAlgorithm(
                 assetSummaryService, rentMedianService, regionMapper, loanPlanCalculator, goalService);
         market = new HashMap<>();
+        lookedUp = new ArrayList<>();
 
         when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(
                 AssetNetWorthBreakdown.builder()
@@ -94,7 +99,12 @@ class RealisticAlgorithmTest {
             return (long) Math.ceil((double) targetAmount / monthlySaving);
         });
 
-        when(rentMedianService.getMedian(any())).thenAnswer(call -> toResponse(call.getArgument(0)));
+        when(rentMedianService.getMedian(any())).thenAnswer(call -> {
+            RentMedianRequest asked = call.getArgument(0);
+            lookedUp.add(key(asked.getRegionCode(), asked.getHousingType(),
+                    asked.getDealType(), asked.getAreaMin()));
+            return toResponse(asked);
+        });
 
         when(loanPlanCalculator.calculate(anyLong(), anyLong(), any()))
                 .thenReturn(LoanPlans.builder().build());
@@ -296,6 +306,18 @@ class RealisticAlgorithmTest {
                 request("11", HousingType.OFFICETEL, DealType.WOLSE));
 
         assertThat(item.getCondition().getRegionCode()).isEqualTo("11140");
+    }
+
+    @Test
+    @DisplayName("1차와 2차에 겹치는 조합을 다시 조회하지 않는다")
+    void doesNotLookUpSameCombinationTwice() {
+        // 주거유형만 입력하면 1차는 아파트로 8가지, 2차는 32가지를 보는데 그 8가지가 2차에 포함된다.
+        // 어느 것도 예산에 맞지 않게 두어 2차까지 반드시 가도록 한다.
+        put("11110", HousingType.APT, DealType.JEONSE, 15, 90 * 억, 0);
+
+        recommend(request("11110", HousingType.APT, null));
+
+        assertThat(lookedUp).doesNotHaveDuplicates();
     }
 
     @Test

--- a/src/test/java/com/team/independence/goal/service/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/RealisticAlgorithmTest.java
@@ -241,8 +241,27 @@ class RealisticAlgorithmTest {
     }
 
     @Test
-    @DisplayName("조건을 전부 지정해도 지역만 지키고 나머지는 조정한다")
-    void adjustsEverythingExceptRegion() {
+    @DisplayName("입력한 조건으로 목표 시점 안에 되면 더 나은 게 있어도 그대로 둔다")
+    void keepsInputConditionWhenItAlreadyFits() {
+        // 사용자가 원한 조건. 예산 2.4억 안에 들어온다.
+        put("11110", HousingType.OFFICETEL, DealType.JEONSE, 10, 1 * 억, 0);
+        // 더 비싸고 예산에도 맞지만, 입력 조건이 이미 되므로 이쪽으로 바꾸면 안 된다.
+        put("11110", HousingType.APT, DealType.JEONSE, 20, 2 * 억, 0);
+
+        GoalRecommendationRequest request = request("11110", HousingType.OFFICETEL, DealType.JEONSE);
+        request.setSizeMin(10);
+        request.setSizeMax(14);
+
+        RecommendationItem item = recommend(request);
+
+        assertThat(item.getCondition().getHousingType()).isEqualTo(HousingType.OFFICETEL);
+        assertThat(item.getCondition().getAreaMin()).isEqualTo(10);
+        assertThat(item.getReason()).doesNotContain("입력하신 조건으로는");
+    }
+
+    @Test
+    @DisplayName("입력한 조건으로 목표 시점을 못 지키면 그때 조건을 풀어 대안을 찾는다")
+    void relaxesInputConditionOnlyWhenItFails() {
         // 사용자가 원한 조건(아파트 20~25평 전세)은 예산 2.4억을 훨씬 넘는다.
         put("11110", HousingType.APT, DealType.JEONSE, 20, 9 * 억, 0);
         // 같은 구의 더 작은 오피스텔이면 들어온다.
@@ -258,7 +277,25 @@ class RealisticAlgorithmTest {
         assertThat(item.getCondition().getRegionCode()).isEqualTo("11110");
         assertThat(item.getCondition().getHousingType()).isEqualTo(HousingType.OFFICETEL);
         assertThat(item.getCondition().getAreaMin()).isEqualTo(10);
-        assertThat(item.getReason()).contains("24개월을 지키면서");
+        assertThat(item.getReason()).contains("입력하신 조건으로는");
+    }
+
+    @Test
+    @DisplayName("시군구 순위는 기본값이 아니라 입력한 조건으로 매긴다")
+    void ranksRegionsByInputCondition() {
+        when(regionMapper.findCodesBySidoPrefix("11")).thenReturn(List.of("11110", "11140"));
+
+        // 사용자가 오피스텔·월세를 원했다. 기본값(아파트·전세)으로 줄을 세우면 종로가 뽑히지만,
+        // 입력 조건으로 보면 중구가 더 낫다.
+        put("11110", HousingType.APT, DealType.JEONSE, 15, 1 * 억, 0);
+        put("11140", HousingType.APT, DealType.JEONSE, 15, 5000 * 만, 0);
+        put("11110", HousingType.OFFICETEL, DealType.WOLSE, 15, 500 * 만, 30 * 만);
+        put("11140", HousingType.OFFICETEL, DealType.WOLSE, 15, 2000 * 만, 30 * 만);
+
+        RecommendationItem item = recommend(
+                request("11", HousingType.OFFICETEL, DealType.WOLSE));
+
+        assertThat(item.getCondition().getRegionCode()).isEqualTo("11140");
     }
 
     @Test

--- a/src/test/java/com/team/independence/goal/service/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/RealisticAlgorithmTest.java
@@ -1,0 +1,302 @@
+package com.team.independence.goal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import com.team.independence.asset.dto.summary.AssetSummaryResponse;
+import com.team.independence.asset.service.AssetSummaryService;
+import com.team.independence.goal.dto.AlgorithmType;
+import com.team.independence.goal.dto.GoalRecommendationRequest;
+import com.team.independence.goal.dto.GoalRecommendationResponse.RecommendationItem;
+import com.team.independence.goal.dto.LoanPlans;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.RentMedianRequest;
+import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.dto.RentMedianResponse.Quartile;
+import com.team.independence.property.mapper.RegionMapper;
+import com.team.independence.property.service.RentMedianService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * 현실 우선 추천 알고리즘 테스트.
+ *
+ * <p>실거래 시세를 조합별로 마음대로 정해 놓고, 알고리즘이 그중 무엇을 고르는지만 본다.
+ * 저축 복리 계산({@code calculateMonthToReach})은 "목표액 ÷ 월저축액" 이라는 단순한 식으로 대체했다.
+ * 복리를 그대로 쓰면 기대값을 손으로 계산하기 어려워 정작 검증하려는 선택 규칙이 가려지기 때문이다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RealisticAlgorithmTest {
+
+    private static final long MEMBER_ID = 1L;
+
+    /** 월 저축액. 기본 목표 24개월과 곱하면 예산이 2.4억이 된다. */
+    private static final long MONTHLY_SAVING = 10_000_000L;
+
+    private static final long 억 = 100_000_000L;
+    private static final long 만 = 10_000L;
+
+    @Mock
+    private AssetSummaryService assetSummaryService;
+    @Mock
+    private RentMedianService rentMedianService;
+    @Mock
+    private RegionMapper regionMapper;
+    @Mock
+    private LoanPlanCalculator loanPlanCalculator;
+    @Mock
+    private GoalService goalService;
+
+    private RealisticAlgorithm algorithm;
+
+    /** "지역|주거유형|거래유형|최소평수" → {보증금, 월세, 표본수} */
+    private Map<String, long[]> market;
+
+    @BeforeEach
+    void setUp() {
+        algorithm = new RealisticAlgorithm(
+                assetSummaryService, rentMedianService, regionMapper, loanPlanCalculator, goalService);
+        market = new HashMap<>();
+
+        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(
+                AssetNetWorthBreakdown.builder()
+                        .interestBearingAssets(0L)
+                        .flatRecognizedAssets(0L)
+                        .build());
+        when(assetSummaryService.getSummary(MEMBER_ID)).thenReturn(
+                AssetSummaryResponse.builder().monthlySavings(MONTHLY_SAVING).build());
+
+        // 목표액 ÷ 월저축액. 저축이 없으면 도달 불가(null).
+        when(goalService.calculateMonthToReach(any(), anyLong(), anyLong())).thenAnswer(call -> {
+            long monthlySaving = call.getArgument(1);
+            long targetAmount = call.getArgument(2);
+            if (monthlySaving <= 0) {
+                return null;
+            }
+            return (long) Math.ceil((double) targetAmount / monthlySaving);
+        });
+
+        when(rentMedianService.getMedian(any())).thenAnswer(call -> toResponse(call.getArgument(0)));
+
+        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any()))
+                .thenReturn(LoanPlans.builder().build());
+    }
+
+    @Test
+    @DisplayName("목표 시점 안에 가능한 후보 중 가장 좋은(비싼) 조건을 고른다")
+    void picksMostExpensiveWithinTarget() {
+        // 예산 2.4억. 2억까지는 되고 3억은 안 된다.
+        put("11110", HousingType.APT, DealType.JEONSE, 20, 3 * 억, 0);
+        put("11110", HousingType.APT, DealType.JEONSE, 15, 2 * 억, 0);
+        put("11110", HousingType.APT, DealType.JEONSE, 10, 1 * 억, 0);
+        put("11110", HousingType.APT, DealType.JEONSE, 4, 5000 * 만, 0);
+
+        RecommendationItem item = recommend(request("11110", HousingType.APT, DealType.JEONSE));
+
+        assertThat(item.getType()).isEqualTo(AlgorithmType.REALISTIC);
+        assertThat(item.getCondition().getAreaMin()).isEqualTo(15);
+        assertThat(item.getCondition().getAreaMax()).isEqualTo(19);
+        // 화면에 나가는 목표 금액은 실제 보증금이다.
+        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(2 * 억), any());
+    }
+
+    @Test
+    @DisplayName("예산이 늘면 더 좋은 조건으로 올라간다")
+    void upgradesWhenBudgetAllows() {
+        put("11110", HousingType.APT, DealType.JEONSE, 20, 3 * 억, 0);
+        put("11110", HousingType.APT, DealType.JEONSE, 15, 2 * 억, 0);
+        put("11110", HousingType.APT, DealType.JEONSE, 10, 1 * 억, 0);
+        put("11110", HousingType.APT, DealType.JEONSE, 4, 5000 * 만, 0);
+
+        // 월 저축 2천만 → 예산 4.8억. 이제 3억짜리도 들어온다.
+        when(assetSummaryService.getSummary(MEMBER_ID)).thenReturn(
+                AssetSummaryResponse.builder().monthlySavings(20_000_000L).build());
+
+        RecommendationItem item = recommend(request("11110", HousingType.APT, DealType.JEONSE));
+
+        assertThat(item.getCondition().getAreaMin()).isEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("목표 시점 안에 되는 후보가 없으면 가장 가까운 것을 알리고 가능하다고 말하지 않는다")
+    void reportsClosestWhenNothingFits() {
+        // 예산 2.4억인데 전부 그 위에 있다.
+        put("11110", HousingType.APT, DealType.JEONSE, 20, 9 * 억, 0);
+        put("11110", HousingType.APT, DealType.JEONSE, 15, 7 * 억, 0);
+        put("11110", HousingType.APT, DealType.JEONSE, 10, 5 * 억, 0);
+        put("11110", HousingType.APT, DealType.JEONSE, 4, 4 * 억, 0);
+
+        RecommendationItem item = recommend(request("11110", HousingType.APT, DealType.JEONSE));
+
+        // 가장 싼 것 = 목표 시점에 가장 가까운 것
+        assertThat(item.getCondition().getAreaMin()).isEqualTo(4);
+        assertThat(item.getReason()).contains("40개월이 필요합니다");
+    }
+
+    @Test
+    @DisplayName("월세는 전세 환산 보증금으로 비교하고, 목표 금액은 실제 보증금으로 내려간다")
+    void comparesWolseByConvertedDeposit() {
+        // 전세 3억은 예산(2.4억) 초과.
+        put("11110", HousingType.APT, DealType.JEONSE, 15, 3 * 억, 0);
+        // 월세 보증금 1,000만 + 월세 40만 → 환산 1,000만 + (480만 ÷ 0.05) = 1.06억. 예산 안에 들어온다.
+        put("11110", HousingType.APT, DealType.WOLSE, 15, 1000 * 만, 40 * 만);
+
+        GoalRecommendationRequest request = request("11110", HousingType.APT, null);
+        request.setSizeMin(15);
+        request.setSizeMax(19);
+
+        RecommendationItem item = recommend(request);
+
+        assertThat(item.getCondition().getDealType()).isEqualTo(DealType.WOLSE);
+        assertThat(item.getCondition().getMonthlyRent()).isEqualTo(40 * 만);
+        // 환산값(1.06억)이 아니라 실제로 모아야 하는 보증금(1,000만)을 넘긴다.
+        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(1000 * 만), any());
+    }
+
+    @Test
+    @DisplayName("환산했을 때 월세가 더 비싸면 전세를 고른다")
+    void prefersJeonseWhenWolseIsPricierAfterConversion() {
+        put("11110", HousingType.APT, DealType.JEONSE, 15, 2 * 억, 0);
+        // 보증금 1,000만 + 월세 10만 → 환산 3,400만. 전세 2억보다 싸므로 전세가 더 좋은 조건이다.
+        put("11110", HousingType.APT, DealType.WOLSE, 15, 1000 * 만, 10 * 만);
+
+        GoalRecommendationRequest request = request("11110", HousingType.APT, null);
+        request.setSizeMin(15);
+        request.setSizeMax(19);
+
+        RecommendationItem item = recommend(request);
+
+        assertThat(item.getCondition().getDealType()).isEqualTo(DealType.JEONSE);
+        assertThat(item.getCondition().getMonthlyRent()).isZero();
+    }
+
+    @Test
+    @DisplayName("시도만 주면 그 안에서 예산에 맞는 가장 좋은 시군구를 고른다")
+    void selectsBestAffordableSigungu() {
+        when(regionMapper.findCodesBySidoPrefix("11")).thenReturn(List.of("11110", "11140", "11170"));
+
+        // 기준 조합(아파트·전세·15~19평) 시세로 시군구 순위가 정해진다. 예산은 2.4억.
+        put("11110", HousingType.APT, DealType.JEONSE, 15, 8 * 억, 0);  // 초과
+        put("11140", HousingType.APT, DealType.JEONSE, 15, 2 * 억, 0);  // 가능 — 가장 비쌈
+        put("11170", HousingType.APT, DealType.JEONSE, 15, 1 * 억, 0);  // 가능하지만 더 쌈
+
+        RecommendationItem item = recommend(request("11", HousingType.APT, DealType.JEONSE));
+
+        assertThat(item.getCondition().getRegionCode()).isEqualTo("11140");
+    }
+
+    @Test
+    @DisplayName("사용자가 시군구를 지정하면 지역을 바꾸지 않는다")
+    void keepsUserSpecifiedSigungu() {
+        put("11110", HousingType.APT, DealType.JEONSE, 15, 2 * 억, 0);
+
+        RecommendationItem item = recommend(request("11110", HousingType.APT, DealType.JEONSE));
+
+        assertThat(item.getCondition().getRegionCode()).isEqualTo("11110");
+        verify(regionMapper, never()).findCodesBySidoPrefix(any());
+    }
+
+    @Test
+    @DisplayName("표본이 부족한 조합은 median을 믿지 않고 건너뛴다")
+    void skipsThinSamples() {
+        // 가장 비싸지만 표본 2건 → 제외되어야 한다.
+        putWithSample("11110", HousingType.APT, DealType.JEONSE, 20, 2 * 억, 0, 2);
+        put("11110", HousingType.APT, DealType.JEONSE, 15, 1 * 억, 0);
+        put("11110", HousingType.APT, DealType.JEONSE, 10, 5000 * 만, 0);
+        put("11110", HousingType.APT, DealType.JEONSE, 4, 3000 * 만, 0);
+
+        RecommendationItem item = recommend(request("11110", HousingType.APT, DealType.JEONSE));
+
+        assertThat(item.getCondition().getAreaMin()).isEqualTo(15);
+    }
+
+    @Test
+    @DisplayName("월 저축액이 등록되지 않았으면 도달 불가로 흘러간다")
+    void treatsMissingMonthlySavingAsZero() {
+        when(assetSummaryService.getSummary(MEMBER_ID)).thenReturn(
+                AssetSummaryResponse.builder().monthlySavings(null).build());
+        put("11110", HousingType.APT, DealType.JEONSE, 15, 2 * 억, 0);
+
+        RecommendationItem item = recommend(request("11110", HousingType.APT, DealType.JEONSE));
+
+        assertThat(item.getReason()).contains("도달하기 어렵습니다");
+    }
+
+    @Test
+    @DisplayName("실거래 표본이 아무 조합에도 없으면 추천하지 않는다")
+    void returnsEmptyWhenNoMarketData() {
+        Optional<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, request("11110", HousingType.APT, DealType.JEONSE));
+
+        assertThat(result).isEmpty();
+    }
+
+    // ===== 헬퍼 =====
+
+    private RecommendationItem recommend(GoalRecommendationRequest request) {
+        return algorithm.recommend(MEMBER_ID, request)
+                .orElseThrow(() -> new AssertionError("추천 결과가 비어 있습니다"));
+    }
+
+    private GoalRecommendationRequest request(String regionCode, HousingType housingType, DealType dealType) {
+        GoalRecommendationRequest request = new GoalRecommendationRequest();
+        request.setRegionCode(regionCode);
+        request.setPropertyType(housingType);
+        request.setTradeType(dealType);
+        return request;
+    }
+
+    private void put(String regionCode, HousingType housingType, DealType dealType,
+            int areaMin, long deposit, long monthlyRent) {
+        putWithSample(regionCode, housingType, dealType, areaMin, deposit, monthlyRent, 30);
+    }
+
+    private void putWithSample(String regionCode, HousingType housingType, DealType dealType,
+            int areaMin, long deposit, long monthlyRent, int sampleCount) {
+        market.put(key(regionCode, housingType, dealType, areaMin),
+                new long[]{deposit, monthlyRent, sampleCount});
+    }
+
+    private String key(String regionCode, HousingType housingType, DealType dealType, int areaMin) {
+        return regionCode + "|" + housingType + "|" + dealType + "|" + areaMin;
+    }
+
+    /** 등록되지 않은 조합은 표본 0건으로 돌려준다. 실제로도 거래가 없는 조건이 흔하다. */
+    private RentMedianResponse toResponse(RentMedianRequest request) {
+        long[] found = market.get(key(request.getRegionCode(), request.getHousingType(),
+                request.getDealType(), request.getAreaMin()));
+
+        RentMedianResponse.RentMedianResponseBuilder builder = RentMedianResponse.builder()
+                .regionCode(request.getRegionCode())
+                .regionName("테스트구")
+                .housingType(request.getHousingType())
+                .dealType(request.getDealType());
+
+        if (found == null) {
+            return builder.sampleCount(0).deposit(Quartile.empty()).monthlyRent(Quartile.empty()).build();
+        }
+        return builder
+                .sampleCount((int) found[2])
+                .deposit(Quartile.of(found[0], found[0], found[0]))
+                .monthlyRent(found[1] > 0 ? Quartile.of(found[1], found[1], found[1]) : Quartile.empty())
+                .build();
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #85

close #85

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 상세하게 설명해주세요(이미지 첨부 가능)

추천 알고리즘 4개 중 **REALISTIC** 한 장을 구현했습니다. `RecommendationAlgorithm` 구현체 하나를 추가하는 작업이라 다른 알고리즘이나 `GoalRecommendationServiceImpl`은 건드리지 않았습니다.

---

## 전체 플로우

분기가 갈렸다가 다시 합쳐집니다. 금액은 이해를 돕기 위한 예시값입니다.

```
                     [입력]  지역(필수) · 나머지 조건(선택)
                        │
              ┌─────────┴─────────┐
        목표 시점 입력함      목표 시점 없음
                │            → 24개월 뒤로
                └─────────┬─────────┘
                          │
                   [시작 조합 만들기]
               입력한 조건 + 빈 칸만 기본값
                          │
              ┌───────────┴───────────┐
      지역이 시군구(5자리)        지역이 시도(2자리)
        → 그 구로 확정        → 시작 조합으로 구 25개 조회
                │                     │
                │           ┌─────────┴─────────┐
                │      되는 구 있음        되는 구 없음
                │     → 가장 비싼 구       → 가장 싼 구
                │           └─────────┬─────────┘
                └───────────┬─────────┘
                            │
                       [동네 확정]
          ★ 지역은 여기서 끝. 이후 어떤 경우에도 안 바뀜
                            │
          [1차]  입력한 항목은 고정, 빈 항목만 펼쳐 확인
                            │
              ┌─────────────┴─────────────┐
        되는 게 있음                 하나도 없음
      → 가장 비싼 것 채택                  │
                │        [2차]  입력한 항목까지 풀어 32가지 확인
                │                          │
                │              ┌───────────┴───────────┐
                │        되는 게 있음            하나도 없음
                │      → 가장 비싼 것 채택      → 가장 싼 것 채택
                │              └───────────┬───────────┘
                └─────────────┬────────────┘
                              │
                        [카드 만들기]
                 어느 길로 왔는지에 따라 문구가 갈림
```

### 목표 시점

입력했으면 그 값, 없으면 24개월 뒤입니다. **이후 어떤 분기에서도 이 시점은 바뀌지 않습니다.** 이 카드의 정체성입니다.

이번 달을 넣었다면 최소 1개월로 봅니다. 남은 개월이 0이면 "몇 배 걸리는가"를 계산할 수 없기 때문입니다.

### 시작 조합 만들기

사용자가 입력한 조건을 그대로 가져오고, **비워 둔 칸만** 기본값으로 채웁니다.

```
주거유형  입력했으면 그 값 / 없으면 아파트
거래유형  입력했으면 그 값 / 없으면 전세
평수      입력했으면 그 값 / 없으면 15~19평
```

"오피스텔 · 월세"만 입력했다면 시작 조합은 **오피스텔 · 월세 · 15~19평**입니다. 평수만 채웠지 유형과 거래방식은 사용자 것 그대로입니다.

이때 함께 읽어 오는 값이 **월 저축액과 순자산**입니다. 추천 요청이 받는 값이 아니라 자산 요약에 이미 등록돼 있는 값이고, 없으면 0으로 봅니다. 0이면 뒤에서 어떤 조합도 계산되지 않아 자연히 "도달 불가" 경로로 흘러갑니다. 별도로 막지 않았습니다.

### 동네 확정

시군구 5자리를 받았으면 그 구로 끝입니다. 시도 2자리만 받았으면 **시작 조합으로** 그 시도의 구 25개 시세를 조회해 고릅니다. 기본값이 아니라 시작 조합을 쓰는 이유는, 사용자가 오피스텔·월세를 원했는데 아파트·전세 시세로 동네 순위를 매기면 그 순위가 의미가 없기 때문입니다.

되는 구가 하나도 없으면 **가장 싼 구**를 고릅니다. 뒤에서 집 조건을 낮추면 그 구에서는 가능할 수 있어 여기서 포기하지 않습니다.

**★ 지역을 낮추는 일은 이 지점에서 끝납니다.** 뒤에서 조건을 아무리 풀어도 지역은 다시 건드리지 않습니다. 이미 가장 싼 구까지 내려왔기 때문입니다. 그리고 **추천이 사용자가 고른 시도를 벗어나는 일은 없습니다** — 서울을 골랐으면 경기도 매물은 어떤 경우에도 나오지 않고, 그래서 "서울에서는 24개월 안에 어렵습니다"로 끝나는 경우가 생깁니다.

### 1차 — 입력한 조건 그대로 확인

확정된 동네에서 **입력한 항목은 그 값으로 고정**하고, **입력하지 않은 항목만** 여러 후보로 펼쳐 전부 확인합니다.

```
"오피스텔·월세"만 입력  → 유형·거래방식 고정, 평수 4구간만  →  4가지
아무것도 입력 안 함      → 평수 4 × 유형 4 × 전세/월세      → 32가지
전부 입력함             → 그 조합 하나                     →  1가지
```

평수 4구간은 `4~9 / 10~14 / 15~19 / 20~25평`, 유형 4가지는 `아파트 · 연립다세대 · 오피스텔 · 단독다가구`입니다.

**되면 여기서 끝냅니다.** 예산이 남아 더 좋은 집도 가능하더라도 입력한 조건을 바꾸지 않습니다. 원한 조건으로 갈 수 있으면 그게 답입니다. 단 입력하지 않은 항목은 예산 안에서 좋은 쪽으로 채웁니다.

### 2차 — 입력한 조건까지 풀고 다시 확인

1차가 실패했을 때만 갑니다. **입력한 유형·거래방식·평수까지 풀어** 그 동네의 32가지를 확인합니다.

1차에서 본 조합은 이 32가지 안에 그대로 들어 있지만, **겹치는 만큼 다시 조회하지는 않습니다.** 한 번 확인한 조합의 결과를 재사용합니다. 목표 시점을 바꾸지 않는 카드라 같은 조합은 언제 확인하든 결과가 같기 때문입니다. 사용자가 아무 조건도 입력하지 않았다면 1차가 이미 32가지 전부라 2차는 아예 실행하지 않습니다.

### 조합 하나를 확인하는 방법 (동네 확정 · 1차 · 2차 공통)

```
① 그 조건의 최근 6개월 실거래 중앙값 조회
     거래 3건 미만  → 이 조합 버림 (중앙값을 믿을 수 없음)
     조회 실패      → 이 조합만 버리고 나머지는 계속

② 전세와 월세를 같은 기준으로 환산
     전세 → 보증금 그대로
     월세 → 보증금 + (월세 × 12 ÷ 5%)

③ 지금 저축 속도로 목표 시점까지 그 금액을 모을 수 있는지 계산
     → 가능 / 불가능
```

확인한 조합이 전부 ①에서 버려졌다면 카드를 내지 않습니다.

### 카드 만들기

목표 금액은 **환산값이 아니라 실제 보증금**입니다. 월세를 추천하면서 환산값을 목표로 보여주면 실제의 몇 배를 모으라는 말이 됩니다.

어느 길로 왔는지에 따라 문구가 갈립니다. 사용자 입장에서 "원한 대로 된다"와 "바꾸면 된다"는 완전히 다른 이야기이므로, 바꿨으면 바꿨다고 말합니다.

```
1차에서 채택   "중랑구 오피스텔 15~19평 월세로 24개월 안에 도달할 수 있습니다"

2차에서 채택   "입력하신 조건으로는 24개월을 지키기 어렵습니다.
                종로구 오피스텔 10~14평 전세로 바꾸면 그 안에 도달할 수 있습니다"

2차도 실패     "24개월 안에 가능한 조건은 찾지 못했습니다.
                도봉구 오피스텔 4~9평 전세가 가장 가까우며 38개월이 필요합니다"

저축액이 0     "지금 저축 속도로는 ... 도달하기 어렵습니다.
                저축액을 늘리면 목표가 잡힙니다"
```

### 실제로 타는 경로 세 가지

**아무 조건도 입력하지 않은 사용자** — `regionCode="11"` / 월 저축 200만 · 순자산 5,000만
시작 조합은 전부 기본값(아파트·전세·15\~19평) → 서울 25개 구 중 예산에 맞는 가장 비싼 **중랑구** → 1차에서 32가지 전부 확인 → 가장 비싼 **아파트 15~19평 전세** 채택 → 2차 안 감

**입력 조건이 그대로 되는 사용자** — 종로구 + 오피스텔 + 전세 + 10\~14평 / 예산 2.4억
종로구로 확정(구 조회 안 함) → 1차에서 그 조합 1가지만 확인 → 1억이라 예산 안에 들어옴 → **채택하고 끝**
같은 구에 아파트 20\~25평(2억)이 예산에 맞아도 바꾸지 않습니다.

**입력 조건이 과한 사용자** — 종로구 + 아파트 + 전세 + 20\~25평 / 예산 2.4억
종로구로 확정 → 1차에서 그 조합 1가지 확인 → 9억이라 실패 → 2차에서 조건을 풀고 32가지 확인 → **오피스텔 10~14평 전세 2억** 채택
지역은 지켰고 유형·평수만 바뀌었습니다. 원래 원한 조건은 PREFERENCE 카드가 그대로 보여줍니다.

---

## 공식과 상수

### 공식 1 — 전세 환산 보증금

```
환산보증금 = 보증금 + (월세 × 12 ÷ 연이자율)
```

**근거 있음.** 전월세전환율의 표준 정의식 `전환율 = (월세 × 12) ÷ (전세보증금 − 월세보증금)`을 전세보증금에 대해 푼 것입니다.

전세와 월세를 같은 저울에 올리기 위해 씁니다. **전세는 돈이 안 나가는 게 아니라 보증금이 묶여 이자를 못 버는 것**이라, 통장에서 빠져나가는 돈만 보면 월세가 실제보다 비싸 보입니다. 이 환산을 넣으면 월세가 "보증금이 작아서 싸 보이는" 착시와 "매달 나가서 비싸 보이는" 착시가 동시에 사라집니다.

그래서 월세를 최후 수단으로 두지 않았습니다. 환산 후에는 그냥 숫자로 비교 가능한 후보 하나이고, 실제로 월세가 더 유리하게 나오는 경우가 있습니다.

예를 들어 전세 3억과 "보증금 1,000만 + 월세 40만"을 비교하면, 후자의 환산보증금은 `1,000만 + (480만 ÷ 0.05) = 1억 600만`이라 전세보다 훨씬 저렴한 조건으로 잡힙니다. 이때 카드에는 **월세 40만원과 목표 금액 1,000만원**이 나가고, 환산값 1억 600만은 내부 비교에만 쓰이고 화면에 나가지 않습니다.

### 공식 2 — 배수

```
배수 = 도달 개월 ÷ 희망 개월
```

**근거 있음.** 이 카드는 시점을 고정하므로, 배수가 1.0을 넘는다는 건 곧 목표 시점을 못 지킨다는 뜻입니다.

### 상수 목록

| 상수 | 값 | 근거 |
|---|---|---|
| 허용 배수 상한 | 1.0 | **있음** — 1.0 초과는 목표 시점을 넘긴다는 뜻이라, 이 카드의 약속과 직접 연결됨 |
| 환산·복리 이자율 | 연 5% | **있음** — `GoalServiceImpl.ANNUAL_INTEREST_RATE`와 같은 값. 자산이 5%로 불어난다고 계산해 놓고 기회비용을 다른 이율로 잡으면 모델 내부에서 모순됨 |
| 기본 목표 시점 | 24개월 | **있음** — 주택임대차보호법상 기본 임대차 기간이 2년이라, 미지정 시 다음 계약 주기로 잡는 것이 자연스러움 |
| 빈 칸 채울 기본 주거유형 | 아파트 | **약함** — 실거래 표본이 가장 많아 데이터 없는 지역이 생길 확률이 낮다는 이유뿐 |
| 빈 칸 채울 기본 거래유형 | 전세 | **약함** — 환산 없이 그대로 목돈으로 비교된다는 이유뿐 |
| 평수 구간 | 4~25평, 5평 폭 4구간 | **없음** — 임의로 정했습니다 |
| 빈 칸 채울 기본 평수 | 15~19평 | **없음** — 중간 구간이라 위아래 탐색 여지가 같다는 정도 |
| 최소 표본 수 | 3건 | **없음** — 한두 건짜리 median이 추천을 좌우하는 것만 막으면 된다는 감 |

### 일부러 만들지 않은 상수

---

## 구현 내용

로직은 전부 **`RealisticAlgorithm`** 한 클래스에 있습니다. `RecommendationAlgorithm` 구현체를 하나 추가하는 작업이라 `GoalRecommendationServiceImpl`이나 다른 알고리즘은 건드리지 않았습니다.

### 플로우의 각 단계를 무엇이 처리하는가

위 플로우에 코드를 얹은 그림입니다. `＊`가 붙은 것이 이번에 새로 만든 것, 나머지는 기존 것을 그대로 씁니다.

```
                     [입력]  GoalRecommendationRequest
                             regionCode 필수화 ＊
                        │
              ┌─────────┴─────────┐
        목표 시점 입력함      목표 시점 없음
                └─────────┬─────────┘
                          │  resolveTargetDate · monthsUntil ＊
                          │
                   [시작 조합 만들기]
               AssetSummaryService
                 .getSummary  → 월 저축액
                 .getNetWorthBreakdown → 순자산
                          │
              ┌───────────┴───────────┐
      지역이 시군구(5자리)        지역이 시도(2자리)
        → 그 구로 확정      RegionMapper.findCodesBySidoPrefix ＊
                │                     │
                │              selectRegion ＊
                │           ┌─────────┴─────────┐
                │      되는 구 있음        되는 구 없음
                │    bestWithinTarget ＊     cheapest ＊
                │           └─────────┬─────────┘
                └───────────┬─────────┘
                            │
                       [동네 확정]
                            │
                  [1차]  evaluateConditions ＊
                           keepInput = true
                            │
              ┌─────────────┴─────────────┐
        되는 게 있음                 하나도 없음
      bestWithinTarget ＊                  │
                │           [2차]  evaluateConditions ＊
                │                    keepInput = false
                │                          │
                │              ┌───────────┴───────────┐
                │        되는 게 있음            하나도 없음
                │      bestWithinTarget ＊         cheapest ＊
                │              └───────────┬───────────┘
                └─────────────┬────────────┘
                              │
                        [카드 만들기]
                  LoanPlanCalculator.calculate  (스텁)
                  Condition.monthlyRent ＊
```

`[1차]`와 `[2차]`가 같은 `evaluateConditions`를 **플래그만 바꿔** 두 번 부르는 게 보입니다. 후보를 좁힐지 말지만 다르고 탐색 로직은 한 벌뿐입니다.

### 조합 하나를 확인하는 부분

위 그림에서 `[동네 확정]`·`[1차]`·`[2차]`가 공통으로 부르는 부분입니다.

```
                    evaluate ＊
                        │
              ┌─────────┴─────────┐
       이미 확인한 조합        처음 보는 조합
       → 저장해 둔 결과 반환          │
         Search.evaluated ＊       lookUp ＊
                │                     │
                │      ① RentMedianService.getMedian
                │           → 실패 · 표본 3건 미만이면 버림
                │      ② toComparableAmount ＊
                │           → 월세를 전세 환산 보증금으로
                │      ③ GoalService.calculateMonthToReach
                │           → 도달 개월
                │                     │
                └─────────┬───────────┘
                          │
                    후보 하나 완성
```

### 바깥에 영향이 있는 변경

- **`GoalRecommendationRequest.regionCode` 필수화** — 지역이 탐색 범위를 여는 기준점이고, 지역 없이는 실거래 조회 자체가 불가능합니다. 시도 2자리 또는 시군구 5자리를 받습니다 ⚠️ **프론트 영향**
- **`GoalRecommendationResponse.Condition`에 `monthlyRent` 추가** — 월세를 후보로 다루기로 했는데 응답 어디에도 월세 금액을 담을 자리가 없어, 월세를 추천해도 사용자가 얼마인지 볼 수 없었습니다. 월세는 "어떤 집이냐"에 속하는 정보라 플랜이 아니라 조건에 뒀습니다 ⚠️ **프론트 영향**
- **`RegionMapper.findCodesBySidoPrefix` 추가** — `region` 테이블이 시군구 단위로만 존재해 시도 범위를 훑을 방법이 없었습니다. `code`가 PK라 프리픽스 검색이 인덱스 레인지 스캔으로 끝납니다

## 테스트

`RealisticAlgorithmTest` 14건 추가. 전체 125건 통과, 회귀 없습니다.

DB 없이 돌도록 실거래 시세를 조합별로 지정해두고 알고리즘이 무엇을 고르는지만 봅니다. 복리 계산은 "목표액 ÷ 월저축액"으로 대체했습니다 — 복리를 그대로 쓰면 기대값을 손으로 계산하기 어려워 정작 검증하려는 선택 규칙이 가려지기 때문입니다.

검증하는 것:

- 목표 시점 안에 되는 후보 중 가장 비싼 조건을 고르는가
- 예산이 늘면 더 좋은 조건으로 올라가는가
- **입력한 조건으로 이미 되면, 더 나은 게 있어도 바꾸지 않는가**
- **입력한 조건으로 안 될 때만 조건을 풀어 대안을 찾는가**
- **시군구 순위를 기본값이 아니라 입력 조건으로 매기는가**
- **1차와 2차에 겹치는 조합을 다시 조회하지 않는가**
- 되는 후보가 없으면 가장 가까운 것을 알리고 **가능하다고 말하지 않는가**
- 월세를 환산해서 비교하고, **목표 금액은 실제 보증금으로 내려가는가**
- 환산했을 때 월세가 더 비싸면 전세를 고르는가
- 시도만 주면 예산에 맞는 가장 좋은 시군구를 고르는가
- 사용자가 시군구를 지정하면 지역을 바꾸지 않는가
- 표본이 부족한 조합을 건너뛰는가
- 저축액 미등록을 도달 불가로 흘려보내는가
- 실거래 표본이 아무 조합에도 없으면 추천하지 않는가

## 남은 논의 (구현을 막지는 않음)

- **정책 대출(청년 전월세 대출 등) 반영** — 예산을 크게 바꾸는 요소인데 이번 라운드에서는 순수 저축만으로 판정했습니다. `LoanPlanCalculator`가 실제 구현되는 시점에 "저축으로는 안 되지만 대출을 끼면 되는" 케이스를 어떻게 다룰지 정해야 합니다
- **집값 상승률** — 미래 시점의 목표액에 상승률을 반영하는 구조는 열어뒀지만 값은 0입니다. 6개월 창으로 뽑은 추세는 계절성 노이즈라 근거가 약해, 데이터가 쌓인 뒤 채우는 편이 낫다고 봤습니다
- **2차 이후 동네를 다시 고르는 것** — 지금은 동네를 시작 조합으로 한 번 정하면 끝이라, 2차에서 조건이 바뀌어도 동네는 그대로입니다. 여기에 구멍이 둘 있습니다. **(1)** 동네의 상대 시세 순위는 유형·거래방식에 따라 달라집니다. 아파트 전세로는 중랑구가 나은데 월세로 보면 도봉구가 나을 수 있습니다. **(2)** 2차로 넘어갔다는 건 동네가 "가장 싼 구"로 떨어졌다는 뜻인데, 조건을 낮춰 예산이 남으면 더 나은 구도 감당 가능해집니다. 그런데 여전히 가장 싼 구에 머뭅니다. 예산이 부족한 사용자가 주로 타는 경로라 실제로는 흔한 상황입니다.
- **쿼리 수** — 요청 한 번에 실거래 집계 쿼리가 최대 57회입니다. 카드 4장이 모두 비슷하면 API 한 번에 수백 회가 될 수 있어, 실제로 느려지면 캐싱이나 사전집계 도입이 필요합니다
