### PR TITLE
feat(goal): 목표 추천 응답 구조 API 명세 반영

### DIFF
--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
@@ -11,23 +11,58 @@ import lombok.Getter;
 @Builder
 public class GoalRecommendationResponse {
 
+    /** 사용자가 요청한 원래 희망 조건 — 세 추천 카드와 비교 기준으로 사용 */
+    private OriginalPreference originalPreference;
+
+    /** 세 추천에 공통으로 사용된 재무 계산 기준 */
+    private FinancialContext financialContext;
+
     private List<RecommendationItem> recommendations;
+
+    @Getter
+    @Builder
+    public static class OriginalPreference {
+        private OriginalCondition condition;
+        private YearMonth targetDate;
+        private long monthlySaving;
+    }
+
+    /** 사용자가 입력한 원래 조건을 그대로 담는 객체 — Condition과 구분 */
+    @Getter
+    @Builder
+    public static class OriginalCondition {
+        private String regionCode;
+        private String regionName;
+        private HousingType housingType;
+        private DealType dealType;
+        private Integer areaMin;
+        private Integer areaMax;
+        private Long depositMin;
+        private Long depositMax;
+        private Long monthlyRentMin;
+        private Long monthlyRentMax;
+    }
+
+    @Getter
+    @Builder
+    public static class FinancialContext {
+        /** 현재 주거 목표 계산에 활용 가능한 자산(원) */
+        private long currentAvailableAmount;
+    }
 
     @Getter
     @Builder
     public static class RecommendationItem {
         /** 이 대안을 만든 추천 알고리즘 */
         private AlgorithmType type;
-        /**
-         * 이 카드가 실현 가능한지 여부.
-         * false면 예산·조건 부족으로 후보를 찾지 못한 것으로, title/reason만 채워지고
-         * condition·loanX·loanO는 null이다. 프론트엔드는 이 필드를 보고 카드를 비활성 스타일로 표시한다.
-         */
-        @Builder.Default
-        private boolean feasible = true;
         private String title;
         private String reason;
+        /**
+         * 추천 주거 조건. 후보를 찾지 못한 경우 null.
+         * 프론트엔드는 이 필드가 null인지 확인해 카드를 비활성 스타일로 표시한다.
+         */
         private Condition condition;
+        private CalculationBasis calculationBasis;
         /** 대출 없는 플랜 */
         private LoanXPlan loanX;
         /** 대출 있는 플랜 */
@@ -57,10 +92,24 @@ public class GoalRecommendationResponse {
          * 이 조건의 대표값을 뽑는 데 쓰인 실거래 건수.
          *
          * <p>거래가 드문 조건에서는 한두 건으로 계산된 값일 수 있어, 숫자를 얼마나 믿을지
-         * 화면에서 판단할 수 있도록 함께 내려준다. 지역을 시도로 받으면 그 시도의 시군구
-         * 거래를 모두 합치므로 건수가 크게 늘어난다.
+         * 화면에서 판단할 수 있도록 함께 내려준다.
          */
         private int sampleCount;
+
+        /** 이 추천 조건의 실거래 중앙값(원). 플랜 계산의 기준이 된 시세. */
+        private long marketMedianAmount;
+    }
+
+    @Getter
+    @Builder
+    public static class CalculationBasis {
+        /**
+         * 사용자가 설정한 목표 시점까지 준비 가능한 총 금액(원).
+         *
+         * <p>REALISTIC 타입만 값을 가진다. "이 금액에 맞는 조건을 찾았다"는 설명에 사용.
+         * PREFERENCE · HOLD_OUT은 이 방식으로 조건을 찾지 않으므로 null.
+         */
+        private Long reachableAmountAtTargetDate;
     }
 
     @Getter

--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
@@ -1,10 +1,13 @@
 package com.team.independence.goal.service;
 
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
 import com.team.independence.asset.service.AssetConnectionService;
+import com.team.independence.asset.service.AssetSummaryService;
 import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
+import com.team.independence.property.mapper.RegionMapper;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -29,6 +32,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class GoalRecommendationServiceImpl implements GoalRecommendationService {
 
     private final AssetConnectionService assetConnectionService;
+    private final AssetSummaryService assetSummaryService;
+    private final RegionMapper regionMapper;
     private final ObjectProvider<RecommendationAlgorithm> algorithmProvider;
 
     @Override
@@ -44,6 +49,11 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
             log.warn("등록된 추천 알고리즘이 없습니다. RecommendationAlgorithm 구현체를 추가해야 합니다.");
         }
 
+        AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
+        long monthlySaving = assetSummaryService.getMonthlySavingsOrZero(memberId);
+        long currentAvailableAmount = netWorth.getInterestBearingAssets()
+                + netWorth.getFlatRecognizedAssets();
+
         // 대안을 내지 못한 알고리즘은 제외하므로 결과 수가 알고리즘 수보다 적을 수 있다
         List<GoalRecommendationResponse.RecommendationItem> recommendations = algorithms.stream()
                 .map(algorithm -> runSafely(algorithm, memberId, request))
@@ -56,7 +66,40 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
         }
 
         return GoalRecommendationResponse.builder()
+                .originalPreference(buildOriginalPreference(request, monthlySaving))
+                .financialContext(GoalRecommendationResponse.FinancialContext.builder()
+                        .currentAvailableAmount(currentAvailableAmount)
+                        .build())
                 .recommendations(recommendations)
+                .build();
+    }
+
+    private GoalRecommendationResponse.OriginalPreference buildOriginalPreference(
+            GoalRecommendationRequest request, long monthlySaving) {
+
+        String regionCode = request.getRegionCode();
+        String regionName = regionCode.length() == 2
+                ? regionMapper.findSidoNameByPrefix(regionCode)
+                : regionMapper.findFullNameByCode(regionCode);
+
+        GoalRecommendationResponse.OriginalCondition condition =
+                GoalRecommendationResponse.OriginalCondition.builder()
+                        .regionCode(regionCode)
+                        .regionName(regionName)
+                        .housingType(request.getPropertyType())
+                        .dealType(request.getTradeType())
+                        .areaMin(request.getSizeMin())
+                        .areaMax(request.getSizeMax())
+                        .depositMin(request.getDepositMin())
+                        .depositMax(request.getDepositMax())
+                        .monthlyRentMin(request.getMonthlyRentMin())
+                        .monthlyRentMax(request.getMonthlyRentMax())
+                        .build();
+
+        return GoalRecommendationResponse.OriginalPreference.builder()
+                .condition(condition)
+                .targetDate(request.getTargetDate())
+                .monthlySaving(monthlySaving)
                 .build();
     }
 

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -129,7 +129,6 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
             log.info("[HoldOut] 적합한 후보 없음 — soft-fail 반환 memberId={} regionCode={}", memberId, base.regionCode);
             return Optional.of(GoalRecommendationResponse.RecommendationItem.builder()
                     .type(AlgorithmType.HOLD_OUT)
-                    .feasible(false)
                     .title(buildInfeasibleTitle(base))
                     .reason(buildInfeasibleReason(base, n))
                     .build());
