### PR TITLE
feat(goal): 선호 우선(PREFERENCE) 추천 알고리즘 구현

### DIFF
--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
@@ -45,6 +45,15 @@ public class GoalRecommendationResponse {
          * 환산값이 아니라 사용자가 실제로 매달 내는 금액이다.
          */
         private long monthlyRent;
+
+        /**
+         * 이 조건의 대표값을 뽑는 데 쓰인 실거래 건수.
+         *
+         * <p>거래가 드문 조건에서는 한두 건으로 계산된 값일 수 있어, 숫자를 얼마나 믿을지
+         * 화면에서 판단할 수 있도록 함께 내려준다. 지역을 시도로 받으면 그 시도의 시군구
+         * 거래를 모두 합치므로 건수가 크게 늘어난다.
+         */
+        private int sampleCount;
     }
 
     @Getter

--- a/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
@@ -1,0 +1,172 @@
+package com.team.independence.goal.service.algorithm;
+
+import com.team.independence.goal.dto.AlgorithmType;
+import com.team.independence.goal.dto.GoalRecommendationRequest;
+import com.team.independence.goal.dto.GoalRecommendationResponse;
+import com.team.independence.goal.dto.LoanPlans;
+import com.team.independence.goal.service.LoanPlanCalculator;
+import com.team.independence.goal.service.RecommendationAlgorithm;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.RentMedianRequest;
+import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.service.RentMedianService;
+import java.time.YearMonth;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 선호 우선 추천 — 사용자가 입력한 조건을 그대로 돌려준다.
+ *
+ * <p>이 카드의 정체성은 <b>계산하지 않는 것</b>이다. 원한 조건의 실거래 시세를 그대로 보여주고,
+ * 그것을 감당할 수 있는지는 판단하지 않는다. 30년이 걸릴 조건이어도 그대로 낸다. 감당 여부를 따지는
+ * 일은 {@code REALISTIC}이, 시점을 늘려 도달 가능성을 보는 일은 {@code HOLD_OUT}이 한다.
+ *
+ * <p>{@code REALISTIC}과의 차이는 "조건을 몇 개 받았느냐"가 아니라 <b>빈 칸을 채울 때 계산을 하느냐</b>다.
+ * 둘 다 빈 칸을 채우지만, 이 카드는 고정된 기본값 하나로 채우고 끝내는 반면 REALISTIC은 저축 여력에
+ * 맞는 값을 탐색해 채운다. 그래서 사용자가 조건을 하나만 줘도 두 카드의 답이 갈린다.
+ *
+ * <p>기본값을 {@code RealisticAlgorithm}과 공유하지 않고 이 클래스에 따로 둔 이유는, 두 카드가 같은
+ * 값을 써야 할 이유가 없기 때문이다. 한쪽 기본값을 바꿀 때 다른 쪽이 따라 움직이면 곤란하다.
+ *
+ * <h3>지역을 시도로 받으면 시도 전체를 한 통에 넣는다</h3>
+ * 시군구를 고르지 않는다. 시도의 모든 시군구 실거래를 섞어 정렬한 중앙값 하나를 낸다. 그래서 응답의
+ * 지역은 "서울특별시"이지 "중랑구"가 아니다. 사용자가 시군구를 묻지 않았는데 우리가 정해 줄 이유가
+ * 없기 때문이며, 감당 가능한 동네를 짚어 주는 일은 {@code REALISTIC}의 몫이다.
+ *
+ * <p>다만 시도 중앙값은 비싼 지역이 끌어올린 값이라 실제로 갈 수 있는 동네와 동떨어질 수 있다.
+ * 그것을 감추지 않는 것이 이 카드의 역할이고, 옆에 나란히 놓이는 REALISTIC 카드가 균형을 잡는다.
+ *
+ * <h3>표본이 적어도 버리지 않는다</h3>
+ * {@code RealisticAlgorithm}은 표본이 적은 조합을 버린다. 중앙값으로 후보들을 <b>비교해 하나를 고르는</b>
+ * 것이 일이라, 한두 건짜리 값이 선택을 왜곡하기 때문이다. 이 카드는 고르는 것이 아니라 <b>그대로
+ * 보고하는</b> 것이 일이므로 버리지 않고, 대신 실거래 건수를 응답에 함께 실어 화면이 판단하게 한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PreferenceAlgorithm implements RecommendationAlgorithm {
+
+    /**
+     * 목표 시점 미지정 시 기본값(개월).
+     *
+     * <p>주택임대차보호법상 기본 임대차 기간이 2년이라, 사용자가 정하지 않았을 때 다음 계약 주기를
+     * 목표로 잡는 것이 자연스럽다.
+     */
+    private static final int DEFAULT_TARGET_MONTHS = 24;
+
+    /** 주거유형 미지정 시 기본값. 실거래 표본이 가장 많아 데이터가 비는 조건이 될 확률이 낮다. */
+    private static final HousingType DEFAULT_HOUSING_TYPE = HousingType.APT;
+
+    /** 거래유형 미지정 시 기본값 */
+    private static final DealType DEFAULT_DEAL_TYPE = DealType.JEONSE;
+
+    /** 평수 미지정 시 기본 구간(평) */
+    private static final int DEFAULT_AREA_MIN = 15;
+    private static final int DEFAULT_AREA_MAX = 19;
+
+    /** 보증금 필터 미지정 시 사용할 상한(원). 사실상 무제한. */
+    private static final long DEPOSIT_MAX_DEFAULT = 100_000_000_000L;
+
+    private final RentMedianService rentMedianService;
+    private final LoanPlanCalculator loanPlanCalculator;
+
+    @Override
+    public Optional<GoalRecommendationResponse.RecommendationItem> recommend(
+            long memberId, GoalRecommendationRequest request) {
+
+        YearMonth targetDate = request.getTargetDate() != null
+                ? request.getTargetDate()
+                : YearMonth.now().plusMonths(DEFAULT_TARGET_MONTHS);
+
+        HousingType housingType = request.getPropertyType() != null
+                ? request.getPropertyType() : DEFAULT_HOUSING_TYPE;
+        DealType dealType = request.getTradeType() != null
+                ? request.getTradeType() : DEFAULT_DEAL_TYPE;
+        int areaMin = request.getSizeMin() != null ? request.getSizeMin() : DEFAULT_AREA_MIN;
+        int areaMax = request.getSizeMax() != null ? request.getSizeMax() : DEFAULT_AREA_MAX;
+
+        RentMedianResponse median;
+        try {
+            median = rentMedianService.getMedian(
+                    buildMedianRequest(request, housingType, dealType, areaMin, areaMax));
+        } catch (RuntimeException e) {
+            log.warn("실거래 조회에 실패해 선호 조건을 추천하지 못했습니다. memberId={}, regionCode={}",
+                    memberId, request.getRegionCode(), e);
+            return Optional.empty();
+        }
+
+        // 표본이 적은 것은 그대로 두지만, 한 건도 없으면 보여줄 금액 자체가 없다.
+        if (median.getSampleCount() == 0 || median.getDeposit().getMedian() == null) {
+            log.info("선호 조건에 해당하는 실거래가 없습니다. memberId={}, regionCode={}",
+                    memberId, request.getRegionCode());
+            return Optional.empty();
+        }
+
+        long deposit = median.getDeposit().getMedian();
+        long monthlyRent = dealType == DealType.WOLSE && median.getMonthlyRent().getMedian() != null
+                ? median.getMonthlyRent().getMedian() : 0L;
+
+        LoanPlans plans = loanPlanCalculator.calculate(memberId, deposit, targetDate);
+
+        GoalRecommendationResponse.Condition condition = GoalRecommendationResponse.Condition.builder()
+                .regionCode(median.getRegionCode())
+                .regionName(median.getRegionName())
+                .housingType(housingType)
+                .dealType(dealType)
+                .areaMin(areaMin)
+                .areaMax(areaMax)
+                .monthlyRent(monthlyRent)
+                .sampleCount(median.getSampleCount())
+                .build();
+
+        return Optional.of(GoalRecommendationResponse.RecommendationItem.builder()
+                .type(AlgorithmType.PREFERENCE)
+                .title(String.format("%s %s", median.getRegionName(), label(housingType)))
+                .reason(String.format("최근 6개월 실거래 %d건 기준 %s %s %d~%d평 %s 시세입니다.",
+                        median.getSampleCount(), median.getRegionName(), label(housingType),
+                        areaMin, areaMax, label(dealType)))
+                .condition(condition)
+                .loanX(plans.getLoanX())
+                .loanO(plans.getLoanO())
+                .build());
+    }
+
+    private RentMedianRequest buildMedianRequest(
+            GoalRecommendationRequest request, HousingType housingType, DealType dealType,
+            int areaMin, int areaMax) {
+
+        RentMedianRequest median = new RentMedianRequest();
+        median.setRegionCode(request.getRegionCode());
+        median.setHousingType(housingType);
+        median.setDealType(dealType);
+        median.setAreaMin(areaMin);
+        median.setAreaMax(areaMax);
+        median.setDepositMin(request.getDepositMin() != null ? request.getDepositMin() : 0L);
+        median.setDepositMax(request.getDepositMax() != null ? request.getDepositMax() : DEPOSIT_MAX_DEFAULT);
+        median.setMonthlyRentMin(request.getMonthlyRentMin());
+        median.setMonthlyRentMax(request.getMonthlyRentMax());
+        return median;
+    }
+
+    private static String label(HousingType housingType) {
+        switch (housingType) {
+            case APT:
+                return "아파트";
+            case ROW_HOUSE:
+                return "연립다세대";
+            case OFFICETEL:
+                return "오피스텔";
+            case DETACHED:
+                return "단독다가구";
+            default:
+                return housingType.name();
+        }
+    }
+
+    private static String label(DealType dealType) {
+        return dealType == DealType.JEONSE ? "전세" : "월세";
+    }
+}

