### PR TITLE
fix: PriceModel Itô 이중 보정 버그 수정

### DIFF
--- a/src/main/java/com/team/independence/goal/service/MonteCarloEngine.java
+++ b/src/main/java/com/team/independence/goal/service/MonteCarloEngine.java
@@ -8,7 +8,7 @@ import java.util.Random;
  * 순수 계산 클래스 — Spring 의존성 없음
  *
  * GBM: P(T) = P(0) × exp((μ − σ²/2) × T + σ × √T × Z), Z ~ N(0,1)
- * Itô 보정 (μ − σ²/2)은 필수. 빠뜨리면 기댓값이 P(0)×exp(μT)가 아닌 P(0)×exp((μ−σ²/2)T)가 된다.
+ * Itô 보정 (μ − σ²/2)은 필수. 빠뜨리면 기댓값이 P(0)×exp(μT)가 아닌 P(0)×exp((μ+σ²/2)T)로 과대평가된다.
  */
 public class MonteCarloEngine {
 

--- a/src/main/java/com/team/independence/property/service/PriceModel.java
+++ b/src/main/java/com/team/independence/property/service/PriceModel.java
@@ -9,8 +9,11 @@ import java.util.List;
  * 엔드포인트 노이즈에 강하고, μ와 σ를 같은 시계열에서 한 번의 순회로 뽑으므로
  * 몬테카를로가 이 결과를 그대로 입력으로 쓸 수 있다.
  *
- * @param annualDrift 연간 연속 성장률(μ): 몬테카를로 drift 입력값
- * @param cagr 표시용 연 상승률: Math.exp(annualDrift) - 1
+ * @param annualDrift 연간 산술 드리프트(μ): 몬테카를로 drift 입력값.
+ *                    OLS 회귀 기울기는 로그드리프트(μ − σ²/2)이므로, σ²/2를 더해 μ로 복원한다.
+ *                    MonteCarloEngine이 내부에서 Itô 보정(−σ²/2)을 직접 적용하므로
+ *                    이 필드는 반드시 산술 드리프트 μ여야 한다.
+ * @param cagr 표시용 연 상승률(중앙 경로 기준): Math.exp(logDrift) - 1
  * @param annualVol 연율 변동성(σ): 몬테카를로 volatility 입력값
  * @param months 회귀에 사용된 유효 표본 월 수
  */
@@ -22,7 +25,7 @@ public record PriceModel(double annualDrift, double cagr, double annualVol, int 
     public static PriceModel estimate(List<Double> pricePerPyeong) {
         int n = pricePerPyeong.size();
 
-        // ln(price) ~ t 최소제곱 회귀 → 월간 연속성장률(기울기)
+        // ln(price) ~ t 최소제곱 회귀 → 월간 로그드리프트(기울기) = (μ − σ²/2) / 12
         double sx = 0, sy = 0, sxx = 0, sxy = 0;
         for (int t = 0; t < n; t++) {
             double y = Math.log(pricePerPyeong.get(t));
@@ -32,8 +35,8 @@ public record PriceModel(double annualDrift, double cagr, double annualVol, int 
             sxy += t * y;
         }
         double slope = (n * sxy - sx * sy) / (n * sxx - sx * sx);
-        double annualDrift = slope * 12;
-        double cagr = Math.exp(annualDrift) - 1;
+        double logDrift = slope * 12;  // 연간 로그드리프트 = (μ − σ²/2)
+        double cagr = Math.exp(logDrift) - 1;  // 중앙 경로 기준 연 상승률
 
         // 월별 로그수익률 표준편차 → 연율 변동성 σ
         int k = n - 1;
@@ -48,6 +51,11 @@ public record PriceModel(double annualDrift, double cagr, double annualVol, int 
         for (double x : r) var += (x - mean) * (x - mean);
         var /= (k - 1);
         double annualVol = Math.sqrt(var) * Math.sqrt(12);
+
+        // 산술 드리프트 μ = logDrift + σ²/2
+        // MonteCarloEngine이 (annualDrift − σ²/2) × T를 exponent로 쓰므로
+        // annualDrift는 반드시 μ(산술)여야 Itô 보정이 정확히 한 번만 적용된다.
+        double annualDrift = logDrift + 0.5 * annualVol * annualVol;
 
         return new PriceModel(annualDrift, cagr, annualVol, n);
     }

--- a/src/test/java/com/team/independence/goal/service/MonteCarloItoCorrectionTest.java
+++ b/src/test/java/com/team/independence/goal/service/MonteCarloItoCorrectionTest.java
@@ -1,0 +1,59 @@
+package com.team.independence.goal.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * MonteCarloEngine Itô 보정 회귀 테스트
+ *
+ * PriceModel.annualDrift는 산술 드리프트 μ(= logDrift + σ²/2)를 저장한다.
+ * MonteCarloEngine은 이 값을 받아 내부에서 Itô 보정(−σ²/2)을 적용하므로
+ * exponent = logDrift × T가 되어 GBM 중앙값과 정확히 일치해야 한다.
+ *
+ * 이중 보정 버그(annualDrift = logDrift였을 때 priceP50이 ~5.8% 낮았던 문제)가
+ * 재발하지 않도록 두 케이스를 모두 고정한다.
+ */
+class MonteCarloItoCorrectionTest {
+
+    private static final double MU = 0.08;
+    private static final double SIGMA = 0.20;
+    private static final double LOG_DRIFT = MU - 0.5 * SIGMA * SIGMA;  // = 0.06
+
+    private static final long INITIAL_PRICE = 100_000_000L;
+    private static final int FORECAST_MONTHS = 36;
+    private static final double T = FORECAST_MONTHS / 12.0;
+
+    private static final long THEORETICAL_MEDIAN =
+            Math.round(INITIAL_PRICE * Math.exp(LOG_DRIFT * T));
+
+    @Test
+    @DisplayName("산술 드리프트 μ를 전달하면 priceP50이 GBM 중앙값과 2% 이내로 일치한다")
+    void arithmeticDrift_matchesTheoreticalMedian() {
+        MonteCarloEngine.Result result = MonteCarloEngine.simulate(
+                MU, SIGMA, INITIAL_PRICE, Long.MAX_VALUE,
+                FORECAST_MONTHS, 100_000, 42L);
+
+        assertEquals(THEORETICAL_MEDIAN, result.priceP50(), THEORETICAL_MEDIAN * 0.02,
+                String.format("p50(%,d)이 GBM 중앙값(%,d)과 2%% 이상 차이남",
+                        result.priceP50(), THEORETICAL_MEDIAN));
+    }
+
+    @Test
+    @DisplayName("로그드리프트를 μ 자리에 넣으면 priceP50이 이론치보다 낮게 편향된다 — 이 동작이 사라지면 버그 재발")
+    void logDrift_as_mu_underestimates_by_half_sigma_squared() {
+        // Itô 이중 보정 시 exponent = (logDrift − σ²/2) × T
+        long biasedMedian = Math.round(INITIAL_PRICE * Math.exp((LOG_DRIFT - 0.5 * SIGMA * SIGMA) * T));
+
+        MonteCarloEngine.Result result = MonteCarloEngine.simulate(
+                LOG_DRIFT, SIGMA, INITIAL_PRICE, Long.MAX_VALUE,
+                FORECAST_MONTHS, 100_000, 42L);
+
+        assertTrue(result.priceP50() < THEORETICAL_MEDIAN,
+                "logDrift를 μ 자리에 넣으면 p50이 이론치보다 낮아야 한다");
+        assertEquals(biasedMedian, result.priceP50(), biasedMedian * 0.03,
+                String.format("p50(%,d)이 이중 보정 기댓값(%,d)과 다르다", result.priceP50(), biasedMedian));
+    }
+}

--- a/src/test/java/com/team/independence/property/service/PriceModelTest.java
+++ b/src/test/java/com/team/independence/property/service/PriceModelTest.java
@@ -55,13 +55,14 @@ class  PriceModelTest {
     }
 
     @Test
-    @DisplayName("연 5% 성장 시계열의 annualDrift → ln(1.05) ≈ 0.0488")
-    void annualDrift_연속복리_검증() {
+    @DisplayName("노이즈 없는 시계열의 annualDrift → σ≈0이므로 μ ≈ logDrift ≈ ln(1.05)")
+    void annualDrift_노이즈없는시계열_검증() {
         double annualRate = 0.05;
         List<Double> series = growingSeries(1_000_000, annualRate, 36);
 
         PriceModel model = PriceModel.estimate(series);
 
+        // 노이즈가 없으면 σ≈0 이므로 annualDrift(=μ) ≈ logDrift = ln(1+rate)
         double expectedDrift = Math.log(1 + annualRate);
         assertEquals(expectedDrift, model.annualDrift(), TOLERANCE);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #100 

## 📝 작업 내용

`PriceModel.estimate()`는 `ln(price) ~ t` OLS 회귀 기울기로 연간 드리프트를 추정합니다. GBM 이론에 의해 이 기울기는 로그드리프트 `(μ − σ²/2)`입니다.

그러나 `annualDrift` 필드에 이 값을 그대로 저장하면서 Javadoc에는 `μ`(산술 드리프트)라고 기술했고, `MonteCarloEngine`은 Javadoc 계약을 믿고 내부에서 다시 `σ²/2`를 빼므로 이중 보정이 발생했습니다.

```
실제 `exponent` = `(logDrift − σ²/2) × T` = `(μ − σ²) × T`
올바른 값 = `logDrift × T` = `(μ − σ²/2) × T`
```

σ=0.20, T=3년 기준으로 priceP50이 이론치보다 **약 5.8% 낮게** 편향되어 미래 주택 가격이 과소 추정되고 성공 확률이 실제보다 낙관적으로 나왔습니다.

## 변경 내용

- `PriceModel.java`: `annualDrift = logDrift + σ²/2`로 수정해 산술 드리프트 μ를 저장

  - `annualVol` 계산 순서를 `annualDrift` 앞으로 이동 (σ²/2 복원에 필요)
  - `cagr = Math.exp(logDrift) - 1` 유지 (중앙 경로 기준이므로 로그드리프트 사용)
  - Javadoc에 변환 이유 명시
- `MonteCarloEngine.java`: 클래스 Javadoc 부호 오류 수정
  - `빠뜨리면 기댓값이 exp((μ−σ²/2)T)가 된다` → `exp((μ+σ²/2)T)로 과대평가된다`
- `MonteCarloItoCorrectionTest.java`: 회귀 테스트 신규 추가
  - 산술 드리프트 μ 전달 시 priceP50 ≈ GBM 이론 중앙값(±2%) 검증
  - 로그드리프트를 μ 자리에 넣으면 낮게 편향되는 동작을 고정해 버그 재발 감지
- `PriceModelTest.java`: `annualDrift` 검증 테스트 설명에 σ≈0 조건 명시

## 테스트 결과

```
priceP50 (수정 전): 112,825,753 원  → 이론치 대비 −5.76%
priceP50 (수정 후): 119,802,508 원  → 이론치 대비 +0.07% 
```

## Test plan

- [x] `MonteCarloItoCorrectionTest`: 수정 후 p50이 이론치와 2% 이내 일치
- [x] `PriceModelTest`: 기존 7개 테스트 전체 통과
- [x] `MonteCarloServiceImplTest`: 5개 테스트 전체 통과