### PR TITLE
feat: GBM 기반 몬테카를로 시뮬레이션 구현

### DIFF
--- a/src/main/java/com/team/independence/goal/controller/GoalController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalController.java
@@ -10,8 +10,10 @@ import com.team.independence.goal.dto.GoalForecastResponse;
 import com.team.independence.goal.dto.GoalResponse;
 import com.team.independence.goal.dto.GoalSaveRequest;
 import com.team.independence.goal.dto.GoalSummaryResponse;
+import com.team.independence.goal.dto.MonteCarloResponse;
 import com.team.independence.goal.service.GoalDetailService;
 import com.team.independence.goal.service.GoalService;
+import com.team.independence.goal.service.MonteCarloService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -31,6 +33,7 @@ public class GoalController {
 
     private final GoalService goalService;
     private final GoalDetailService goalDetailService;
+    private final MonteCarloService monteCarloService;
 
     @PostMapping("/diagnosis")
     public ApiResponse<GoalDiagnosisResponse> diagnose(
@@ -82,6 +85,13 @@ public class GoalController {
             @PathVariable Long goalId,
             @RequestParam Long monthlySaving) {
         return ApiResponse.ok(goalService.simulateMonthlySaving(memberId, goalId, monthlySaving));
+    }
+
+    @GetMapping("/{goalId}/simulation")
+    public ApiResponse<MonteCarloResponse> simulate(
+            @LoginMember Long memberId,
+            @PathVariable Long goalId) {
+        return ApiResponse.ok(monteCarloService.simulate(memberId, goalId));
     }
 
     @GetMapping("/market-trend")

--- a/src/main/java/com/team/independence/goal/dto/MonteCarloResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/MonteCarloResponse.java
@@ -1,0 +1,39 @@
+package com.team.independence.goal.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import java.time.YearMonth;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MonteCarloResponse {
+
+    // 목표 식별
+    private Long goalId;
+    private String regionCode;
+    private String regionName;
+    private HousingType housingType;
+    private DealType dealType;
+
+    // 시뮬레이션 기간
+    private int months;
+    private YearMonth targetDate;
+
+    // 가격 모델 파라미터 (PriceModel 산출값)
+    private double annualDrift; // μ값: 몬테카를로 drift 입력값
+    private double cagr;  // exp(μ) - 1: 표시용 연 상승률
+    private double annualVol;  // σ: 몬테카를로 volatility 입력값
+
+    // 현재 상태
+    private long initialPrice;  // P(0) = 목표 설정 당시 실거래 중앙값
+    private long currentBudget;  // 현재 순자산 (이자 적용 자산 + 이자 적용하지 않은 자산)
+
+    // 시뮬레이션 결과
+    private long budgetAtT;  // T 시점 결정적 예상 예산
+    private long priceP5;  // P(T) 5th percentile (낙관 시나리오의 하방)
+    private long priceP50;  // P(T) 중앙값
+    private long priceP95;  // P(T) 95th percentile (비관 시나리오)
+    private double successProbability;  // P(budgetAtT >= P(T)) — 목표 달성 확률
+}

--- a/src/main/java/com/team/independence/goal/service/MonteCarloEngine.java
+++ b/src/main/java/com/team/independence/goal/service/MonteCarloEngine.java
@@ -1,0 +1,68 @@
+package com.team.independence.goal.service;
+
+import java.util.Arrays;
+import java.util.Random;
+
+/**
+ * GBM(기하 브라운 운동) 기반 몬테카를로 시뮬레이션 엔진
+ * 순수 계산 클래스 — Spring 의존성 없음
+ *
+ * GBM: P(T) = P(0) × exp((μ − σ²/2) × T + σ × √T × Z), Z ~ N(0,1)
+ * Itô 보정 (μ − σ²/2)은 필수. 빠뜨리면 기댓값이 P(0)×exp(μT)가 아닌 P(0)×exp((μ−σ²/2)T)가 된다.
+ */
+public class MonteCarloEngine {
+
+    public static final int DEFAULT_SIMULATIONS = 10_000;
+    public static final long DEFAULT_SEED = 42L;
+
+    private MonteCarloEngine() {}
+
+    public record Result(
+        long priceP5,
+        long priceP50,
+        long priceP95,
+        double successProbability
+    ) {}
+
+    /**
+     * @param annualDrift  PriceModel.annualDrift (μ, 연속 복리 연율 드리프트)
+     * @param annualVol    PriceModel.annualVol (σ, 연율 변동성)
+     * @param initialPrice P(0) — 기준 시점의 주택 가격 (원)
+     * @param budgetAtT    T 시점의 결정적 예상 예산 (원) — 성공 여부 판단 기준
+     * @param months       시뮬레이션 기간 (개월, 양수)
+     * @param simulations  경로 수
+     * @param seed         난수 시드 (재현성 보장)
+     */
+    public static Result simulate(double annualDrift, double annualVol,
+                                  long initialPrice, long budgetAtT,
+                                  int months, int simulations, long seed) {
+        if (months <= 0) {
+            throw new IllegalArgumentException("months must be positive: " + months);
+        }
+        double T = months / 12.0;
+        // Itô 보정된 드리프트: (μ - σ²/2) × T
+        double drift = (annualDrift - 0.5 * annualVol * annualVol) * T;
+        double diffusion = annualVol * Math.sqrt(T);
+
+        Random rng = new Random(seed);
+        long[] prices = new long[simulations];
+        int successes = 0;
+
+        for (int i = 0; i < simulations; i++) {
+            double z = rng.nextGaussian();
+            long price = Math.round(initialPrice * Math.exp(drift + diffusion * z));
+            prices[i] = price;
+            if (budgetAtT >= price) {
+                successes++;
+            }
+        }
+
+        Arrays.sort(prices);
+        long p5  = prices[(int)(0.05 * simulations)];
+        long p50 = prices[(int)(0.50 * simulations)];
+        long p95 = prices[Math.min((int)(0.95 * simulations), simulations - 1)];
+        double successProbability = (double) successes / simulations;
+
+        return new Result(p5, p50, p95, successProbability);
+    }
+}

--- a/src/main/java/com/team/independence/goal/service/MonteCarloService.java
+++ b/src/main/java/com/team/independence/goal/service/MonteCarloService.java
@@ -1,0 +1,20 @@
+package com.team.independence.goal.service;
+
+import com.team.independence.goal.dto.MonteCarloResponse;
+
+public interface MonteCarloService {
+
+    /**
+     * 회원의 목표에 대해 GBM 몬테카를로 시뮬레이션을 실행한다.
+     *
+     * PriceModel(μ, σ)을 목표의 주거 조건으로 산출하고,
+     * P(0) = 목표 설정 당시 중앙값 기준으로 T 시점의 가격 분포를 시뮬레이션한다.
+     * 동시에 BudgetCalculator로 T 시점 예상 예산을 결정적으로 계산 후
+     * 목표 달성 확률(successProbability)을 함께 반환한다.
+     *
+     * @param memberId 요청 회원 ID
+     * @param goalId 시뮬레이션할 목표 ID
+     * @return 시뮬레이션 결과 (가격 분위값, 달성 확률 등)
+     */
+    MonteCarloResponse simulate(Long memberId, Long goalId);
+}

--- a/src/main/java/com/team/independence/goal/service/MonteCarloServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/MonteCarloServiceImpl.java
@@ -1,0 +1,96 @@
+package com.team.independence.goal.service;
+
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import com.team.independence.asset.service.AssetConnectionService;
+import com.team.independence.asset.service.AssetSummaryService;
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.goal.domain.Goal;
+import com.team.independence.goal.domain.GoalHousing;
+import com.team.independence.goal.dto.MonteCarloResponse;
+import com.team.independence.goal.mapper.GoalHousingMapper;
+import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.property.dto.PriceModelResponse;
+import com.team.independence.property.service.PriceModelService;
+import com.team.independence.property.service.RegionQueryService;
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MonteCarloServiceImpl implements MonteCarloService {
+
+    private final GoalService goalService;
+    private final GoalHousingMapper goalHousingMapper;
+    private final AssetConnectionService assetConnectionService;
+    private final AssetSummaryService assetSummaryService;
+    private final BudgetCalculator budgetCalculator;
+    private final PriceModelService priceModelService;
+    private final RegionQueryService regionQueryService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public MonteCarloResponse simulate(Long memberId, Long goalId) {
+        Goal goal = goalService.findOwnedGoal(memberId, goalId);
+
+        GoalHousing housing = goalHousingMapper.findByGoalId(goalId);
+        if (housing == null) {
+            throw new BusinessException(ErrorCode.GOAL_NOT_FOUND);
+        }
+
+        YearMonth targetDate = YearMonth.from(goal.getTargetDate());
+        int months = (int) YearMonth.now().until(targetDate, ChronoUnit.MONTHS);
+        if (months <= 0) {
+            throw new BusinessException(ErrorCode.GOAL_INVALID_DATE);
+        }
+
+        assetConnectionService.validateConnectedAccountExists(memberId);
+        AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
+        long currentBudget = netWorth.getInterestBearingAssets() + netWorth.getFlatRecognizedAssets();
+        long budgetAtT = budgetCalculator.calculate(netWorth, goal.getMonthlySaving(), months);
+
+        PriceModelResponse priceModel = priceModelService.estimate(buildPriceModelRequest(housing));
+
+        long initialPrice = goal.getTargetRentMiddleAmount();
+
+        MonteCarloEngine.Result result = MonteCarloEngine.simulate(
+                priceModel.getAnnualDrift(), priceModel.getAnnualVol(),
+                initialPrice, budgetAtT,
+                months, MonteCarloEngine.DEFAULT_SIMULATIONS, MonteCarloEngine.DEFAULT_SEED);
+
+        String regionName = regionQueryService.resolveRegionName(housing.getRegionCode());
+
+        return MonteCarloResponse.builder()
+                .goalId(goalId)
+                .regionCode(housing.getRegionCode())
+                .regionName(regionName)
+                .housingType(housing.getHousingType())
+                .dealType(housing.getDealType())
+                .months(months)
+                .targetDate(targetDate)
+                .annualDrift(priceModel.getAnnualDrift())
+                .cagr(priceModel.getCagr())
+                .annualVol(priceModel.getAnnualVol())
+                .initialPrice(initialPrice)
+                .currentBudget(currentBudget)
+                .budgetAtT(budgetAtT)
+                .priceP5(result.priceP5())
+                .priceP50(result.priceP50())
+                .priceP95(result.priceP95())
+                .successProbability(result.successProbability())
+                .build();
+    }
+
+    private PriceModelRequest buildPriceModelRequest(GoalHousing housing) {
+        PriceModelRequest req = new PriceModelRequest();
+        req.setRegionCode(housing.getRegionCode());
+        req.setHousingType(housing.getHousingType());
+        req.setDealType(housing.getDealType());
+        req.setAreaMin(housing.getAreaMin());
+        req.setAreaMax(housing.getAreaMax());
+        return req;
+    }
+}

--- a/src/test/java/com/team/independence/goal/service/MonteCarloEngineTest.java
+++ b/src/test/java/com/team/independence/goal/service/MonteCarloEngineTest.java
@@ -1,0 +1,110 @@
+package com.team.independence.goal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * MonteCarloEngine.simulate() 단위 테스트
+ *
+ * 순수 계산이라 Spring 컨텍스트 없이 실행된다.
+ * 시드를 고정하여 재현성을 보장한다.
+ */
+class MonteCarloEngineTest {
+
+    private static final long INITIAL_PRICE = 300_000_000L;
+    private static final int SIMULATIONS = 10_000;
+    private static final long SEED = 42L;
+
+    // ------------------------------------------------------------------
+    // σ = 0 결정적 경로
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("σ=0 → 모든 경로가 같은 값 (P5 == P50 == P95)")
+    void 변동성_0_결정적_수렴() {
+        MonteCarloEngine.Result result = MonteCarloEngine.simulate(
+                0.05, 0.0, INITIAL_PRICE, Long.MAX_VALUE, 24, SIMULATIONS, SEED);
+
+        assertEquals(result.priceP5(), result.priceP50(), "σ=0 → P5 == P50");
+        assertEquals(result.priceP50(), result.priceP95(), "σ=0 → P50 == P95");
+        assertEquals(1.0, result.successProbability(), 0.001);
+    }
+
+    @Test
+    @DisplayName("μ=0, σ=0 → P50 ≈ P(0) (드리프트, 변동성 없음)")
+    void 드리프트_0_변동성_0_가격_불변() {
+        MonteCarloEngine.Result result = MonteCarloEngine.simulate(
+                0.0, 0.0, INITIAL_PRICE, 0L, 12, SIMULATIONS, SEED);
+
+        assertEquals(INITIAL_PRICE, result.priceP50(), INITIAL_PRICE * 0.01,
+                "μ=σ=0 → P50 ≈ P(0)");
+    }
+
+    // ------------------------------------------------------------------
+    // 드리프트 방향성
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("μ>0, σ=0 → P50 > P(0) (양의 드리프트로 가격 상승)")
+    void 양의_드리프트_가격_상승() {
+        MonteCarloEngine.Result result = MonteCarloEngine.simulate(
+                0.10, 0.0, INITIAL_PRICE, 0L, 12, SIMULATIONS, SEED);
+
+        assertTrue(result.priceP50() > INITIAL_PRICE,
+                "μ>0 → P50 > P(0). 실제 P50=" + result.priceP50());
+    }
+
+    // ------------------------------------------------------------------
+    // 분포 형태
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("σ>0 → P5 < P50 < P95 (변동성이 분포를 펼침)")
+    void 변동성_있으면_분포_펼쳐짐() {
+        MonteCarloEngine.Result result = MonteCarloEngine.simulate(
+                0.05, 0.20, INITIAL_PRICE, 0L, 36, SIMULATIONS, SEED);
+
+        assertTrue(result.priceP5() < result.priceP50(), "P5 < P50");
+        assertTrue(result.priceP50() < result.priceP95(), "P50 < P95");
+    }
+
+    // ------------------------------------------------------------------
+    // 성공 확률
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("예산이 P(0)×100 → 성공 확률 ≈ 1.0")
+    void 예산_충분하면_성공률_1() {
+        long hugeBudget = INITIAL_PRICE * 100L;
+        MonteCarloEngine.Result result = MonteCarloEngine.simulate(
+                0.05, 0.15, INITIAL_PRICE, hugeBudget, 12, SIMULATIONS, SEED);
+
+        assertEquals(1.0, result.successProbability(), 0.001,
+                "압도적 예산 → 성공률 ≈ 1");
+    }
+
+    @Test
+    @DisplayName("예산=0 → 성공 확률 ≈ 0.0")
+    void 예산_0이면_성공률_0() {
+        MonteCarloEngine.Result result = MonteCarloEngine.simulate(
+                0.05, 0.15, INITIAL_PRICE, 0L, 12, SIMULATIONS, SEED);
+
+        assertEquals(0.0, result.successProbability(), 0.001,
+                "예산=0 → 성공률 ≈ 0");
+    }
+
+    // ------------------------------------------------------------------
+    // 예외
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("months <= 0이면 IllegalArgumentException")
+    void 기간이_0이하면_예외() {
+        assertThrows(IllegalArgumentException.class,
+                () -> MonteCarloEngine.simulate(0.05, 0.10, INITIAL_PRICE, 0L, 0, SIMULATIONS, SEED));
+    }
+}

--- a/src/test/java/com/team/independence/goal/service/MonteCarloServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/MonteCarloServiceImplTest.java
@@ -1,0 +1,192 @@
+package com.team.independence.goal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import com.team.independence.asset.service.AssetConnectionService;
+import com.team.independence.asset.service.AssetSummaryService;
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.goal.domain.Goal;
+import com.team.independence.goal.domain.GoalHousing;
+import com.team.independence.goal.dto.MonteCarloResponse;
+import com.team.independence.goal.mapper.GoalHousingMapper;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.PriceModelResponse;
+import com.team.independence.property.service.PriceModelService;
+import com.team.independence.property.service.RegionQueryService;
+import java.time.YearMonth;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * MonteCarloServiceImpl 서비스 로직 단위 테스트.
+ *
+ * DB 없이 테스트 수행. 의존 서비스를 Mockito로 목 처리하고,
+ * 서비스의 조립, 검증, 예외 경로만 검증한다.
+ * MonteCarloEngine 계산 자체는 MonteCarloEngineTest에서 별도로 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class MonteCarloServiceImplTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long GOAL_ID = 10L;
+    private static final String REGION_CODE = "11680";
+    private static final String REGION_NAME = "서울특별시 강남구";
+    private static final long INITIAL_PRICE = 300_000_000L;
+
+    @Mock private GoalService goalService;
+    @Mock private GoalHousingMapper goalHousingMapper;
+    @Mock private AssetConnectionService assetConnectionService;
+    @Mock private AssetSummaryService assetSummaryService;
+    @Mock private BudgetCalculator budgetCalculator;
+    @Mock private PriceModelService priceModelService;
+    @Mock private RegionQueryService regionQueryService;
+
+    @InjectMocks private MonteCarloServiceImpl service;
+
+    private Goal goal;
+    private GoalHousing housing;
+    private AssetNetWorthBreakdown netWorth;
+
+    @BeforeEach
+    void setUp() {
+        goal = Goal.builder()
+                .id(GOAL_ID)
+                .memberId(MEMBER_ID)
+                .targetAmount(400_000_000L)
+                .targetRentMiddleAmount(INITIAL_PRICE)
+                .targetDate(YearMonth.now().plusMonths(24).atDay(1))
+                .monthlySaving(1_000_000L)
+                .status("ACTIVE")
+                .build();
+
+        housing = GoalHousing.builder()
+                .goalId(GOAL_ID)
+                .regionCode(REGION_CODE)
+                .housingType(HousingType.APT)
+                .dealType(DealType.JEONSE)
+                .areaMin(15)
+                .areaMax(25)
+                .build();
+
+        netWorth = AssetNetWorthBreakdown.builder()
+                .interestBearingAssets(50_000_000L)
+                .flatRecognizedAssets(20_000_000L)
+                .build();
+    }
+
+    // ------------------------------------------------------------------
+    // 정상 경로
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("정상 경로 → 응답 필드가 올바르게 조립된다")
+    void 정상_경로_응답_조립() {
+        stubHappyPath(0.05, 0.10, 250_000_000L);
+
+        MonteCarloResponse response = service.simulate(MEMBER_ID, GOAL_ID);
+
+        assertEquals(GOAL_ID, response.getGoalId());
+        assertEquals(REGION_CODE, response.getRegionCode());
+        assertEquals(REGION_NAME, response.getRegionName());
+        assertEquals(HousingType.APT, response.getHousingType());
+        assertEquals(DealType.JEONSE, response.getDealType());
+        assertEquals(INITIAL_PRICE, response.getInitialPrice());
+        assertEquals(70_000_000L, response.getCurrentBudget());
+        assertTrue(response.getMonths() > 0);
+        assertTrue(response.getSuccessProbability() >= 0.0 && response.getSuccessProbability() <= 1.0);
+    }
+
+    @Test
+    @DisplayName("σ=0 → P5 == P50 == P95 (결정적 경로)")
+    void 변동성_0_결정적() {
+        stubHappyPath(0.0, 0.0, 1_000_000_000L);
+
+        MonteCarloResponse response = service.simulate(MEMBER_ID, GOAL_ID);
+
+        assertEquals(response.getPriceP5(), response.getPriceP50(), "σ=0 → P5 == P50");
+        assertEquals(response.getPriceP50(), response.getPriceP95(), "σ=0 → P50 == P95");
+    }
+
+    @Test
+    @DisplayName("예산이 충분히 크면 성공 확률 ≈ 1.0")
+    void 예산_충분하면_성공률_1() {
+        stubHappyPath(0.05, 0.15, Long.MAX_VALUE / 2);
+
+        MonteCarloResponse response = service.simulate(MEMBER_ID, GOAL_ID);
+
+        assertEquals(1.0, response.getSuccessProbability(), 0.001,
+                "압도적 예산 → 성공률 ≈ 1");
+    }
+
+    // ------------------------------------------------------------------
+    // 예외 경로
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("목표 시점이 현재 이전 → GOAL_INVALID_DATE")
+    void 목표_시점_과거_예외() {
+        Goal expired = Goal.builder()
+                .id(GOAL_ID)
+                .memberId(MEMBER_ID)
+                .targetRentMiddleAmount(INITIAL_PRICE)
+                .monthlySaving(1_000_000L)
+                .targetDate(YearMonth.now().minusMonths(1).atDay(1))
+                .status("ACTIVE")
+                .build();
+        when(goalService.findOwnedGoal(MEMBER_ID, GOAL_ID)).thenReturn(expired);
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(housing);
+
+        BusinessException e = assertThrows(BusinessException.class,
+                () -> service.simulate(MEMBER_ID, GOAL_ID));
+        assertEquals(ErrorCode.GOAL_INVALID_DATE, e.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("GoalHousing이 없으면 GOAL_NOT_FOUND")
+    void 주거조건_없으면_예외() {
+        when(goalService.findOwnedGoal(MEMBER_ID, GOAL_ID)).thenReturn(goal);
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(null);
+
+        BusinessException e = assertThrows(BusinessException.class,
+                () -> service.simulate(MEMBER_ID, GOAL_ID));
+        assertEquals(ErrorCode.GOAL_NOT_FOUND, e.getErrorCode());
+    }
+
+    // ------------------------------------------------------------------
+    // 헬퍼
+    // ------------------------------------------------------------------
+
+    private void stubHappyPath(double cagr, double annualVol, long budgetAtT) {
+        when(goalService.findOwnedGoal(MEMBER_ID, GOAL_ID)).thenReturn(goal);
+        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(housing);
+        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth);
+        when(budgetCalculator.calculate(eq(netWorth), anyLong(), anyLong())).thenReturn(budgetAtT);
+        when(priceModelService.estimate(any())).thenReturn(PriceModelResponse.builder()
+                .regionCode(REGION_CODE)
+                .regionName(REGION_NAME)
+                .housingType(HousingType.APT)
+                .dealType(DealType.JEONSE)
+                .annualDrift(Math.log(1 + cagr))
+                .cagr(cagr)
+                .annualVol(annualVol)
+                .months(24)
+                .startYm("202406")
+                .endYm("202606")
+                .build());
+        when(regionQueryService.resolveRegionName(REGION_CODE)).thenReturn(REGION_NAME);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #86 

---

## 📝작업 내용

### 한 줄 요약

사용자의 주거 목표에 대해 GBM(기하 브라운 운동) 기반 몬테카를로 시뮬레이션을 실행하는 기능을 구현했습니다. 실거래가 시계열에서 산출한 연간 가격 성장률(μ)과 변동성(σ)을 이용해, 목표 시점의 주택 가격 분포를 10,000개 경로로 시뮬레이션하고 저축 계획이 그 가격을 감당할 확률(성공 확률)을 반환합니다.

---

### 왜 이 기능이 필요한가?

기존 `GoalServiceImpl`의 진단은 결정론적입니다.

```
budget(T) >= 현재 중앙값  →  ACHIEVABLE / INSUFFICIENT 
```

집값이 현재와 변함이 없을 것이라는 가정 위에 있어서, 가격이 오를 수 있다는 불확실성을 전혀 반영하지 못합니다. 이번 기능은 그 불확실성을 수치로 표현한 것입니다.

```
budget(T) >= 미래 가격 P(T)  →  성공 확률 xx%  (확률적 판단)
```

---

### GBM 수식

```
P(T) = P(0) × exp( (μ − σ²/2) × T  +  σ × √T × Z )
                   ────────────────    ────────────
                   Itô 보정 드리프트       확산(노이즈)

Z ~ N(0,1): 표준 정규분포 난수
T: 잔여 개월 / 12 (연 단위)
```

Itô 보정 `(μ − σ²/2)`은 반드시 필요합니다. 빠뜨리면 기댓값이 실제보다 낮게 나와 성공 확률이 실제보다 낮게 계산됩니다.

---

### 구현한 내용

1. MonteCarloEngine.java: GBM 순수 계산 엔진

Spring 의존성이 전혀 없는 계산 전용 클래스입니다. 입력을 받아 10,000개 경로를 시뮬레이션하고 결과를 반환합니다.

```
입력: μ, σ, P(0), budgetAtT, 잔여 개월, 경로 수, 시드
출력: priceP5 / priceP50 / priceP95 / successProbability
```

시드를 고정(42)해 같은 입력에 항상 동일한 결과가 나오게 했습니다.

---

2. MonteCarloServiceImpl.java: 서비스 조립

아래 순서로 데이터를 조합합니다.

```
① goalService.findOwnedGoal()  목표 조회 및 소유권 확인
② goalHousingMapper.findByGoalId()  주거 희망 조건 조회
③ months 계산 (현재 ~ targetDate)  months ≤ 0이면 GOAL_INVALID_DATE
④ assetSummaryService.getNetWorthBreakdown()  현재 순자산 조회
⑤ budgetCalculator.calculate()  T 시점 결정적 예산 산출
⑥ priceModelService.estimate()  μ, σ 산출 (직전 PR 구현체 사용)
⑦ MonteCarloEngine.simulate()  10,000개 경로 실행
⑧ MonteCarloResponse 조립 및 반환
```

주요 설계 결정

| 항목 | 결정 | 이유 |
|------|------|------|
| P(0) | `goal.targetRentMiddleAmount` | 추가 API 호출 없이 일관된 기준. 목표를 최근에 설정했다면 현재 시세와 큰 차이 없음 |
| 예산 계산 | `BudgetCalculator` 재사용 | 진단 화면과 동일한 공식(예적금 연 5% 복리 + 적립식 미래가치). 화면 간 수치 일관성 |
| PriceModelRequest | 보증금 필터 없음, 면적 범위만 사용 | 시장 전체 흐름을 보기 위해 필터로 표본을 좁히지 않음. 좁히면 μ, σ가 왜곡될 수 있음 |

---

3. GET /api/v1/goals/{goalId}/simulation 엔드포인트

```
GET /api/v1/goals/{goalId}/simulation
```

응답 예시:

```json
{
  "success": true,
  "data": {
    "goalId": 10,
    "regionCode": "11680",
    "regionName": "서울특별시 강남구",
    "housingType": "APT",
    "dealType": "JEONSE",
    "months": 24,
    "targetDate": "2028-08",
    "annualDrift": 0.0488,
    "cagr": 0.05,
    "annualVol": 0.12,
    "initialPrice": 300000000,
    "currentBudget": 70000000,
    "budgetAtT": 130000000,
    "priceP5":  265000000,
    "priceP50": 330000000,
    "priceP95": 415000000,
    "successProbability": 0.12
  },
  "error": null
}
```

응답 필드 해석:

| 필드 | 의미 |
|------|------|
| `priceP5` | 집값이 이보다 낮을 확률 5%. 가장 낙관적인 시나리오 |
| `priceP50` | 집값의 예상 중앙값 |
| `priceP95` | 집값이 이보다 높을 확률 5%. 가장 비관적인 시나리오 |
| `successProbability` | 내 예산이 집값을 감당할 확률 |
| `cagr` | 연간 가격 상승률 (표시용) |
| `annualVol` | 가격 변동성. 클수록 P5, P95 간격이 넓어짐 |

---

### 테스트

MonteCarloEngineTest: 7건

| 테스트 | 검증 내용 |
|--------|-----------|
| `변동성_0_결정적_수렴` | σ=0이면 모든 경로가 같으므로 P5 == P50 == P95 |
| `드리프트_0_변동성_0_가격_불변` | μ=σ=0이면 집값이 안 변하므로 P50 ≈ P(0) |
| `양의_드리프트_가격_상승` | μ>0이면 집값이 오르므로 P50 > P(0) |
| `변동성_있으면_분포_펼쳐짐` | σ>0이면 P5 < P50 < P95 로 분포가 퍼짐 |
| `예산_충분하면_성공률_1` | 압도적으로 큰 예산 → successProbability ≈ 1.0 |
| `예산_0이면_성공률_0` | 예산 = 0 → successProbability ≈ 0.0 |
| `기간이_0이하면_예외` | months ≤ 0 → IllegalArgumentException |

MonteCarloServiceImplTest: 5건 (Mockito)

| 테스트 | 검증 내용 |
|--------|-----------|
| `정상_경로_응답_조립` | 모든 응답 필드가 올바르게 채워지는지 확인 |
| `변동성_0_결정적` | σ=0일 때 서비스 레이어에서도 P5 == P50 == P95 |
| `예산_충분하면_성공률_1` | 서비스 레이어에서 successProbability가 1.0으로 정상 전달 |
| `목표_시점_과거_예외` | targetDate가 이미 지났을 때 GOAL_INVALID_DATE |
| `주거조건_없으면_예외` | GoalHousing이 없을 때 GOAL_NOT_FOUND |

---

## 💬리뷰 요구사항

1. P(0) 기준점 선택
목표 설정 당시 중앙값(`goal.targetRentMiddleAmount`)을 P(0)으로 사용했습니다. 목표를 오래 전에 세운 사용자의 경우 현재 시세와 차이가 생길 수 있는데, 대신 `RentMedianService`로 현재 중앙값을 매번 조회하는 방식이 더 정확할 수 있습니다. 

2. 시뮬레이션 경로 수 (10,000개)
성능과 정밀도를 고려해 10,000개로 고정했습니다. 응답 속도가 문제가 될 경우 5,000개로 줄이거나, Redis 캐시를 도입하는 방향을 검토할 수 있습니다.