--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -1,4 +1,4 @@
-package com.team.independence.goal.service;
+package com.team.independence.goal.service.algorithm;
 
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
 import com.team.independence.asset.dto.summary.AssetSummaryResponse;
@@ -7,6 +7,9 @@ import com.team.independence.goal.dto.AlgorithmType;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
 import com.team.independence.goal.dto.LoanPlans;
+import com.team.independence.goal.service.GoalService;
+import com.team.independence.goal.service.LoanPlanCalculator;
+import com.team.independence.goal.service.RecommendationAlgorithm;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.dto.RentMedianRequest;

--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -373,7 +373,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         return Optional.of(new Candidate(
                 regionCode, median.getRegionName(), housingType, dealType,
                 areaMin, areaMax, deposit, monthlyRent, comparableAmount,
-                reachMonths, search.desiredMonths));
+                median.getSampleCount(), reachMonths, search.desiredMonths));
     }
 
     /**
@@ -424,6 +424,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
                 .areaMin(chosen.getAreaMin())
                 .areaMax(chosen.getAreaMax())
                 .monthlyRent(chosen.getMonthlyRent())
+                .sampleCount(chosen.getSampleCount())
                 .build();
 
         return GoalRecommendationResponse.RecommendationItem.builder()
@@ -550,13 +551,15 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         private final long monthlyRent;
         /** 전세 환산 보증금 — 후보끼리 비교할 때만 쓰는 내부 저울 */
         private final long comparableAmount;
