### PR TITLE
refactor: MonteCarloService 개선 - PriceModel 캡슐화, goalId 의존 제거, 시뮬레이션 캐싱

### DIFF
--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -32,10 +32,10 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * 프론트 희망조건 입력을 검증·정규화하고 region_code까지 붙여 돌려준다.
  * 순자산 중 예적금만 연 5% 복리로 굴리고(나머지는 인정률만 반영한 원금 그대로) + 월저축액 예상값으로
- * budget을, 조건에 맞는 실거래 보증금 4분위값을 marketStats로 계산해 반환.
+ * budget을, 조건에 맞는 실거래 보증금 4분위값을 marketStats로 계산해 반환
  * budget과 median을 비교해 status/shortfall을 매기고, 부족(INSUFFICIENT)할 때
  * 저축액 증가/기간 연장/평수 축소 3가지 조정 제안을 함께 계산한다.
- * 목표 저장은 다음 단계에서 추가.
+ * 목표 저장은 다음 단계에서 추가
  */
 @Service
 @RequiredArgsConstructor
@@ -47,14 +47,14 @@ public class GoalServiceImpl implements GoalService {
     private static final String GOAL_TYPE_HOUSING = "HOUSING";
     private static final String GOAL_STATUS_ACTIVE = "ACTIVE";
 
-    /** 예산 계산에 적용하는 연 이자율(고정 상수). 실제 상품 금리 연동 없이 5%로 가정. */
+    /** 예산 계산에 적용하는 연 이자율(고정 상수: 실제 상품 금리 연동 없이 5%로 가정) */
     private static final double ANNUAL_INTEREST_RATE = 0.05;
 
     /** 기간 연장 제안 탐색 상한(개월) */
     private static final long EXTEND_PERIOD_MAX_MONTHS = 240;
     /** 평수 축소 제안 탐색 상한(평) */
     private static final int REDUCE_SIZE_MAX_STEPS = 10;
-    /** 예상 달성 시점 탐색 상한(개월). 저축액이 미미해 사실상 도달 불가할 때 무한 루프를 막는 안전장치. */
+    /** 예상 달성 시점 탐색 상한(개월). 저축액이 미미해 사실상 도달 불가할 때 무한 루프를 막는 안전장치 */
     private static final long MAX_FORECAST_MONTHS = 1200;
 
     /** RentMedianResponse.baseEndYm("YYYYMM") 파싱용 */
@@ -67,6 +67,7 @@ public class GoalServiceImpl implements GoalService {
     private final GoalMapper goalMapper;
     private final GoalHousingMapper goalHousingMapper;
     private final GoalMarketTrendCacheStore goalMarketTrendCacheStore;
+    private final MonteCarloSimulationStore monteCarloSimulationStore;
 
     @Override
     public GoalDiagnosisResponse diagnose(Long memberId, GoalDiagnosisRequest request) {
@@ -185,7 +186,7 @@ public class GoalServiceImpl implements GoalService {
 
         assetConnectionService.validateConnectedAccountExists(memberId);
 
-        // 동시 ACTIVE 목표는 1개만 허용 — 이미 있으면 저장을 거부(수정/삭제 후 재시도 유도)
+        // 동시 ACTIVE 목표는 1개만 허용: 이미 있으면 저장을 거부(수정/삭제 후 재시도 유도)
         if (goalMapper.existsActiveByMemberId(memberId)) {
             throw new BusinessException(ErrorCode.GOAL_ALREADY_EXISTS);
         }
@@ -211,8 +212,8 @@ public class GoalServiceImpl implements GoalService {
     }
 
     /**
-     * 목표 하나를 조회한다. 수정 화면이 폼을 채우는 데 쓰므로 응답은 생성·수정과 같은 GoalResponse다.
-     * 상태로 거르지 않는다 — 삭제는 행을 지우지 않는 소프트 삭제고, 지난 목표 열람을 막을 이유가 없다.
+     * 목표 하나를 조회한다. 수정 화면이 폼을 채우는 데 쓰므로 응답은 생성, 수정과 같은 GoalResponse다.
+     * 상태로 거르지 않는다: 삭제는 행을 지우지 않는 소프트 삭제고, 지난 목표 열람을 막을 이유가 없다.
      * 수정 가능 여부는 updateGoal의 GOAL_NOT_ACTIVE가 판정한다.
      */
     @Override
@@ -223,7 +224,7 @@ public class GoalServiceImpl implements GoalService {
     }
 
     /**
-     * 목표의 조건을 통째로 교체한다. 저장 계약은 생성과 같다 — 프론트가 진단을 다시 호출해 받은
+     * 목표의 조건을 통째로 교체한다. 저장 계약은 생성과 같다: 프론트가 진단을 다시 호출해 받은
      * targetAmount/targetRentMiddleAmount를 실어 보내면 서버는 재계산 없이 그대로 고정 저장한다.
      * 이미 끝난(ACHIEVED/ARCHIVED) 목표는 수정할 수 없다.
      */
@@ -251,9 +252,10 @@ public class GoalServiceImpl implements GoalService {
         // 생성 때와 같은 이유로 asset_summary 캐시도 함께 갱신한다
         assetSummaryService.updateMonthlySavings(memberId, request.getMonthlySavings());
 
-        // 시세 변화 캐시는 목표 금액과 주거 조건을 그대로 담고 있어 수정 즉시 stale해진다.
-        // 지워두면 다음 조회 때 캐시 미스 경로가 새 조건으로 다시 계산한다.
+        // 목표 조건이 바뀌면 시세 변화 캐시, 시뮬레이션 캐시 모두 stale해진다.
+        // 지워두면 다음 조회 때 새 조건으로 재계산한다.
         goalMarketTrendCacheStore.delete(goalId);
+        monteCarloSimulationStore.delete(goalId);
 
         return toGoalResponse(goalMapper.findById(goalId), goalHousing);
     }
@@ -261,12 +263,12 @@ public class GoalServiceImpl implements GoalService {
     /**
      * 목표를 삭제한다. 행을 지우지 않고 status만 ARCHIVED로 내린다.
      *
-     * <p>goal을 참조하는 FK 세 개(goal_housing, saving_record, goal_snapshot)에 ON DELETE CASCADE가
+     * goal을 참조하는 FK 세 개(goal_housing, saving_record, goal_snapshot)에 ON DELETE CASCADE가
      * 없어 물리 삭제는 제약 위반이고, 특히 goal_snapshot은 또래 비교 집계가 회원 구분 없이
-     * 기준월·순자산·나이로만 묶여 있어 지우면 과거 통계가 소급해서 바뀐다.
+     * 기준월, 순자산, 나이로만 묶여 있어 지우면 과거 통계가 소급해서 바뀐다.
      *
-     * <p>ARCHIVED가 되면 목표 생성을 막는 조건(ACTIVE 목표 존재)에서 빠지므로 새 목표를 만들 수 있다.
-     * asset_summary.monthly_savings는 건드리지 않는다 — 목표가 없으면 화면에 쓰이지 않고
+     * ARCHIVED가 되면 목표 생성을 막는 조건(ACTIVE 목표 존재)에서 빠지므로 새 목표를 만들 수 있다.
+     * asset_summary.monthly_savings는 건드리지 않는다: 목표가 없으면 화면에 쓰이지 않고
      * 새 목표를 만들면 그때 덮어쓴다.
      */
     @Override
@@ -279,12 +281,12 @@ public class GoalServiceImpl implements GoalService {
 
         goalMapper.archive(goalId, memberId);
 
-        // 시세 변화 캐시는 TTL이 35일이라 지우지 않으면 삭제한 목표의 데이터가 한 달 넘게 남는다
         goalMarketTrendCacheStore.delete(goalId);
+        monteCarloSimulationStore.delete(goalId);
     }
 
     /**
-     * 생성·수정 공통. 희망 조건을 진단과 같은 규칙으로 검증하고 goal_housing 저장 형태로 정규화한다.
+     * 생성, 수정 공통. 희망 조건을 진단과 같은 규칙으로 검증하고 goal_housing 저장 형태로 정규화한다.
      * goalId는 아직 모르거나(생성) 호출부가 이미 아는 값(수정)이라 여기서 채우지 않는다.
      */
     private GoalHousing validateAndBuildHousing(GoalSaveRequest request) {
@@ -316,7 +318,7 @@ public class GoalServiceImpl implements GoalService {
                 .build();
     }
 
-    /** 생성·수정 공통 응답 조립. createdAt/updatedAt은 DB가 채운 값을 그대로 쓴다. */
+    /** 생성, 수정 공통 응답 조립. createdAt/updatedAt은 DB가 채운 값을 그대로 쓴다. */
     private GoalResponse toGoalResponse(Goal goal, GoalHousing goalHousing) {
         return GoalResponse.builder()
                 .goalId(goal.getId())
@@ -360,7 +362,7 @@ public class GoalServiceImpl implements GoalService {
     @Override
     public Long calculateMonthToReach(AssetNetWorthBreakdown netWorth, long monthlySaving, long targetAmount) {
         long growingAssets = netWorth.getInterestBearingAssets(); // 이자로 불어나는 자산(예적금)
-        long fixedAssets = netWorth.getFlatRecognizedAssets();    // 원금 그대로 인정하는 자산
+        long fixedAssets = netWorth.getFlatRecognizedAssets();  // 원금 그대로 인정하는 자산
 
         if (growingAssets + fixedAssets >= targetAmount) {
             return 0L;
@@ -422,7 +424,7 @@ public class GoalServiceImpl implements GoalService {
      * 목표의 희망 조건으로 실거래 중앙값을 다시 조회하고, reflectEta(현재 시세 반영 시 도달 예상 시점)만
      * 오늘 기준 자산으로 다시 계산한다.
      *
-     * <p>maintainEta(목표 유지 시 도달 예상 시점)는 재계산하지 않고 goal.target_date를 그대로 쓴다.
+     * maintainEta(목표 유지 시 도달 예상 시점)는 재계산하지 않고 goal.target_date를 그대로 쓴다.
      * 홈 화면 다른 곳에도 같은 target_date가 "목표 시점"으로 노출되는데, 여기서 오늘 자산 기준으로
      * 다시 계산해버리면 같은 화면 안에서 목표 시점이 두 가지 다른 값으로 보이게 된다.
      */

--- a/src/main/java/com/team/independence/goal/service/MonteCarloService.java
+++ b/src/main/java/com/team/independence/goal/service/MonteCarloService.java
@@ -1,20 +1,28 @@
 package com.team.independence.goal.service;
 
 import com.team.independence.goal.dto.MonteCarloResponse;
+import com.team.independence.property.dto.PriceModelRequest;
 
 public interface MonteCarloService {
 
     /**
-     * 회원의 목표에 대해 GBM 몬테카를로 시뮬레이션을 실행한다.
+     * 저장된 목표에 대해 시뮬레이션을 실행한다. 목표 상세 화면(엔드포인트)용
      *
-     * PriceModel(μ, σ)을 목표의 주거 조건으로 산출하고,
-     * P(0) = 목표 설정 당시 중앙값 기준으로 T 시점의 가격 분포를 시뮬레이션한다.
-     * 동시에 BudgetCalculator로 T 시점 예상 예산을 결정적으로 계산 후
-     * 목표 달성 확률(successProbability)을 함께 반환한다.
-     *
-     * @param memberId 요청 회원 ID
-     * @param goalId 시뮬레이션할 목표 ID
-     * @return 시뮬레이션 결과 (가격 분위값, 달성 확률 등)
+     * P(0): 목표 설정 당시 기록된 중앙값(targetRentMiddleAmount)
      */
     MonteCarloResponse simulate(Long memberId, Long goalId);
+
+    /**
+     * 주거 조건과 예산 파라미터를 직접 받아 시뮬레이션을 실행한다. (추천 알고리즘 내부용)
+     *
+     * goalId 없이 호출할 수 있어, 목표 저장 전 추천 흐름에서 사용한다.
+     * PriceModel(μ, σ) 산출은 내부에서 처리하므로 호출자는 주거 조건만 넘기면 된다.
+     *
+     * @param housing PriceModel 산출에 필요한 주거 조건 (지역 / 유형 / 평수)
+     * @param initialPrice P(0): 기준 시점의 주택 가격 (현재 시세 중앙값, 원)
+     * @param budgetAtT T 시점의 예상 예산 (BudgetCalculator 결과, 원)
+     * @param months 시뮬레이션 기간 (개월)
+     * @return p5 / p50 / p95 가격 분위값과 성공 확률
+     */
+    MonteCarloEngine.Result simulate(PriceModelRequest housing, long initialPrice, long budgetAtT, int months);
 }

--- a/src/main/java/com/team/independence/goal/service/MonteCarloServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/MonteCarloServiceImpl.java
@@ -16,9 +16,11 @@ import com.team.independence.property.service.RegionQueryService;
 import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MonteCarloServiceImpl implements MonteCarloService {
@@ -30,11 +32,24 @@ public class MonteCarloServiceImpl implements MonteCarloService {
     private final BudgetCalculator budgetCalculator;
     private final PriceModelService priceModelService;
     private final RegionQueryService regionQueryService;
+    private final MonteCarloSimulationStore simulationStore;
 
     @Override
     @Transactional(readOnly = true)
     public MonteCarloResponse simulate(Long memberId, Long goalId) {
+        // 소유권 확인은 캐시 조회 전에 수행한다
         Goal goal = goalService.findOwnedGoal(memberId, goalId);
+
+        // 캐시 HIT: 목표 조건이 바뀌지 않았으면 재계산 없이 반환
+        return simulationStore.find(goalId).orElseGet(() -> {
+            log.info("[Monte Carlo] 캐시 MISS: 계산 후 캐싱 goalId={}", goalId);
+            MonteCarloResponse response = compute(memberId, goal, goalId);
+            simulationStore.save(goalId, response);
+            return response;
+        });
+    }
+
+    private MonteCarloResponse compute(Long memberId, Goal goal, Long goalId) {
 
         GoalHousing housing = goalHousingMapper.findByGoalId(goalId);
         if (housing == null) {
@@ -52,10 +67,9 @@ public class MonteCarloServiceImpl implements MonteCarloService {
         long currentBudget = netWorth.getInterestBearingAssets() + netWorth.getFlatRecognizedAssets();
         long budgetAtT = budgetCalculator.calculate(netWorth, goal.getMonthlySaving(), months);
 
-        PriceModelResponse priceModel = priceModelService.estimate(buildPriceModelRequest(housing));
-
         long initialPrice = goal.getTargetRentMiddleAmount();
-
+        PriceModelRequest priceModelRequest = buildPriceModelRequest(housing);
+        PriceModelResponse priceModel = priceModelService.estimate(priceModelRequest);
         MonteCarloEngine.Result result = MonteCarloEngine.simulate(
                 priceModel.getAnnualDrift(), priceModel.getAnnualVol(),
                 initialPrice, budgetAtT,
@@ -82,6 +96,15 @@ public class MonteCarloServiceImpl implements MonteCarloService {
                 .priceP95(result.priceP95())
                 .successProbability(result.successProbability())
                 .build();
+    }
+
+    @Override
+    public MonteCarloEngine.Result simulate(PriceModelRequest housing, long initialPrice, long budgetAtT, int months) {
+        PriceModelResponse priceModel = priceModelService.estimate(housing);
+        return MonteCarloEngine.simulate(
+                priceModel.getAnnualDrift(), priceModel.getAnnualVol(),
+                initialPrice, budgetAtT,
+                months, MonteCarloEngine.DEFAULT_SIMULATIONS, MonteCarloEngine.DEFAULT_SEED);
     }
 
     private PriceModelRequest buildPriceModelRequest(GoalHousing housing) {

--- a/src/main/java/com/team/independence/goal/service/MonteCarloSimulationStore.java
+++ b/src/main/java/com/team/independence/goal/service/MonteCarloSimulationStore.java
@@ -1,0 +1,64 @@
+package com.team.independence.goal.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.independence.goal.dto.MonteCarloResponse;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 목표별 Monte Carlo 시뮬레이션 결과를 Redis에 캐싱한다.
+ * Key: goal:simulation:{goalId} (TTL: 30일)
+ *
+ * 시뮬레이션 결과는 목표 조건(주거 조건·목표 시점·월 저축액)이 바뀌지 않는 한 재계산할 필요가 없다.
+ * 목표 수정 및 삭제(ARCHIVE) 시 {@link #delete}로 무효화하면 다음 조회 때 새 조건으로 다시 계산된다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MonteCarloSimulationStore {
+
+    private static final String KEY_PREFIX = "goal:simulation:";
+    private static final Duration TTL = Duration.ofDays(30);
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public Optional<MonteCarloResponse> find(Long goalId) {
+        String json = redisTemplate.opsForValue().get(key(goalId));
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(json, MonteCarloResponse.class));
+        } catch (JsonProcessingException e) {
+            log.warn("[Monte Carlo 캐시] 역직렬화 실패, 캐시 미스로 처리: goalId={}", goalId, e);
+            return Optional.empty();
+        }
+    }
+
+    public void save(Long goalId, MonteCarloResponse response) {
+        try {
+            String json = objectMapper.writeValueAsString(response);
+            redisTemplate.opsForValue().set(key(goalId), json, TTL);
+        } catch (JsonProcessingException e) {
+            log.warn("[Monte Carlo 캐시] 직렬화 실패, 캐싱 건너뜀: goalId={}", goalId, e);
+        }
+    }
+
+    /**
+     * 목표 조건 수정 및 삭제 시 바뀌면 캐시를 무효화한다.
+     * 다음 조회 때 새 조건으로 재계산된다.
+     */
+    public void delete(Long goalId) {
+        redisTemplate.delete(key(goalId));
+    }
+
+    private String key(Long goalId) {
+        return KEY_PREFIX + goalId;
+    }
+}

--- a/src/main/java/com/team/independence/property/controller/PropertyController.java
+++ b/src/main/java/com/team/independence/property/controller/PropertyController.java
@@ -1,11 +1,8 @@
 package com.team.independence.property.controller;
 
 import com.team.independence.common.response.ApiResponse;
-import com.team.independence.property.dto.PriceModelRequest;
-import com.team.independence.property.dto.PriceModelResponse;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
-import com.team.independence.property.service.PriceModelService;
 import com.team.independence.property.service.RentMedianService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class PropertyController {
 
     private final RentMedianService rentMedianService;
-    private final PriceModelService priceModelService;
 
     /**
      * 실거래 매물 중앙값 조회.
@@ -31,10 +27,5 @@ public class PropertyController {
     @GetMapping("/median")
     public ApiResponse<RentMedianResponse> getMedian(@Valid @ModelAttribute RentMedianRequest request) {
         return ApiResponse.ok(rentMedianService.getMedian(request));
-    }
-
-    @GetMapping("/price-model")
-    public ApiResponse<PriceModelResponse> getPriceModel(@Valid @ModelAttribute PriceModelRequest request) {
-        return ApiResponse.ok(priceModelService.estimate(request));
     }
 }

--- a/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
@@ -69,7 +69,7 @@ class GoalDetailServiceImplTest {
         // 그 외 의존성은 이 경로에서 쓰이지 않아 null로 둔다.
         service = new GoalDetailServiceImpl(
                 goalHousingMapper, savingRecordMapper, assetConnectionService, assetSummaryService,
-                new GoalServiceImpl(null, null, null, null, goalMapper, null, null));
+                new GoalServiceImpl(null, null, null, null, goalMapper, null, null, null));
     }
 
     // ------------------------------------------------------------------

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplMarketTrendTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplMarketTrendTest.java
@@ -56,7 +56,7 @@ class GoalServiceImplMarketTrendTest {
     void setUp() {
         service = new GoalServiceImpl(
                 regionQueryService, assetConnectionService, assetSummaryService, rentMedianService,
-                goalMapper, goalHousingMapper, goalMarketTrendCacheStore);
+                goalMapper, goalHousingMapper, goalMarketTrendCacheStore, null);
     }
 
     private Goal goal(long targetAmount, long targetRentMiddleAmount, long monthlySaving) {

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplSummaryTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplSummaryTest.java
@@ -47,7 +47,7 @@ class GoalServiceImplSummaryTest {
     void setUp() {
         service = new GoalServiceImpl(
                 regionQueryService, assetConnectionService, assetSummaryService, rentMedianService,
-                goalMapper, goalHousingMapper, goalMarketTrendCacheStore);
+                goalMapper, goalHousingMapper, goalMarketTrendCacheStore, null);
     }
 
     private Goal goal(long targetAmount, long monthlySaving) {

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplTest.java
@@ -25,7 +25,7 @@ class GoalServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        service = new GoalServiceImpl(null, null, null, null, null, null, null);
+        service = new GoalServiceImpl(null, null, null, null, null, null, null, null);
     }
 
     // ------------------------------------------------------------------

--- a/src/test/java/com/team/independence/goal/service/MonteCarloServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/MonteCarloServiceImplTest.java
@@ -8,6 +8,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
 import com.team.independence.asset.service.AssetConnectionService;
 import com.team.independence.asset.service.AssetSummaryService;
@@ -54,6 +56,7 @@ class MonteCarloServiceImplTest {
     @Mock private BudgetCalculator budgetCalculator;
     @Mock private PriceModelService priceModelService;
     @Mock private RegionQueryService regionQueryService;
+    @Mock private MonteCarloSimulationStore simulationStore;
 
     @InjectMocks private MonteCarloServiceImpl service;
 
@@ -86,6 +89,9 @@ class MonteCarloServiceImplTest {
                 .interestBearingAssets(50_000_000L)
                 .flatRecognizedAssets(20_000_000L)
                 .build();
+
+        // 기본적으로 캐시 미스로 처리: 실제 계산 경로를 검증한다
+        when(simulationStore.find(any())).thenReturn(Optional.empty());
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## #️⃣연관된 이슈

> #94 

## 📝작업 내용

### 배경

추천 알고리즘이 Monte Carlo 시뮬레이션을 사용하려면 `goalId` 없이 호출할 수 있어야 합니다. 기존 `MonteCarloService.simulate(memberId, goalId)`는 DB에서 저장된 목표를 조회하는 구조라 목표 저장 전 단계인 추천 흐름에서는 호출 자체가 불가능했습니다.

또한 GET `/{goalId}/simulation` 엔드포인트가 호출될 때마다 36개월치 실거래 데이터 조회와 OLS 회귀 분석이 반복되는 구조였습니다. 목표 조건이 바뀌지 않는 한 같은 결과를 반복 계산할 이유가 없으므로 캐싱으로 개선했습니다..

---

### 1. PriceModel 캡슐화 및 price-model 엔드포인트 제거

문제: 알고리즘이 Monte Carlo를 직접 쓰려면 `PriceModelService`(μ, σ 산출)와 `MonteCarloEngine`(시뮬레이션 실행) 두 곳에 의존해야 했습니다..

해결: `PriceModelService.estimate()` 호출을 `MonteCarloService` 내부로 이전하고, `goalId` 없이 주거 조건과 예산 파라미터를 직접 받는 오버로드를 추가했다.

```java
// 기존: 저장된 목표 조회용 (유지)
MonteCarloResponse simulate(Long memberId, Long goalId);

// 신규: 추천 알고리즘 내부용 (goalId 불필요)
MonteCarloEngine.Result simulate(PriceModelRequest housing, long initialPrice, long budgetAtT, int months);
```

알고리즘은 이제 `MonteCarloService` 하나에만 의존합니다. `initialPrice`와 `budgetAtT`는 알고리즘이 이미 갖고 있는 값(현재 시세 중앙값, BudgetCalculator 결과)이므로 추가 조회 없이 넘기면 됩니다.

`PriceModelService` 빈 자체는 유지했습니다. `PriceModelServiceImpl`이 `property` 도메인 Mapper(`RegionMapper`, `RentTransactionMapper`)를 직접 사용하므로, `goal` 도메인으로 로직을 이전하면 크로스 도메인 Mapper 직접 호출이 되어 레이어링 규칙 위반에 해당하기 때문입니다.

개발 테스트 용도로만 열어두었던 `GET /api/v1/properties/price-model` 엔드포인트는 제거했습니다.

---

### 2. 시뮬레이션 결과 Redis 캐싱

문제: GET `/{goalId}/simulation`이 호출될 때마다 매번 DB 조회와 회귀 분석이 실행됐습니다. 목표 조건(주거 조건, 목표 시점, 월 저축액)이 바뀌지 않는 한 결과는 동일합니다.

해결: `MonteCarloSimulationStore`를 신규 생성해 결과를 Redis에 캐싱했습니다.

```
Key: goal:simulation:{goalId}
TTL: 30일 (캐시 삭제 실패 시 stale 데이터가 무기한 남지 않도록 하는 안전장치)
```

```
GET /{goalId}/simulation 호출
  ├── 캐시 HIT  → 즉시 반환 (DB 조회 없음)
  └── 캐시 MISS → compute() 실행 → 결과 저장 → 반환

목표 수정(updateGoal) → 캐시 무효화 → 다음 호출 시 새 조건으로 재계산
목표 삭제(deleteGoal) → 캐시 삭제
```

순환 의존 방지: `GoalServiceImpl`에서 `MonteCarloService`를 직접 주입하면 `MonteCarloServiceImpl → GoalService → MonteCarloService`의 순환이 생깁니다. 이를 방지하기 위해 캐시 삭제만 담당하는 `MonteCarloSimulationStore`를 `GoalServiceImpl`에 주입하는 방식으로 분리했습니다.

소유권 확인(`findOwnedGoal`)은 캐시 조회 전에 수행해 다른 사용자의 `goalId`로 캐시를 읽는 상황을 차단합니다.

---

### 변경 파일 요약

| 파일 | 변경 내용 |
|---|---|
| `PropertyController` | `GET /api/v1/properties/price-model` 엔드포인트 및 `PriceModelService` 의존 제거 |
| `MonteCarloService` | 알고리즘용 `simulate(housing, initialPrice, budgetAtT, months)` 오버로드 추가 |
| `MonteCarloServiceImpl` | 신규 메서드 구현, 캐시 HIT/MISS 로직 추가, `compute()` 분리 |
| `MonteCarloSimulationStore` | Redis 캐시 스토어 신규 생성 |
| `GoalServiceImpl` | `updateGoal`, `deleteGoal` 시 시뮬레이션 캐시 무효화 |
| 테스트 5종 | `MonteCarloSimulationStore` 목 추가, `GoalServiceImpl` 생성자 인자 수 수정 |

## 💬리뷰 요구사항

- `MonteCarloSimulationStore`의 TTL을 30일로 설정했습니다. 명시적 삭제(`updateGoal`, `deleteGoal`)가 있으므로 TTL은 안전망 역할이지만, 더 적절한 기간이 있다면 의견 부탁드립니다.
- 소유권 확인을 캐시 조회 앞에 배치했습니다. 이 순서가 맞는지 확인 부탁드립니다.