### PR TITLE
fix: Redis SET NX 원자적 Job 획득으로 자산 동기화 중복 요청 방지

### DIFF
--- a/src/main/java/com/team/independence/asset/service/AssetSyncJobRunner.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncJobRunner.java
@@ -23,6 +23,8 @@ public class AssetSyncJobRunner {
         } catch (Exception e) {
             log.error("[비동기 동기화] 실패: memberId={}, jobId={}", memberId, jobId, e);
             jobStore.markFailed(jobId, e.getMessage());
+        } finally {
+            jobStore.clearActiveJob(memberId);
         }
     }
 }

--- a/src/main/java/com/team/independence/asset/service/AssetSyncJobStarter.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncJobStarter.java
@@ -12,7 +12,10 @@ public class AssetSyncJobStarter {
     private final AssetSyncJobRunner jobRunner;
 
     public SyncJobResponse start(Long memberId) {
-        String jobId = jobStore.createJob();
+        String jobId = jobStore.tryAcquireNewJob(memberId);
+        if (jobId == null) {
+            return SyncJobResponse.builder().jobId(jobStore.getActiveJobId(memberId)).build();
+        }
         jobRunner.runAsync(memberId, jobId);
         return SyncJobResponse.builder().jobId(jobId).build();
     }

--- a/src/main/java/com/team/independence/asset/service/AssetSyncJobStarter.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncJobStarter.java
@@ -13,10 +13,20 @@ public class AssetSyncJobStarter {
 
     public SyncJobResponse start(Long memberId) {
         String jobId = jobStore.tryAcquireNewJob(memberId);
-        if (jobId == null) {
-            return SyncJobResponse.builder().jobId(jobStore.getActiveJobId(memberId)).build();
+        if (jobId != null) {
+            jobRunner.runAsync(memberId, jobId);
+            return SyncJobResponse.builder().jobId(jobId).build();
         }
-        jobRunner.runAsync(memberId, jobId);
-        return SyncJobResponse.builder().jobId(jobId).build();
+        String activeJobId = jobStore.getActiveJobId(memberId);
+        if (activeJobId != null) {
+            return SyncJobResponse.builder().jobId(activeJobId).build();
+        }
+        // tryAcquireNewJob 실패와 getActiveJobId 호출 사이에 잡이 완료된 경우: 새 잡으로 재시도
+        jobId = jobStore.tryAcquireNewJob(memberId);
+        if (jobId != null) {
+            jobRunner.runAsync(memberId, jobId);
+        }
+        return SyncJobResponse.builder().jobId(
+                jobId != null ? jobId : jobStore.getActiveJobId(memberId)).build();
     }
 }

--- a/src/main/java/com/team/independence/asset/service/AssetSyncJobStore.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncJobStore.java
@@ -11,16 +11,26 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class AssetSyncJobStore {
 
+    public static final String STATUS_PENDING = "PENDING";
+    public static final String STATUS_SUCCESS = "SUCCESS";
+    public static final String STATUS_FAILED = "FAILED";
+
     private static final String KEY_STATUS = "asset:sync:job:%s:status";
     private static final String KEY_ERROR = "asset:sync:job:%s:error";
     private static final String KEY_RESULT = "asset:sync:job:%s:result";
+    private static final String KEY_ACTIVE_JOB = "asset:sync:member:%d:activeJob";
     private static final long TTL_MINUTES = 10;
 
     private final StringRedisTemplate redisTemplate;
 
-    public String createJob() {
+    public String tryAcquireNewJob(Long memberId) {
         String jobId = UUID.randomUUID().toString();
-        redisTemplate.opsForValue().set(statusKey(jobId), "PENDING", TTL_MINUTES, TimeUnit.MINUTES);
+        Boolean acquired = redisTemplate.opsForValue().setIfAbsent(
+                String.format(KEY_ACTIVE_JOB, memberId), jobId, TTL_MINUTES, TimeUnit.MINUTES);
+        if (!Boolean.TRUE.equals(acquired)) {
+            return null;
+        }
+        redisTemplate.opsForValue().set(statusKey(jobId), STATUS_PENDING, TTL_MINUTES, TimeUnit.MINUTES);
         return jobId;
     }
 
@@ -33,7 +43,7 @@ public class AssetSyncJobStore {
     }
 
     public void markSuccess(String jobId, String resultUrl) {
-        redisTemplate.opsForValue().set(statusKey(jobId), "SUCCESS", TTL_MINUTES, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set(statusKey(jobId), STATUS_SUCCESS, TTL_MINUTES, TimeUnit.MINUTES);
         redisTemplate.opsForValue().set(resultKey(jobId), resultUrl, TTL_MINUTES, TimeUnit.MINUTES);
     }
 
@@ -42,11 +52,19 @@ public class AssetSyncJobStore {
     }
 
     public void markFailed(String jobId, String errorMessage) {
-        redisTemplate.opsForValue().set(statusKey(jobId), "FAILED", TTL_MINUTES, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set(statusKey(jobId), STATUS_FAILED, TTL_MINUTES, TimeUnit.MINUTES);
         redisTemplate.opsForValue().set(
                 errorKey(jobId),
                 errorMessage != null ? errorMessage : "알 수 없는 오류",
                 TTL_MINUTES, TimeUnit.MINUTES);
+    }
+
+    public String getActiveJobId(Long memberId) {
+        return redisTemplate.opsForValue().get(String.format(KEY_ACTIVE_JOB, memberId));
+    }
+
+    public void clearActiveJob(Long memberId) {
+        redisTemplate.delete(String.format(KEY_ACTIVE_JOB, memberId));
     }
 
     private String statusKey(String jobId) {

--- a/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
+++ b/src/main/java/com/team/independence/asset/service/AssetSyncServiceImpl.java
@@ -89,8 +89,8 @@ public class AssetSyncServiceImpl implements AssetSyncService {
         return SyncJobStatusResponse.builder()
                 .jobId(jobId)
                 .status(status)
-                .errorMessage("FAILED".equals(status) ? jobStore.getError(jobId) : null)
-                .resultUrl("SUCCESS".equals(status) ? jobStore.getResultUrl(jobId) : null)
+                .errorMessage(AssetSyncJobStore.STATUS_FAILED.equals(status) ? jobStore.getError(jobId) : null)
+                .resultUrl(AssetSyncJobStore.STATUS_SUCCESS.equals(status) ? jobStore.getResultUrl(jobId) : null)
                 .build();
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#112

## 📝작업 내용

### 문제: 동시 요청 시 동기화가 여러 개 실행된다

POST `/api/v1/assets/sync`를 짧은 시간 안에 여러 번 호출하면, 요청마다 새로운 jobId가 발급되어 `syncAccounts()`가 동시에 여러 개 실행됩니다.

아래는 5개 요청을 동시에 보낸 결과입니다.

```bash
# 수정 전
[1] jobId: e366e5ba-3048-45a7-be99-107659c01608
[2] jobId: 1dbce485-89a7-436b-82fd-3dbc87e9f605
[3] jobId: 8940e914-bdc6-46f3-ac03-c9686e650e03
[4] jobId: 9ac828f0-2fa7-4720-bcbb-00220593de17
[5] jobId: a78b9983-5dd9-4e05-951a-253f8eac988e
```

`syncAccounts()`는 각 기관 계좌를 `DELETE → INSERT` 순서로 교체하기 때문에,
동일한 회원에 대해 이 작업이 동시에 여러 개 돌면 트랜잭션 간 충돌로 계좌 데이터가 중복되거나 유실될 수 있습니다.

---

### 원인 1: 체크와 등록이 분리된 두 번의 연산 (TOCTOU)

기존 코드는 아래 두 단계로 중복을 막으려 했습니다.

```java
// AS-IS
String activeJobId = jobStore.getActiveJobId(memberId);  // ① 현재 활성 잡 조회
if (activeJobId != null && "PENDING".equals(...)) {
    return 기존_jobId;                                    // ② 있으면 반환
}
String jobId = jobStore.createJob();                      // ③ 없으면 새 잡 생성
jobStore.registerActiveJob(memberId, jobId);              // ④ 활성 잡으로 등록
```

문제는 ①과 ③ 사이에 시간 간격이 존재한다는 점입니다. 5개 요청이 동시에 들어오면, 모두 ①에서 "활성 잡 없음"을 확인하고 ③으로 넘어가 버립니다.

```
요청1 ── ① 조회: null ─────────────────── ③ 새 잡 생성 → ④ 등록
요청2 ── ① 조회: null ─────────────────── ③ 새 잡 생성 → ④ 등록
요청3 ── ① 조회: null ─────────────────── ③ 새 잡 생성 → ④ 등록
```

이처럼 "조회 시점"과 "등록 시점" 사이의 틈을 TOCTOU(Time of Check to Time of Use) 문제라고 합니다.
  
---
### 원인 2: 활성 잡 조회 사이에 동기화가 완료되는 케이스
  
1차 수정에서 `tryAcquireNewJob` 실패 시 `getActiveJobId`로 기존 `jobId`를 반환하도록 했으나, 두 호출 사이에 동기화가 완료되어 활성 잡 키가 삭제되면 null이 반환되는 엣지 케이스가 있었습니다.
  
  요청B ── tryAcquireNewJob 실패
              ↓ (이 사이에 요청A의 동기화 완료 → clearActiveJob 호출)
  요청B ── getActiveJobId → null → jobId(null) 반환 ← 문제

---
### 해결 1: Redis SET NX로 체크와 등록을 하나의 원자적 연산으로
  
SET NX는 Redis 명령어 SET key value NX의 약자로, "키가 존재하지 않을 때만 값을 저장" 하는 연산입니다.

핵심은 이 조건 확인과 저장이 단 하나의 연산으로 처리된다는 점입니다. Redis는 싱글 스레드로 명령어를 처리하기 때문에, 여러 요청이 동시에 SET NX를 실행해도 딱 하나만 성공하고 나머지는 실패합니다.

```
요청1 ── SET NX: 성공 → 잡 획득 ✓
요청2 ── SET NX: 실패 (이미 키 존재) → 기존 jobId 반환
요청3 ── SET NX: 실패 (이미 키 존재) → 기존 jobId 반환
요청4 ── SET NX: 실패 (이미 키 존재) → 기존 jobId 반환
요청5 ── SET NX: 실패 (이미 키 존재) → 기존 jobId 반환
```

### 해결 2: `getActiveJobId`가 null이면 새 잡으로 재시도

`tryAcquireNewJob` 실패 후 `getActiveJobId`도 null이면, 두 호출 사이에 동기화가 완료된 케이스이므로 새 잡 획득을 한 번 더 시도합니다.
  
```java
// TO-BE
public SyncJobResponse start(Long memberId) {
    String jobId = jobStore.tryAcquireNewJob(memberId);
    if (jobId != null) {
        jobRunner.runAsync(memberId, jobId);
        return SyncJobResponse.builder().jobId(jobId).build();
    }
    String activeJobId = jobStore.getActiveJobId(memberId);
    if (activeJobId != null) {
        return SyncJobResponse.builder().jobId(activeJobId).build();
    }
    // tryAcquireNewJob 실패와 getActiveJobId 호출 사이에 잡이 완료된 경우 — 새 잡으로 재시도
    jobId = jobStore.tryAcquireNewJob(memberId);
    if (jobId != null) {
        jobRunner.runAsync(memberId, jobId);
    }
    return SyncJobResponse.builder().jobId(
            jobId != null ? jobId : jobStore.getActiveJobId(memberId)).build();
}
```


---

### 변경 내용

**`AssetSyncJobStore` — `tryAcquireNewJob()` 신규 추가**

기존 `createJob()` + `registerActiveJob()`을 하나로 통합했습니다. `setIfAbsent`가 Spring에서 Redis SET NX를 호출하는 메서드입니다.

```java
public String tryAcquireNewJob(Long memberId) {
    String jobId = UUID.randomUUID().toString();
    Boolean acquired = redisTemplate.opsForValue().setIfAbsent(
            String.format(KEY_ACTIVE_JOB, memberId), jobId, TTL_MINUTES, TimeUnit.MINUTES);
    if (!Boolean.TRUE.equals(acquired)) {
        return null;  // 이미 다른 요청이 잡을 획득함
    }
    redisTemplate.opsForValue().set(statusKey(jobId), STATUS_PENDING, TTL_MINUTES, TimeUnit.MINUTES);
    return jobId;
}
```

**`AssetSyncJobStarter` — 획득 실패 시 기존 jobId 반환**

```java
// TO-BE
public SyncJobResponse start(Long memberId) {
    String jobId = jobStore.tryAcquireNewJob(memberId);
    if (jobId == null) {
        return SyncJobResponse.builder().jobId(jobStore.getActiveJobId(memberId)).build();
    }
    jobRunner.runAsync(memberId, jobId);
    return SyncJobResponse.builder().jobId(jobId).build();
}
```

**`AssetSyncJobRunner` — `finally`에서 활성 잡 키 해제**

동기화가 완료되거나 실패하면 반드시 활성 잡 키를 삭제해 다음 동기화 요청을 받을 수 있게 합니다.

```java
} finally {
    jobStore.clearActiveJob(memberId);
}
```

**`AssetSyncServiceImpl` — 상태 문자열 상수 참조로 교체**

`"FAILED"`, `"SUCCESS"` 등 흩어진 문자열 리터럴을 `AssetSyncJobStore` 상수로 통일했습니다.

---

### 로컬 검증

```bash
# 5개 동시 요청
for i in {1..5}; do
  curl -s -X POST "http://localhost:8080/api/v1/assets/sync" \
    -H "X-Dev-Member-Id: 1" \
    | grep -o '"jobId":"[^"]*"' | cut -d'"' -f4 &
done
wait
```
<img width="1221" height="446" alt="스크린샷 2026-08-18 오후 1 22 31" src="https://github.com/user-attachments/assets/17c1174d-8066-4078-8e8d-2428fa05e0f1" />

## 💬리뷰 요구사항(선택)
-