+        /** 대표값을 뽑는 데 쓰인 실거래 건수 */
+        private final int sampleCount;
         /** 도달까지 걸리는 개월. null이면 탐색 상한 안에 도달 불가 */
         private final Long reachMonths;
         private final long desiredMonths;
 
         private Candidate(String regionCode, String regionName, HousingType housingType, DealType dealType,
                 int areaMin, int areaMax, long deposit, long monthlyRent, long comparableAmount,
-                Long reachMonths, long desiredMonths) {
+                int sampleCount, Long reachMonths, long desiredMonths) {
             this.regionCode = regionCode;
             this.regionName = regionName;
             this.housingType = housingType;
@@ -566,6 +569,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
             this.deposit = deposit;
             this.monthlyRent = monthlyRent;
             this.comparableAmount = comparableAmount;
+            this.sampleCount = sampleCount;
             this.reachMonths = reachMonths;
             this.desiredMonths = desiredMonths;
         }
@@ -605,6 +609,10 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
 
         private long getMonthlyRent() {
             return monthlyRent;
+        }
+
+        private int getSampleCount() {
+            return sampleCount;
         }
 
         private long getComparableAmount() {

--- a/src/main/java/com/team/independence/property/mapper/RegionMapper.java
+++ b/src/main/java/com/team/independence/property/mapper/RegionMapper.java
@@ -21,5 +21,14 @@ public interface RegionMapper {
      */
     List<String> findCodesBySidoPrefix(@Param("sidoPrefix") String sidoPrefix);
 
+    /**
+     * 시도 코드(법정동코드 앞 2자리)에 해당하는 시도명을 조회한다. 없으면 null.
+     *
+     * <p>region 테이블에 시도 자체를 가리키는 행은 없지만 모든 시군구 행이 {@code sido}를 갖고 있어,
+     * 그중 하나만 읽으면 시도명을 알 수 있다. 시도 행을 따로 만들면 전체 지역을 순회하는 실거래
+     * 동기화가 존재하지 않는 sggCd까지 호출하게 되므로 마스터를 늘리지 않는다.
+     */
+    String findSidoNameByPrefix(@Param("sidoPrefix") String sidoPrefix);
+
     String findFullNameByCode(@Param("code") String code);
 }

--- a/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
@@ -34,8 +34,7 @@ public class RentMedianServiceImpl implements RentMedianService {
     @Override
     @Transactional(readOnly = true)
     public RentMedianResponse getMedian(RentMedianRequest request) {
-        // full_name은 NOT NULL이므로 null이면 그 지역 코드가 없다는 뜻이다.
-        String regionName = regionMapper.findFullNameByCode(request.getRegionCode());
+        String regionName = resolveRegionName(request.getRegionCode());
         if (regionName == null) {
             throw new BusinessException(ErrorCode.REGION_NOT_FOUND);
         }
@@ -66,6 +65,24 @@ public class RentMedianServiceImpl implements RentMedianService {
                         ? quartile(amounts, RentMedianAmount::getMonthlyRent)
                         : Quartile.empty())
                 .build();
+    }
+
+    /** 시도 코드 길이(법정동코드 앞 2자리). 이보다 길면 시군구 코드다. */
+    private static final int SIDO_CODE_LENGTH = 2;
+
+    /**
+     * 지역 코드에 해당하는 지명을 찾는다. 없으면 null.
+     *
+     * <p>시군구(5자리)는 그 지역의 전체 지명을, 시도(2자리)는 시도명을 돌려준다.
+     * 시도로 조회하면 그 시도의 시군구 실거래를 모두 한 통에 넣고 집계하므로,
+     * 결과는 "어느 구"가 아니라 "그 시도 전체"의 대표값이 된다.
+     */
+    private String resolveRegionName(String regionCode) {
+        if (regionCode != null && regionCode.length() == SIDO_CODE_LENGTH) {
+            return regionMapper.findSidoNameByPrefix(regionCode);
+        }
+        // full_name은 NOT NULL이므로 null이면 그 지역 코드가 없다는 뜻이다.
+        return regionMapper.findFullNameByCode(regionCode);
     }
 
     /** 평수를 ㎡로 환산한다. 양쪽 모두 버림이라 하한은 넓어지고 상한은 좁아지는데, 명세서가 정한 규칙이다. */

--- a/src/main/resources/mybatis/mapper/property/RegionMapper.xml
+++ b/src/main/resources/mybatis/mapper/property/RegionMapper.xml
@@ -22,6 +22,14 @@
         ORDER BY code
     </select>
 
+    <!-- 같은 시도의 시군구는 모두 같은 sido 값을 가지므로 한 행만 읽으면 된다. -->
+    <select id="findSidoNameByPrefix" resultType="string">
+        SELECT sido
+        FROM region
+        WHERE code LIKE CONCAT(#{sidoPrefix}, '%')
+        LIMIT 1
+    </select>
+
     <select id="findFullNameByCode" resultType="string">
         SELECT full_name
         FROM region

--- a/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
+++ b/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
@@ -59,7 +59,16 @@
     <select id="findAmountsForMedian" resultType="com.team.independence.property.dto.RentMedianAmount">
         SELECT deposit, monthly_rent
           FROM rent_transaction
+        <!-- 지역 코드가 시도 2자리면 그 시도의 시군구 전체를 한 통에 넣고 집계한다.
+             region_code가 idx_rent_reload의 최좌측이라 프리픽스도 레인지 스캔으로 처리된다. -->
+        <choose>
+            <when test="request.regionCode.length() == 2">
+         WHERE region_code LIKE CONCAT(#{request.regionCode}, '%')
+            </when>
+            <otherwise>
          WHERE region_code = #{request.regionCode}
+            </otherwise>
+        </choose>
            AND housing_type = #{request.housingType}
            AND deal_type = #{request.dealType}
            AND deal_ym BETWEEN #{startYm} AND #{endYm}

--- a/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
@@ -1,0 +1,205 @@
+package com.team.independence.goal.service.algorithm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.team.independence.goal.dto.AlgorithmType;
+import com.team.independence.goal.dto.GoalRecommendationRequest;
+import com.team.independence.goal.dto.GoalRecommendationResponse.RecommendationItem;
+import com.team.independence.goal.dto.LoanPlans;
+import com.team.independence.goal.service.LoanPlanCalculator;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.RentMedianRequest;
+import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.dto.RentMedianResponse.Quartile;
+import com.team.independence.property.service.RentMedianService;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * 선호 우선 추천 알고리즘 테스트.
+ *
+ * <p>이 카드는 판단하지 않고 그대로 옮기는 것이 일이라, 검증도 "입력이 조회 조건으로 그대로
+ * 흘러갔는가"와 "조회 결과가 응답으로 그대로 나왔는가"에 집중한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PreferenceAlgorithmTest {
+
+    private static final long MEMBER_ID = 1L;
+    private static final long 억 = 100_000_000L;
+    private static final long 만 = 10_000L;
+
+    @Mock
+    private RentMedianService rentMedianService;
+    @Mock
+    private LoanPlanCalculator loanPlanCalculator;
+
+    private PreferenceAlgorithm algorithm;
+
+    /** 실제로 나간 실거래 조회 조건 */
+    private List<RentMedianRequest> asked;
+
+    @BeforeEach
+    void setUp() {
+        algorithm = new PreferenceAlgorithm(rentMedianService, loanPlanCalculator);
+        asked = new ArrayList<>();
+
+        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any()))
+                .thenReturn(LoanPlans.builder().build());
+        stubMedian(2 * 억, 0, 120);
+    }
+
+    @Test
+    @DisplayName("입력한 조건을 그대로 조회 조건으로 넘긴다")
+    void passesInputConditionThrough() {
+        GoalRecommendationRequest request = request("11110");
+        request.setPropertyType(HousingType.OFFICETEL);
+        request.setTradeType(DealType.WOLSE);
+        request.setSizeMin(10);
+        request.setSizeMax(14);
+
+        RecommendationItem item = recommend(request);
+
+        RentMedianRequest sent = asked.get(0);
+        assertThat(sent.getRegionCode()).isEqualTo("11110");
+        assertThat(sent.getHousingType()).isEqualTo(HousingType.OFFICETEL);
+        assertThat(sent.getDealType()).isEqualTo(DealType.WOLSE);
+        assertThat(sent.getAreaMin()).isEqualTo(10);
+        assertThat(sent.getAreaMax()).isEqualTo(14);
+
+        assertThat(item.getType()).isEqualTo(AlgorithmType.PREFERENCE);
+        assertThat(item.getCondition().getHousingType()).isEqualTo(HousingType.OFFICETEL);
+        assertThat(item.getCondition().getAreaMin()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("빈 칸은 고정 기본값으로 채운다")
+    void fillsBlanksWithFixedDefaults() {
+        RecommendationItem item = recommend(request("11110"));
+
+        RentMedianRequest sent = asked.get(0);
+        assertThat(sent.getHousingType()).isEqualTo(HousingType.APT);
+        assertThat(sent.getDealType()).isEqualTo(DealType.JEONSE);
+        assertThat(sent.getAreaMin()).isEqualTo(15);
+        assertThat(sent.getAreaMax()).isEqualTo(19);
+        assertThat(item.getCondition().getAreaMax()).isEqualTo(19);
+    }
+
+    @Test
+    @DisplayName("감당할 수 없는 금액이어도 조정하지 않고 그대로 낸다")
+    void reportsUnaffordableConditionAsIs() {
+        stubMedian(90 * 억, 0, 40);
+
+        RecommendationItem item = recommend(request("11110"));
+
+        // 예산을 보지 않으므로 조회 횟수는 언제나 1회이고, 조건도 바뀌지 않는다.
+        assertThat(asked).hasSize(1);
+        assertThat(item.getCondition().getHousingType()).isEqualTo(HousingType.APT);
+        assertThat(item.getCondition().getAreaMin()).isEqualTo(15);
+    }
+
+    @Test
+    @DisplayName("시도를 받으면 시군구를 고르지 않고 시도 전체로 답한다")
+    void answersWithWholeSidoWhenGivenSidoCode() {
+        stubMedian("11", "서울특별시", 6 * 억, 0, 8200);
+
+        RecommendationItem item = recommend(request("11"));
+
+        assertThat(asked).hasSize(1);
+        assertThat(asked.get(0).getRegionCode()).isEqualTo("11");
+        assertThat(item.getCondition().getRegionCode()).isEqualTo("11");
+        assertThat(item.getCondition().getRegionName()).isEqualTo("서울특별시");
+    }
+
+    @Test
+    @DisplayName("표본이 적어도 버리지 않고 건수를 함께 내려준다")
+    void keepsThinSampleAndReportsCount() {
+        stubMedian(3 * 억, 0, 2);
+
+        RecommendationItem item = recommend(request("11110"));
+
+        assertThat(item.getCondition().getSampleCount()).isEqualTo(2);
+        assertThat(item.getReason()).contains("2건");
+    }
+
+    @Test
+    @DisplayName("월세면 월세 금액을 조건에 담고, 목표 금액은 보증금으로 넘긴다")
+    void carriesMonthlyRentAndUsesDepositAsTarget() {
+        stubMedian(1000 * 만, 40 * 만, 60);
+
+        GoalRecommendationRequest request = request("11110");
+        request.setTradeType(DealType.WOLSE);
+
+        RecommendationItem item = recommend(request);
+
+        assertThat(item.getCondition().getMonthlyRent()).isEqualTo(40 * 만);
+        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(1000 * 만), any());
+    }
+
+    @Test
+    @DisplayName("실거래가 한 건도 없으면 추천하지 않는다")
+    void returnsEmptyWhenNoTransaction() {
+        stubMedian(0, 0, 0);
+
+        assertThat(algorithm.recommend(MEMBER_ID, request("11110"))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("실거래 조회가 실패해도 예외를 밖으로 던지지 않는다")
+    void returnsEmptyWhenLookUpFails() {
+        doThrow(new IllegalStateException("조회 실패")).when(rentMedianService).getMedian(any());
+
+        assertThat(algorithm.recommend(MEMBER_ID, request("11110"))).isEmpty();
+    }
+
+    // ===== 헬퍼 =====
+
+    private RecommendationItem recommend(GoalRecommendationRequest request) {
+        return algorithm.recommend(MEMBER_ID, request)
+                .orElseThrow(() -> new AssertionError("추천 결과가 비어 있습니다"));
+    }
+
+    private GoalRecommendationRequest request(String regionCode) {
+        GoalRecommendationRequest request = new GoalRecommendationRequest();
+        request.setRegionCode(regionCode);
+        return request;
+    }
+
+    private void stubMedian(long deposit, long monthlyRent, int sampleCount) {
+        stubMedian("11110", "서울특별시 종로구", deposit, monthlyRent, sampleCount);
+    }
+
+    private void stubMedian(String regionCode, String regionName,
+            long deposit, long monthlyRent, int sampleCount) {
+        doAnswer(call -> {
+            RentMedianRequest req = call.getArgument(0);
+            asked.add(req);
+            return RentMedianResponse.builder()
+                    .regionCode(regionCode)
+                    .regionName(regionName)
+                    .housingType(req.getHousingType())
+                    .dealType(req.getDealType())
+                    .sampleCount(sampleCount)
+                    .deposit(sampleCount == 0 ? Quartile.empty() : Quartile.of(deposit, deposit, deposit))
+                    .monthlyRent(monthlyRent > 0
+                            ? Quartile.of(monthlyRent, monthlyRent, monthlyRent) : Quartile.empty())
+                    .build();
+        }).when(rentMedianService).getMedian(any());
+    }
+}

--- a/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
@@ -1,4 +1,4 @@
-package com.team.independence.goal.service;
+package com.team.independence.goal.service.algorithm;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,6 +15,8 @@ import com.team.independence.goal.dto.AlgorithmType;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse.RecommendationItem;
 import com.team.independence.goal.dto.LoanPlans;
+import com.team.independence.goal.service.GoalService;
+import com.team.independence.goal.service.LoanPlanCalculator;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.dto.RentMedianRequest;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #91

close #91

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 상세하게 설명해주세요(이미지 첨부 가능)

추천 알고리즘 4개 중 **PREFERENCE** 한 장을 구현했습니다. 함께 필요한 실거래 조회 기능(시도 단위 집계)을 property 도메인에 추가했습니다.

### 이 카드가 하는 말

**계산하지 않는 것이 이 카드의 정체성입니다.** 사용자가 원한 조건의 실거래 시세를 그대로 보여주고, 그것을 감당할 수 있는지는 판단하지 않습니다. 30년이 걸릴 조건이어도 그대로 냅니다.

### REALISTIC과 무엇이 다른가

둘 다 빈 칸을 채웁니다. 차이는 "조건을 몇 개 받았느냐"가 아니라 **빈 칸을 채울 때 계산을 하느냐**입니다.

```
사용자가 "서울 · 전세"만 입력했을 때

PREFERENCE  빈 칸을 고정 기본값으로 채움      → 서울 아파트 15~19평 전세, 6억
              (예산을 보지 않음)                 감당 가능한지는 말하지 않음

REALISTIC   빈 칸을 저축 여력에 맞게 탐색      → 도봉구 오피스텔 4~9평 전세, 8천만
              (예산에 맞는 최선을 찾음)          "24개월 안에 갈 수 있습니다"
```

같은 입력에 다른 답이 나오는 것이 정상이고, 두 카드가 나란히 놓여야 의미가 완성됩니다.

---

## 전체 플로우

분기가 갈렸다가 다시 합쳐집니다. 금액은 이해를 돕기 위한 예시값입니다.

```
                  [입력]  지역(필수) · 나머지 조건(선택)
                     │
           ┌─────────┴─────────┐
     목표 시점 입력함      목표 시점 없음
           │              → 24개월 뒤로
           └─────────┬─────────┘
                     │
                [조건 확정]
        입력한 값 + 빈 칸은 고정 기본값
          (아파트 · 15~19평)
                     │
           ┌─────────┴──────────┐
    지역이 시군구(5자리)     지역이 시도(2자리)
    → 그 구의 실거래만    → 그 시도의 구 전체 실거래를
                              한 통에 넣음
           └─────────┬──────────┘
                     │
           ┌─────────┴──────────┐
    거래유형 입력함        거래유형 없음
    → 그 유형만 조회    → 전세·월세 각각 조회하고
       (1회)              실거래가 많은 쪽 채택 (2회)
           └─────────┬──────────┘
                     │
           ┌─────────┴─────────┐
      거래 1건 이상          거래 0건
           │              → 추천 없음
    [LoanPlanCalculator]
                     │
              [카드 만들기]
```

**예산 계산도, 탐색도, 배수 판정도 없습니다.** 조회는 **1회**이고, 거래유형을 정하지 않았을 때만 2회입니다.

### 목표 시점

입력했으면 그 값, 없으면 24개월 뒤입니다. 이 카드는 시점으로 무언가를 판단하지 않고, `LoanPlanCalculator`에 넘겨 저축 플랜을 만드는 데만 씁니다.

### 조건 확정

입력한 값을 그대로 쓰고 **비워 둔 칸만** 기본값으로 채웁니다.

```
주거유형  입력했으면 그 값 / 없으면 아파트
평수      입력했으면 그 값 / 없으면 15~19평
거래유형  입력했으면 그 값 / 없으면 → 실거래가 많은 쪽 (아래 참고)
```

여기서 끝입니다. REALISTIC처럼 이 값을 놓고 더 나은 조합을 찾아보지 않습니다. **사용자가 원한 것을 보여주는 것이 일**이기 때문입니다.

보증금·월세 범위를 입력했다면 실거래 조회 필터로 그대로 넘어갑니다.

### 지역이 시도면 시군구를 고르지 않는다

시도(`"11"`)를 받으면 **그 시도의 모든 시군구 실거래를 한 통에 넣고 정렬해 중앙값 하나**를 냅니다.

```
서울 25개 구의 최근 6개월 실거래 중 조건에 맞는 것을 전부 모음
      종로 3.2억, 도봉 1.8억, 강남 9억, 중랑 2.1억, ...
                        ↓
                 전부 한 줄로 정렬
                        ↓
                   가운데 값 하나
```

그래서 응답의 지역은 **"서울특별시"**이지 "중랑구"가 아닙니다. 사용자가 묻지 않은 시군구를 우리가 정해 주지 않는다는 뜻이고, 감당 가능한 동네를 짚어 주는 일은 REALISTIC의 몫입니다.

다만 시도 중앙값은 비싼 지역이 끌어올린 값이라 **실제로 갈 수 있는 동네와 동떨어질 수 있습니다.** 그것을 감추지 않는 것이 이 카드의 역할이고, 옆의 REALISTIC 카드가 균형을 잡습니다.

### 거래유형은 기본값을 두지 않는다

주거유형·평수와 달리 거래유형은 고정 기본값을 두지 않았습니다. 처음에는 전세로 박아 뒀는데 **근거 없는 값**이었고, 원룸급처럼 월세가 사실상 표준인 조건에서 표본이 적은 전세 시세를 내놓거나 전세 거래가 아예 없어 카드가 나가지 못했습니다.

대신 **전세와 월세를 각각 조회해 실거래가 더 많은 쪽**을 고릅니다.

```
거래유형 미지정 + 강남구 아파트 15~19평
  전세 320건 / 월세 45건   → 전세 카드

거래유형 미지정 + 관악구 오피스텔 4~9평
  전세  30건 / 월세 210건  → 월세 카드
```

같은 "미지정"인데 지역·평수에 따라 답이 갈립니다. **우리가 정하는 것이 아니라 그 동네에서 실제로 무엇을 많이 하는지가 정합니다.** "어느 쪽이 유리한가"를 따지는 것이 아니라 "그 조건에서는 보통 이렇게 거래한다"를 옮기는 것이라, 판단하지 않는 이 카드의 성격을 깨지 않습니다. 유리한지를 따지는 것은 REALISTIC의 일입니다.

전세·월세 실거래를 **한 통에 섞지는 않습니다.** 전세 보증금 3억과 월세 보증금 1천만이 같이 정렬되면 중앙값이 어느 쪽도 대표하지 못합니다.

한쪽에 거래가 없으면 남은 쪽으로 내고, 건수가 같으면 전세로 고정합니다 — 드문 경우지만 같은 요청에 매번 다른 답이 나오면 안 되기 때문입니다.

### 표본이 적어도 버리지 않는다

REALISTIC은 거래 3건 미만인 조합을 버립니다. 중앙값으로 후보들을 **비교해 하나를 고르는** 것이 일이라 한두 건짜리 값이 선택을 왜곡하기 때문입니다.

이 카드는 고르는 것이 아니라 **그대로 보고하는** 것이 일이므로 버리지 않고, 대신 실거래 건수(`sampleCount`)를 응답에 실어 화면이 판단하게 합니다. 단 **0건이면 보여줄 금액 자체가 없어** 카드를 내지 않습니다.

### 카드 만들기

목표 금액은 **실제 보증금**입니다. 월세면 월세 금액이 `condition.monthlyRent`로 따로 나갑니다.

```
"최근 6개월 실거래 128건 기준 서울특별시 아파트 15~19평 전세 시세입니다."
```

`reason`에 건수를 함께 적어, 숫자의 근거가 얼마나 두터운지 카드에서 바로 보이게 했습니다.

### 실제로 타는 경로 세 가지

**아무 조건도 입력하지 않은 사용자** — `regionCode="11"`
조건 확정 = 아파트·전세·15\~19평(전부 기본값) → 서울 전체 실거래 8,200건 집계 → 6억 → 카드

**조건을 다 입력한 사용자** — 종로구 + 오피스텔 + 월세 + 10\~14평
입력값 그대로 조회 → 보증금 1,000만 · 월세 40만 → `condition.monthlyRent = 400000`, 목표 금액은 1,000만

**감당할 수 없는 조건을 입력한 사용자** — 강남구 + 아파트 + 전세 + 20\~25평
90억이 나와도 **조정하지 않고 그대로** 카드로 냅니다. 조회도 1회로 끝납니다

---

## 공식과 상수

이 카드에는 **공식이 없습니다.** 실거래 중앙값을 그대로 옮기고, 저축 플랜은 `LoanPlanCalculator`에 위임합니다.

### 상수 목록

| 상수 | 값 | 근거 |
|---|---|---|
| 기본 목표 시점 | 24개월 | **있음** — 주택임대차보호법상 기본 임대차 기간이 2년이라, 미지정 시 다음 계약 주기로 잡는 것이 자연스러움 |
| 기본 주거유형 | 아파트 | **약함** — 실거래 표본이 가장 많아 데이터가 비는 조건이 될 확률이 낮다는 이유뿐 |
| 기본 평수 | 15~19평 | **없음** — 임의로 정했습니다 |

### 기본값을 REALISTIC과 공유하지 않았습니다

값이 같더라도 상수를 공유하지 않고 각 클래스에 따로 뒀습니다. **두 카드가 같은 값을 써야 할 이유가 없고**, 한쪽 기본값을 조정할 때 다른 쪽이 따라 움직이면 곤란하기 때문입니다. 공유하면 "PREFERENCE 기본 평수를 넓히자"는 변경이 REALISTIC의 탐색 기준까지 바꿔 버립니다.

### 일부러 만들지 않은 상수

- **기본 거래유형** — 처음에는 전세로 뒀다가 없앴습니다. 근거 없는 값인데다 결과를 크게 바꿔서, 실거래 건수가 정하도록 바꿨습니다. 대신 "건수가 같으면 전세"라는 훨씬 작은 규칙만 남았습니다
- **최소 표본 수** — REALISTIC에는 3건이라는 하한이 있지만 이 카드에는 두지 않았습니다. 버리는 대신 건수를 그대로 내려보내 판단을 화면에 맡기는 쪽이 이 카드의 성격에 맞습니다

---

## 구현 내용

### 플로우의 각 단계를 무엇이 처리하는가

위 플로우에 코드를 얹은 그림입니다. `＊`가 붙은 것이 이번에 새로 만든 것, 나머지는 기존 것을 그대로 씁니다.

```
                  [입력]  GoalRecommendationRequest
                     │
           ┌─────────┴─────────┐
     목표 시점 입력함      목표 시점 없음
           └─────────┬─────────┘
                     │
                [조건 확정]
        PreferenceAlgorithm.recommend ＊
        빈 칸만 자체 기본값으로 채움
                     │
           ┌─────────┴──────────┐
    거래유형 입력함        거래유형 없음
           │            resolveMedian ＊
           │            전세·월세 각각 lookUp ＊
           └─────────┬──────────┘
                     │
           ┌─────────┴──────────┐
    지역이 시군구(5자리)     지역이 시도(2자리)
           │            RegionMapper.findSidoNameByPrefix ＊
           │            findAmountsForMedian 프리픽스 매칭 ＊
           └─────────┬──────────┘
                     │
          RentMedianService.getMedian
                     │
           ┌─────────┴─────────┐
      거래 1건 이상          거래 0건
           │              → Optional.empty()
    LoanPlanCalculator.calculate  (스텁)
                     │
              [카드 만들기]
        Condition.sampleCount ＊
        Condition.monthlyRent
```

시도 처리를 알고리즘이 아니라 **`RentMedianService` 안**에 넣은 것이 이 PR의 구조적 판단입니다. "지역 코드가 시도면 시도 전체"는 실거래 조회의 의미론이지 추천 알고리즘의 사정이 아니라서, 여기 두면 다른 알고리즘도 각자 분기를 만들 필요가 없습니다.

### 바깥에 영향이 있는 변경

- **`GoalRecommendationResponse.Condition`에 `sampleCount` 추가** — 대표값을 뽑는 데 쓰인 실거래 건수. 거래가 드문 조건에서는 한두 건으로 계산된 값일 수 있어 화면이 신뢰도를 판단할 수 있게 합니다 ⚠️ **프론트 영향**
- **`RentMedianService`가 시도 코드를 받습니다** — 기존 5자리 동작은 그대로이고 2자리가 추가로 동작합니다. `/api/v1/properties` 쪽 실거래 조회 API도 함께 시도를 지원하게 됩니다

## 테스트

`PreferenceAlgorithmTest` 12건 추가. 전체 177건 통과, 회귀 없습니다.

이 카드는 판단하지 않고 그대로 옮기는 것이 일이라, 검증도 **"입력이 조회 조건으로 그대로 흘러갔는가"**와 **"조회 결과가 응답으로 그대로 나왔는가"**에 집중했습니다.

- 입력한 조건을 그대로 조회 조건으로 넘기는가
- 빈 칸을 고정 기본값으로 채우는가
- **거래유형을 정하지 않으면 실거래가 더 많은 쪽을 고르는가**
- **거래유형을 정했으면 그쪽만 조회하는가**
- **한쪽 거래유형에 실거래가 없으면 남은 쪽으로 내는가**
- **건수가 같으면 전세로 고정하는가**
- **감당할 수 없는 금액(90억)이어도 조정하지 않고 그대로 내는가** — 조회가 1회로 끝나는 것까지 확인
- **시도를 받으면 시군구를 고르지 않고 시도 전체로 답하는가**
- **표본이 2건이어도 버리지 않고 건수를 함께 내려주는가**
- 월세면 월세 금액을 조건에 담고, 목표 금액은 보증금으로 넘기는가
- 실거래가 한 건도 없으면 추천하지 않는가
- 실거래 조회가 실패해도 예외를 밖으로 던지지 않는가

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

1. **시도 전체를 한 통에 넣는 것**을 봐주세요. 강남과 도봉이 섞인 중앙값이라 그 값에 해당하는 동네가 실재하지 않습니다. 사용자가 시군구를 묻지 않았으니 정해 주지 않는다는 판단인데, 차라리 대표 시군구를 골라 주는 편이 쓸모 있다고 보시면 말씀해주세요.
2. **표본이 적어도 카드를 내는 것**을 봐주세요. 거래 2건으로 계산된 중앙값도 `sampleCount`와 함께 나갑니다. 프론트가 이 값을 실제로 표시하지 않으면 신뢰할 수 없는 숫자가 그대로 보이게 됩니다 — 화면 처리가 전제입니다.
3. **거래유형을 실거래 건수로 정하는 것**을 봐주세요. 사용자가 정하지 않았을 때 "그 조건에서 많이 하는 방식"을 따르는데, 건수가 많다고 그 사용자에게 맞는 것은 아닐 수 있습니다.
4. **`Condition.sampleCount` 추가**를 봐주세요. 응답 스펙 변경이라 프론트 협의가 필요합니다.
5. **`RentMedianService`를 건드린 것**을 봐주세요. property 도메인 공용 서비스라 다른 소비처(진단·HoldOut·실거래 조회 API)에 영향이 갑니다. 기존 5자리 동작은 바뀌지 않지만, goal 도메인 사정으로 property를 고치는 것이 맞는지 봐주세요.

## 남은 논의 (구현을 막지는 않음)

- **시도 조회의 표본 규모** — `findAmountsForMedian`은 조건에 맞는 실거래 금액을 전부 애플리케이션으로 가져와 자바에서 정렬합니다. 시군구 단위는 수백 건이지만 서울 전체는 수만 건이 될 수 있습니다. 당장 못 버틸 양은 아니나, 중앙값을 SQL에서 구하는 쪽으로 옮기면 근본적으로 해결됩니다
- **`HOLD_OUT`의 시도 코드 처리** — `GoalRecommendationRequest`는 세 알고리즘이 공유하는데, HoldOut은 `regionCode`를 검증 없이 실거래 조회에 넘깁니다. 이번 PR로 `RentMedianService`가 시도를 이해하게 되어 함께 동작하게 되지만, HoldOut이 시도를 어떻게 다룰지는 담당자와 확인이 필요합니다
- **`sampleCount`를 채우지 않는 알고리즘** — HoldOut은 아직 이 필드를 채우지 않아 `0`으로 나갑니다
- **`BudgetCalculator` 전환** — REALISTIC이 아직 `GoalService.calculateMonthToReach`를 직접 씁니다. develop에 같은 공식을 뽑아 둔 `BudgetCalculator`가 있어 전환이 필요하지만, 이번 PR 범위 밖입니다
