### PR TITLE
fix: 배치 수동 트리거 경로 인증 인터셉터 제외 추가

### DIFF
--- a/src/main/java/com/team/independence/config/WebConfig.java
+++ b/src/main/java/com/team/independence/config/WebConfig.java
@@ -53,7 +53,8 @@ public class WebConfig implements WebMvcConfigurer {
                 .excludePathPatterns(
                         "/api/v1/oauth/**",
                         "/api/v1/auth/refresh",
-                        "/api/v1/members/health"
+                        "/api/v1/members/health",
+                        "/api/v1/admin/batch/**"
                 );
     }
 


### PR DESCRIPTION
## Summary

- `WebConfig.excludePathPatterns`에 `/api/v1/admin/batch/**` 누락으로 인증 인터셉터에 막혀 배치 수동 트리거 호출 불가
- exclude 목록에 해당 경로 추가

## Test plan

- [x] `POST /api/v1/admin/batch/all` 인증 없이 호출 시 200 응답 확인