### PR TITLE
fix: 목표 추천 API를 명세대로 GET + Query Parameter로 전환

### DIFF
--- a/src/main/java/com/team/independence/goal/controller/GoalRecommendationController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalRecommendationController.java
@@ -7,8 +7,8 @@ import com.team.independence.goal.dto.GoalRecommendationResponse;
 import com.team.independence.goal.service.GoalRecommendationService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,10 +19,10 @@ public class GoalRecommendationController {
 
     private final GoalRecommendationService recommendationService;
 
-    @PostMapping("/recommendations")
+    @GetMapping("/recommendations")
     public ApiResponse<GoalRecommendationResponse> recommend(
             @LoginMember Long memberId,
-            @Valid @RequestBody GoalRecommendationRequest request) {
+            @Valid @ModelAttribute GoalRecommendationRequest request) {
         return ApiResponse.ok(recommendationService.recommend(memberId, request));
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #113

close #113

## 📝 작업 내용

### 이 기능이 하는 말

목표 추천 API(`/goals/recommendations`) 명세는 GET + Query Parameter인데, 구현은 `POST` + `@RequestBody`로 남아 있었습니다. 프론트가 명세대로 GET을 보내면 이 컨트롤러가 매칭되지 않고, 같은 `/goals` prefix를 쓰는 `GoalController`의 `GET /{goalId}`로 라우팅이 넘어가면서 `"recommendations"` 문자열이 `goalId`(Long)에 바인딩되어 400이 났습니다. 이번 PR은 컨트롤러를 GET + `@ModelAttribute`로 바꿔 명세와 실제 라우팅을 맞춥니다.

---

## 구현 내용

`GoalRecommendationController`(`src/main/java/com/team/independence/goal/controller/GoalRecommendationController.java`) 한 곳만 수정했습니다. 새로 만든 것은 없고 기존 `GoalRecommendationRequest`, `GoalRecommendationService`를 그대로 재사용합니다.

```
@PostMapping("/recommendations") + @RequestBody
        ↓
@GetMapping("/recommendations") + @ModelAttribute
```

`GoalRecommendationRequest`는 원래 `@Valid` 대상 DTO였고, `@ModelAttribute`로 바꿔도 `@Valid`는 그대로 동작합니다(스프링이 바인딩 후 검증을 수행하는 지점이 `@RequestBody`든 `@ModelAttribute`든 동일).