@@ -165,6 +164,10 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
                                 && best.median.getMonthlyRent().getQ3() != null
                                 ? best.median.getMonthlyRent().getQ3() : 0L)
                         .sampleCount(best.median.getSampleCount())
+                        .marketMedianAmount(best.futurePrice)
+                        .build())
+                .calculationBasis(GoalRecommendationResponse.CalculationBasis.builder()
+                        .reachableAmountAtTargetDate(null)
                         .build())
                 .loanX(plans.getLoanX())
                 .loanO(loanO)

--- a/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
@@ -162,6 +162,7 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
                 .areaMax(areaMax)
                 .monthlyRent(monthlyRent)
                 .sampleCount(median.getSampleCount())
+                .marketMedianAmount(projectedDeposit)
                 .build();
 
         return Optional.of(GoalRecommendationResponse.RecommendationItem.builder()
@@ -171,6 +172,9 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
                         median.getSampleCount(), median.getRegionName(), RecommendationAlgorithm.label(housingType),
                         areaMin, areaMax, RecommendationAlgorithm.label(dealType)))
                 .condition(condition)
+                .calculationBasis(GoalRecommendationResponse.CalculationBasis.builder()
+                        .reachableAmountAtTargetDate(null)
+                        .build())
                 .loanX(plans.getLoanX())
                 .loanO(loanO)
                 .build());

--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -434,6 +434,9 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
             loanO = loanO.toBuilder().shortenedMonths(shortened).build();
         }
 
+        long reachableAmountAtTargetDate =
+                budgetCalculator.calculate(search.netWorth, search.effectiveSaving, desiredMonths);
+
         GoalRecommendationResponse.Condition condition = GoalRecommendationResponse.Condition.builder()
                 .regionCode(chosen.regionCode())
                 .regionName(chosen.regionName())
@@ -443,6 +446,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
                 .areaMax(chosen.areaMax())
                 .monthlyRent(chosen.monthlyRent())
                 .sampleCount(chosen.sampleCount())
+                .marketMedianAmount(chosen.deposit())
                 .build();
 
         return GoalRecommendationResponse.RecommendationItem.builder()
@@ -450,6 +454,9 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
                 .title(buildTitle(chosen, desiredMonths))
                 .reason(buildReason(chosen, desiredMonths, adjusted))
                 .condition(condition)
+                .calculationBasis(GoalRecommendationResponse.CalculationBasis.builder()
+                        .reachableAmountAtTargetDate(reachableAmountAtTargetDate)
+                        .build())
                 .loanX(plans.getLoanX())
                 .loanO(loanO)
                 .build();

