### PR TITLE
[FEATURE] LoanPlanCalculator DSR 기반 대출 플랜 계산 구현

### DIFF
--- a/src/main/java/com/team/independence/goal/service/LoanPlanCalculator.java
+++ b/src/main/java/com/team/independence/goal/service/LoanPlanCalculator.java
@@ -4,42 +4,45 @@ import com.team.independence.goal.dto.LoanPlans;
 import java.time.YearMonth;
 
 /**
- * 추천 대안에 붙는 저축·대출 플랜 계산 — 모든 추천 알고리즘이 공유하는 유일한 계산기.
- *
- * <p>알고리즘들은 서로 다른 방식으로 "어떤 주거를, 언제까지"만 정하고,
- * 그 뒤에 붙는 산수(대출 한도, 자력으로 모을 금액, 월 저축액)는 전부 여기로 위임한다.
- * 카드 4장에 나란히 노출되는 금액이라 알고리즘마다 식이 다르면 사용자가 비교할 수 없기 때문이다.
+ * 모든 추천 알고리즘이 공유하는 계산기
  *
  * <p>계산 가정
  * <ul>
- *   <li>대출: DSR 40% 한도, 연 3.5% 30년 원리금균등상환</li>
- *   <li>저축: 연 5% 복리({@code GoalServiceImpl.ANNUAL_INTEREST_RATE}와 동일 기준)</li>
+ *   <li>신규 대출: DSR 40% 한도, 연 3.5% 30년 원리금균등상환</li>
+ *   <li>기존 대출 월 상환액: 잔액과 {@code loan_account.end_date} 잔여 기간으로 같은 금리(연 3.5%)로 역산.
+ *       {@code end_date}가 null이거나 이미 만기된 대출은 상환 부담 없음으로 처리</li>
+ *   <li>저축: 연 5% 복리({@link BudgetCalculator}에 위임)</li>
  *   <li>소득은 {@code member.monthly_income}, 보유 자산은 순자산 분해 결과를 사용한다</li>
  * </ul>
  *
- * <p>{@code GoalServiceImpl.diagnose()}의 계산이 "월 저축액 → 달성 가능한 예산"인 정방향이라면,
- * 이 계산기는 "필요 금액 → 그에 필요한 월 저축액"인 역방향이다.
  */
 public interface LoanPlanCalculator {
 
     /**
      * 목표 금액과 목표 시점으로 대출 없는 플랜과 대출 낀 플랜을 함께 계산한다.
      *
-     * <p>대출 낀 플랜은 DSR 한도만큼을 목표 금액에서 차감한 뒤 나머지를 자력으로 모으는 것으로 잡는다.
-     * DSR 한도가 0이면(소득 미등록·기존 대출 과다) loanO는 null이 된다.
+     * <p>두 플랜 모두 {@code targetDate}는 동일하고, 대출 낀 플랜은 DSR 한도만큼을 목표 금액에서
+     * 차감해 자력으로 모아야 할 금액을 줄인다. 결과적으로 같은 시점에 도달하는 데 필요한 월 저축액이
+     * 줄어든다. DSR 한도가 0이면(소득 미등록·기존 대출 과다) loanO는 null이 된다.
+     *
+     * <p>대출 한도가 목표 금액을 초과하는 경우 대출액은 목표 금액으로 캡되며,
+     * 자력 부담({@code LoanOPlan.targetAmount})은 0, 월 저축액도 0이 된다.
      *
      * @param memberId       요청 회원 ID (소득·자산 조회용)
-     * @param requiredAmount 목표 주거를 얻는 데 필요한 금액 (원). 보통 실거래 보증금 중앙값
+     * @param requiredAmount 목표 주거를 얻는 데 필요한 금액 (원). 보통 실거래 보증금 Q3
      * @param targetDate     목표 시점
      * @return 플랜 한 쌍
      */
     LoanPlans calculate(long memberId, long requiredAmount, YearMonth targetDate);
 
     /**
-     * DSR 40% 기준 최대 대출 가능액을 계산한다.
+     * DSR 40% 기준 신규 대출 최대 가능액을 계산한다.
      *
      * <p>{@link #calculate}가 내부적으로 쓰는 값이지만, 대안을 고르기 전에 예산 상한을 알아야 하는
      * 알고리즘(예: 소득 대비 현실적인 매물만 추리는 경우)이 따로 호출할 수 있도록 열어 둔다.
+     *
+     * <p>산출 공식: (월소득 × 0.4 − 기존 대출 월 원리금 합계)를 30년 연금 현가로 환산.
+     * 소득 미등록이거나 기존 대출이 DSR 40%를 이미 소진한 경우 0을 반환한다.
      *
      * @param memberId 요청 회원 ID
      * @return 신규 대출 가능 최대 금액 (원). 한도가 없으면 0

--- a/src/main/java/com/team/independence/goal/service/LoanPlanCalculatorImpl.java
+++ b/src/main/java/com/team/independence/goal/service/LoanPlanCalculatorImpl.java
@@ -1,69 +1,108 @@
 package com.team.independence.goal.service;
 
+import com.team.independence.asset.dto.account.LoanAccountDetailItem;
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import com.team.independence.asset.service.AssetSummaryService;
+import com.team.independence.asset.service.LoanAccountService;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
 import com.team.independence.goal.dto.LoanPlans;
+import com.team.independence.member.service.MemberService;
+import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-/**
- * ⚠️ 임시 스텁 — 실제 계산 로직이 없습니다.
- *
- * <p><b>이 클래스는 구현하지 마세요.</b> 담당자가 따로 채울 예정입니다.
- * 추천 알고리즘 담당자들이 {@link LoanPlanCalculator} 구현을 기다리지 않고 바로 개발을 시작할 수
- * 있도록, 호출하면 고정된 더미 값을 돌려주는 껍데기만 먼저 올려 둔 것입니다.
- *
- * <p>알고리즘 쪽에서는 평소처럼 {@link LoanPlanCalculator}를 주입받아 호출하면 됩니다.
- * 지금은 값이 가짜지만 시그니처와 반환 구조는 최종본과 동일하므로,
- * 나중에 이 클래스 내용만 채워지면 알고리즘 코드는 손대지 않아도 됩니다.
- *
- * <p>더미 값이라는 것을 한눈에 알 수 있도록 월 저축액 100만원, 대출 한도 1억으로 고정해 두었습니다.
- * 화면에 이 숫자가 그대로 보인다면 아직 계산기가 안 붙은 것입니다.
- */
+/** {@link LoanPlanCalculator} 구현체. 계산 가정은 인터페이스 주석 참고. */
 @Service
 @RequiredArgsConstructor
 public class LoanPlanCalculatorImpl implements LoanPlanCalculator {
 
-    /** 더미 월 저축액 (원) */
-    private static final long STUB_MONTHLY_SAVING = 1_000_000L;
+    private static final double DSR_LIMIT               = 0.40;
+    // 실제 대출 조건을 알 수 없으므로 신규·기존 대출 모두 동일한 금리로 추정한다
+    private static final double ASSUMED_LOAN_ANNUAL_RATE = 0.035;
+    private static final int    NEW_LOAN_TERM_MONTHS     = 360;
 
-    /** 더미 대출 한도 (원) */
-    private static final long STUB_LOAN_AMOUNT = 100_000_000L;
+    private final MemberService       memberService;
+    private final LoanAccountService  loanAccountService;
+    private final AssetSummaryService assetSummaryService;
+    private final BudgetCalculator    budgetCalculator;
 
-    /**
-     * {@inheritDoc}
-     *
-     * <p>⚠️ 스텁: 입력을 그대로 되돌려주고 나머지는 더미 값으로 채웁니다.
-     * 소득·자산 조회, DSR 한도 산출, 복리 저축 역산 모두 아직 없습니다.
-     */
     @Override
     public LoanPlans calculate(long memberId, long requiredAmount, YearMonth targetDate) {
+        long months = ChronoUnit.MONTHS.between(YearMonth.now(), targetDate);
+        AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
+
+        long loanXSaving = calcMonthlySavingNeeded(netWorth, requiredAmount, months);
         GoalRecommendationResponse.LoanXPlan loanX = GoalRecommendationResponse.LoanXPlan.builder()
                 .targetAmount(requiredAmount)
                 .targetDate(targetDate)
-                .monthlySaving(STUB_MONTHLY_SAVING)
+                .monthlySaving(loanXSaving)
                 .build();
 
+        long loanAmount = Math.min(calcMaxLoanAmount(memberId), requiredAmount);
+        if (loanAmount <= 0) {
+            return LoanPlans.builder().loanX(loanX).loanO(null).build();
+        }
+
+        long selfFunded = requiredAmount - loanAmount;
+        long loanOSaving = calcMonthlySavingNeeded(netWorth, selfFunded, months);
         GoalRecommendationResponse.LoanOPlan loanO = GoalRecommendationResponse.LoanOPlan.builder()
-                .loanAmount(STUB_LOAN_AMOUNT)
-                .targetAmount(Math.max(requiredAmount - STUB_LOAN_AMOUNT, 0L))
+                .loanAmount(loanAmount)
+                .targetAmount(selfFunded)
                 .targetDate(targetDate)
-                .monthlySaving(STUB_MONTHLY_SAVING)
+                .monthlySaving(loanOSaving)
                 .build();
 
-        return LoanPlans.builder()
-                .loanX(loanX)
-                .loanO(loanO)
-                .build();
+        return LoanPlans.builder().loanX(loanX).loanO(loanO).build();
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * <p>⚠️ 스텁: 회원과 무관하게 고정 한도를 반환합니다.
-     */
     @Override
     public long calcMaxLoanAmount(long memberId) {
-        return STUB_LOAN_AMOUNT;
+        Long monthlyIncome = memberService.getMember(memberId).monthlyIncome();
+        if (monthlyIncome == null || monthlyIncome <= 0) return 0L;
+
+        double r = ASSUMED_LOAN_ANNUAL_RATE / 12.0;
+        double factor = Math.pow(1 + r, NEW_LOAN_TERM_MONTHS);
+
+        double existingMonthlyPayments = loanAccountService.getLoanAccounts(memberId).stream()
+                .mapToDouble(loan -> calcExistingMonthlyPayment(loan, r))
+                .sum();
+
+        double availableMonthly = monthlyIncome * DSR_LIMIT - existingMonthlyPayments;
+        if (availableMonthly <= 0) return 0L;
+
+        // 연금 현가: M × (factor − 1) / (r × factor)
+        return (long) (availableMonthly * (factor - 1) / (r * factor));
+    }
+
+    // 기존 대출 한 건의 월 원리금 상환액. endDate 기준 잔여 기간으로 역산.
+    // 실제 대출 조건을 사용할 수 없으므로 ASSUMED_LOAN_ANNUAL_RATE, 원리금균등상환으로 추정한다.
+    private double calcExistingMonthlyPayment(LoanAccountDetailItem loan, double r) {
+        if (loan.getLoanBalance() == null || loan.getLoanBalance() <= 0) return 0.0;
+        if (loan.getEndDate() == null) return 0.0;
+        long remaining = ChronoUnit.MONTHS.between(LocalDate.now(), loan.getEndDate());
+        if (remaining <= 0) return 0.0;
+        double f = Math.pow(1 + r, remaining);
+        return loan.getLoanBalance() * r * f / (f - 1);
+    }
+
+    // n개월 안에 targetAmount에 도달하기 위한 최소 월 저축액을 이진탐색으로 역산.
+    private long calcMonthlySavingNeeded(AssetNetWorthBreakdown netWorth, long targetAmount, long months) {
+        if (targetAmount <= 0) return 0L;
+        if (months <= 0) return targetAmount;
+        if (budgetCalculator.calculate(netWorth, 0L, months) >= targetAmount) return 0L;
+
+        long lo = 0L;
+        long hi = targetAmount;
+        while (hi - lo > 1) {
+            long mid = (lo + hi) / 2;
+            if (budgetCalculator.calculate(netWorth, mid, months) >= targetAmount) {
+                hi = mid;
+            } else {
+                lo = mid;
+            }
+        }
+        return hi;
     }
 }

--- a/src/test/java/com/team/independence/goal/service/LoanPlanCalculatorImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/LoanPlanCalculatorImplTest.java
@@ -1,0 +1,229 @@
+package com.team.independence.goal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.team.independence.asset.dto.account.LoanAccountDetailItem;
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import com.team.independence.asset.service.AssetSummaryService;
+import com.team.independence.asset.service.LoanAccountService;
+import com.team.independence.goal.dto.LoanPlans;
+import com.team.independence.member.dto.MemberProfileResponse;
+import com.team.independence.member.service.MemberService;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LoanPlanCalculatorImplTest {
+
+    @Mock MemberService      memberService;
+    @Mock LoanAccountService loanAccountService;
+    @Mock AssetSummaryService assetSummaryService;
+
+    private LoanPlanCalculatorImpl calculator;
+
+    /** 기준 월 소득 (원) */
+    private static final long MONTHLY_INCOME = 4_000_000L;
+
+    /** 테스트 공통 memberId */
+    private static final long MEMBER_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        calculator = new LoanPlanCalculatorImpl(
+                memberService,
+                loanAccountService,
+                assetSummaryService,
+                new BudgetCalculatorImpl()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // calcMaxLoanAmount
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("소득이 null이면 대출 한도는 0")
+    void 소득_null이면_대출한도_0() {
+        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(null));
+
+        assertEquals(0L, calculator.calcMaxLoanAmount(MEMBER_ID));
+    }
+
+    @Test
+    @DisplayName("소득이 0이면 대출 한도는 0")
+    void 소득_0이면_대출한도_0() {
+        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(0L));
+
+        assertEquals(0L, calculator.calcMaxLoanAmount(MEMBER_ID));
+    }
+
+    @Test
+    @DisplayName("기존 대출이 없으면 월소득 × 40% 전부를 신규 대출 상환에 쓸 수 있다")
+    void 기존대출_없으면_DSR_전체_여유() {
+        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(MONTHLY_INCOME));
+        when(loanAccountService.getLoanAccounts(MEMBER_ID)).thenReturn(List.of());
+
+        long maxLoan = calculator.calcMaxLoanAmount(MEMBER_ID);
+
+        // 월 소득 400만 × 40% = 160만 → 30년 연 3.5% 기준 대출 가능액
+        // 정확한 값 검증 대신 합리적 범위 확인 (약 3.5억 수준)
+        assertTrue(maxLoan > 300_000_000L, "대출 한도가 3억 이상이어야 한다");
+        assertTrue(maxLoan < 500_000_000L, "대출 한도가 5억 미만이어야 한다");
+    }
+
+    @Test
+    @DisplayName("기존 대출이 DSR 한도를 꽉 채우면 신규 대출 한도는 0")
+    void 기존대출_DSR_초과시_신규한도_0() {
+        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(MONTHLY_INCOME));
+
+        // 기존 대출: 잔액 5억, 잔여 30년 → 월 상환액이 DSR 40%(160만)를 이미 초과
+        LoanAccountDetailItem heavyLoan = loanItem(500_000_000L, LocalDate.now().plusYears(30));
+        when(loanAccountService.getLoanAccounts(MEMBER_ID)).thenReturn(List.of(heavyLoan));
+
+        assertEquals(0L, calculator.calcMaxLoanAmount(MEMBER_ID));
+    }
+
+    @Test
+    @DisplayName("기존 대출이 있으면 한도가 줄어든다")
+    void 기존대출_있으면_한도_감소() {
+        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(MONTHLY_INCOME));
+
+        long maxWithout = maxLoanWithNoExistingDebt();
+
+        LoanAccountDetailItem existingLoan = loanItem(50_000_000L, LocalDate.now().plusYears(10));
+        when(loanAccountService.getLoanAccounts(MEMBER_ID)).thenReturn(List.of(existingLoan));
+
+        long maxWith = calculator.calcMaxLoanAmount(MEMBER_ID);
+
+        assertTrue(maxWith < maxWithout, "기존 대출이 있으면 한도가 줄어야 한다");
+    }
+
+    @Test
+    @DisplayName("만기가 지난 대출은 DSR 부담에서 제외된다")
+    void 만기_지난_대출은_DSR_무시() {
+        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(MONTHLY_INCOME));
+
+        // 이미 만기된 대출
+        LoanAccountDetailItem expiredLoan = loanItem(100_000_000L, LocalDate.now().minusDays(1));
+        when(loanAccountService.getLoanAccounts(MEMBER_ID)).thenReturn(List.of(expiredLoan));
+
+        long maxWithExpired = calculator.calcMaxLoanAmount(MEMBER_ID);
+
+        when(loanAccountService.getLoanAccounts(MEMBER_ID)).thenReturn(List.of());
+        long maxWithNone = calculator.calcMaxLoanAmount(MEMBER_ID);
+
+        assertEquals(maxWithNone, maxWithExpired, "만기된 대출은 한도 계산에 영향 없어야 한다");
+    }
+
+    // -----------------------------------------------------------------------
+    // calculate
+    // -----------------------------------------------------------------------
+
+    @Test
+    @DisplayName("소득이 없으면 loanO가 null이다")
+    void 소득없으면_loanO_null() {
+        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(null));
+        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(0L, 0L));
+
+        LoanPlans plans = calculator.calculate(MEMBER_ID, 200_000_000L, YearMonth.now().plusMonths(36));
+
+        assertNotNull(plans.getLoanX());
+        assertNull(plans.getLoanO(), "대출 한도 0이면 loanO는 null이어야 한다");
+    }
+
+    @Test
+    @DisplayName("대출이 목표금액 이상이면 loanO의 월 저축액은 0")
+    void 대출이_목표초과시_loanO_저축_0() {
+        // 대출 한도 > 목표 금액 → selfFunded = 0
+        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(10_000_000L)); // 고소득
+        when(loanAccountService.getLoanAccounts(MEMBER_ID)).thenReturn(List.of());
+        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(0L, 0L));
+
+        long requiredAmount = 50_000_000L; // 5천만 (대출 한도보다 훨씬 작음)
+        LoanPlans plans = calculator.calculate(MEMBER_ID, requiredAmount, YearMonth.now().plusMonths(24));
+
+        assertNotNull(plans.getLoanO());
+        assertEquals(0L, plans.getLoanO().getMonthlySaving(), "대출으로 전액 충당되면 월 저축 0이어야 한다");
+        assertEquals(requiredAmount, plans.getLoanO().getLoanAmount(), "대출액은 목표금액으로 캡이어야 한다");
+        assertEquals(0L, plans.getLoanO().getTargetAmount(), "자기자금 부담은 0이어야 한다");
+    }
+
+    @Test
+    @DisplayName("loanO의 월 저축액은 loanX보다 작다")
+    void loanO_월저축이_loanX보다_작다() {
+        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(MONTHLY_INCOME));
+        when(loanAccountService.getLoanAccounts(MEMBER_ID)).thenReturn(List.of());
+        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(10_000_000L, 5_000_000L));
+
+        // 현재 자산으로는 부족하고 저축이 필요한 규모
+        LoanPlans plans = calculator.calculate(MEMBER_ID, 200_000_000L, YearMonth.now().plusMonths(48));
+
+        assertNotNull(plans.getLoanO());
+        assertTrue(plans.getLoanO().getMonthlySaving() < plans.getLoanX().getMonthlySaving(),
+                "대출을 끼면 월 저축 부담이 줄어야 한다");
+    }
+
+    @Test
+    @DisplayName("loanX의 목표금액과 targetDate는 입력값 그대로다")
+    void loanX_필드_검증() {
+        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(null));
+        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(0L, 0L));
+
+        long requiredAmount = 150_000_000L;
+        YearMonth targetDate = YearMonth.now().plusMonths(30);
+        LoanPlans plans = calculator.calculate(MEMBER_ID, requiredAmount, targetDate);
+
+        assertEquals(requiredAmount, plans.getLoanX().getTargetAmount());
+        assertEquals(targetDate, plans.getLoanX().getTargetDate());
+    }
+
+    @Test
+    @DisplayName("이미 자산이 목표금액 이상이면 월 저축액은 0")
+    void 자산이_목표초과시_저축_0() {
+        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(null));
+        // 현재 자산 2억 > 목표 1억
+        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(200_000_000L, 0L));
+
+        LoanPlans plans = calculator.calculate(MEMBER_ID, 100_000_000L, YearMonth.now().plusMonths(24));
+
+        assertEquals(0L, plans.getLoanX().getMonthlySaving(), "자산이 이미 충분하면 저축 0이어야 한다");
+    }
+
+    // -----------------------------------------------------------------------
+    // 헬퍼
+    // -----------------------------------------------------------------------
+
+    private MemberProfileResponse profile(Long monthlyIncome) {
+        return new MemberProfileResponse(MEMBER_ID, "테스터", null, monthlyIncome, null, false, false);
+    }
+
+    private AssetNetWorthBreakdown netWorth(long interestBearing, long flat) {
+        return AssetNetWorthBreakdown.builder()
+                .interestBearingAssets(interestBearing)
+                .flatRecognizedAssets(flat)
+                .build();
+    }
+
+    private LoanAccountDetailItem loanItem(long balance, LocalDate endDate) {
+        LoanAccountDetailItem item = new LoanAccountDetailItem();
+        item.setLoanBalance(balance);
+        item.setEndDate(endDate);
+        return item;
+    }
+
+    private long maxLoanWithNoExistingDebt() {
+        when(loanAccountService.getLoanAccounts(MEMBER_ID)).thenReturn(List.of());
+        return calculator.calcMaxLoanAmount(MEMBER_ID);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #89

## 📝 작업 내용

`LoanPlanCalculatorImpl`의 더미 고정값(월 저축 100만, 대출 한도 1억)을 제거하고, 소득·기존 대출·순자산을 실제로 반영하는 DSR 기반 계산으로 대체했습니다.

**`calcMaxLoanAmount` — 신규 대출 최대 한도**
- DSR 40% 한도 내 월 여유분 = `월소득 × 0.4 − 기존 대출 월 원리금 합계`
- 연금현가 공식으로 30년 원리금균등상환 기준 대출 원금으로 환산
- 기존 대출은 잔액 + `end_date` 잔여 기간으로 역산 (CODEF에 금리 필드 미제공 → 연 3.5% 가정)

**`calcMonthlySavingNeeded` — 최소 월 저축액**
- `BudgetCalculator`의 복리 적립 미래가치를 기준으로 이진탐색으로 역산
- `months ≤ 0` 가드 추가: 목표 시점이 현재·과거면 `calculateProjectedSavings`가 음수를 반환해 이진탐색이 수렴하지 않는 버그 수정

**테스트**
- `LoanPlanCalculatorImplTest` 신규 추가 (10개 케이스)
- `calcMaxLoanAmount`: 소득 null/0, DSR 전체 여유, DSR 초과, 기존대출 한도 감소, 만기된 대출 제외
- `calculate`: loanO null, 대출 전액 충당, loanO 저축 < loanX, 필드 검증, 자산 충분 시 저축 0

## 💬리뷰 요구사항(선택)

- 기존 대출 금리를 CODEF 응답에서 파싱할 수 없어 신규 대출과 동일한 연 3.5%로 역산하고 있습니다. 실제 금리가 높을수록 대출 한도가 과대평가될 수 있습니다.