--- a/src/test/java/com/team/independence/goal/service/GoalRecommendationServiceIntegrationTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalRecommendationServiceIntegrationTest.java
@@ -104,7 +104,7 @@ class GoalRecommendationServiceIntegrationTest {
         print("오피스텔 월세 / member=" + MEMBER_NO_LOAN, response);
         assertThat(response.getRecommendations()).isNotEmpty();
         response.getRecommendations().stream()
-                .filter(item -> item.isFeasible())
+                .filter(item -> item.getCondition() != null)
                 .forEach(item -> {
                     if (item.getCondition().getDealType() == DealType.WOLSE) {
                         assertThat(item.getCondition().getMonthlyRent()).isPositive();
@@ -128,7 +128,7 @@ class GoalRecommendationServiceIntegrationTest {
         assertThat(response.getRecommendations()).isNotEmpty();
         // 결과 지역이 서울(11xxx) 안에 있어야 한다 (feasible=false 카드는 condition=null이므로 제외)
         response.getRecommendations().stream()
-                .filter(item -> item.isFeasible())
+                .filter(item -> item.getCondition() != null)
                 .forEach(item ->
                         assertThat(item.getCondition().getRegionCode()).startsWith("11"));
     }

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
@@ -129,7 +129,7 @@ class HoldOutAlgorithmTest {
         Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"));
 
         assertThat(result).isPresent();
-        assertThat(result.get().isFeasible()).isFalse();
+        assertThat(result.get().getCondition()).isNull();
     }
 
     @Test
@@ -152,7 +152,7 @@ class HoldOutAlgorithmTest {
         Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request);
 
         assertThat(result).isPresent();
-        assertThat(result.get().isFeasible()).isFalse();
+        assertThat(result.get().getCondition()).isNull();
     }
 
     @Test
@@ -165,7 +165,7 @@ class HoldOutAlgorithmTest {
         Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"));
 
         assertThat(result).isPresent();
-        assertThat(result.get().isFeasible()).isFalse();
+        assertThat(result.get().getCondition()).isNull();
     }
 
     @Test
@@ -174,7 +174,7 @@ class HoldOutAlgorithmTest {
         Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"));
 
         assertThat(result).isPresent();
-        assertThat(result.get().isFeasible()).isFalse();
+        assertThat(result.get().getCondition()).isNull();
     }
 
     // ===== 평수 업그레이드 필터 =====
@@ -189,7 +189,7 @@ class HoldOutAlgorithmTest {
         Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"));
 
         assertThat(result).isPresent();
-        assertThat(result.get().isFeasible()).isFalse();
+        assertThat(result.get().getCondition()).isNull();
     }
 
     @Test
@@ -267,7 +267,7 @@ class HoldOutAlgorithmTest {
         Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request);
 
         assertThat(result).isPresent();
-        assertThat(result.get().isFeasible()).isFalse();
+        assertThat(result.get().getCondition()).isNull();
     }
 
     // ===== 메시지 =====


### PR DESCRIPTION
## #️⃣연관된 이슈

- #110

## 📝작업 내용

`POST /api/v1/goals/recommendations` 응답 구조를 프론트엔드 협의 API 명세에 맞게 확장했습니다.

### 변경 배경

기존 응답은 `recommendations` 배열만 반환했으나, 명세에서는 세 카드의 비교 기준이 되는 **원래 희망 조건**과 **재무 계산 기준**을 최상위에 요구합니다. 또한 각 카드에 실거래 중앙값과 계산 근거가 빠져 있어 프론트에서 "왜 이 금액인지"를 설명할 수 없는 상태였습니다.

### 주요 변경 사항

**`GoalRecommendationResponse` DTO 구조 변경**
- `originalPreference` 추가 — 사용자가 입력한 원래 희망 조건(지역·주택유형·거래유형·평수·보증금·월세·목표시점)과 월저축액을 담음. 세 추천 카드와의 비교 기준값으로 사용
- `financialContext` 추가 — 세 추천에 공통으로 사용된 현재 활용 가능 자산(`currentAvailableAmount`)
- `RecommendationItem.feasible` 제거 → **`condition = null`로 후보 없음 표현**. 프론트는 `condition !== null`로 카드 활성/비활성을 판단
- `Condition.marketMedianAmount` 추가 — 해당 추천 조건의 실거래 중앙값(원). 플랜 계산의 기준이 된 시세
- `RecommendationItem.calculationBasis` 추가 — `reachableAmountAtTargetDate`(목표 시점까지 준비 가능한 금액). REALISTIC 타입만 값을 가지며, 나머지는 null

**서비스 / 알고리즘 변경**
- `GoalRecommendationServiceImpl` — `AssetSummaryService`, `RegionMapper` 의존성 추가. 알고리즘 실행 전 `originalPreference` · `financialContext` 조립
- `HoldOutAlgorithm` — soft-fail 카드에서 `feasible(false)` 제거. 정상 반환에 `marketMedianAmount`, `calculationBasis` 추가
- `PreferenceAlgorithm` — `Condition`에 `marketMedianAmount`(MC 투영 후 보증금), `calculationBasis(null)` 추가
- `RealisticAlgorithm` — `Condition`에 `marketMedianAmount`(선택된 후보의 보증금), `calculationBasis.reachableAmountAtTargetDate`(목표 시점 예산 계산값) 추가

**테스트**
- `HoldOutAlgorithmTest`, `GoalRecommendationServiceIntegrationTest`에서 `isFeasible()` → `getCondition() != null`로 대체

## 💬리뷰 요구사항(선택)