### PR TITLE
feat: 저장된 목표 추천 결과 재조회 API 추가

### DIFF
--- a/src/main/java/com/team/independence/common/exception/ErrorCode.java
+++ b/src/main/java/com/team/independence/common/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
     GOAL_NOT_ACTIVE("GOAL_010", "진행 중인 목표가 아닙니다.", HttpStatus.CONFLICT),
     GOAL_RECOMMENDATION_NO_CANDIDATE("GOAL_011", "추천 가능한 주거 후보가 없습니다.", HttpStatus.NOT_FOUND),
     GOAL_ASSET_REQUIRED("GOAL_012", "추천을 위해 자산 연동이 필요합니다.", HttpStatus.BAD_REQUEST),
+    GOAL_RECOMMENDATION_NOT_FOUND("GOAL_013", "저장된 추천 결과가 없습니다. 조건을 다시 입력해 주세요.", HttpStatus.NOT_FOUND),
 
     // ===== 또래 비교 COMPARE_xxx =====
     COMPARE_SNAPSHOT_NOT_FOUND("COMPARE_001", "비교할 집계 데이터가 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/team/independence/goal/controller/GoalRecommendationController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalRecommendationController.java
@@ -25,4 +25,11 @@ public class GoalRecommendationController {
             @Valid @ModelAttribute GoalRecommendationRequest request) {
         return ApiResponse.ok(recommendationService.recommend(memberId, request));
     }
+
+    // 조건 재입력 없이, 직전에 계산해 둔 추천 결과를 그대로 재조회한다 (결과 화면 재진입·새로고침용)
+    @GetMapping("/recommendation")
+    public ApiResponse<GoalRecommendationResponse> getSavedRecommendation(
+            @LoginMember Long memberId) {
+        return ApiResponse.ok(recommendationService.getSavedRecommendation(memberId));
+    }
 }

--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
@@ -6,9 +6,11 @@ import java.time.YearMonth;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
 
 @Getter
 @Builder
+@Jacksonized
 public class GoalRecommendationResponse {
 
     /** 사용자가 요청한 원래 희망 조건 — 세 추천 카드와 비교 기준으로 사용 */
@@ -21,6 +23,7 @@ public class GoalRecommendationResponse {
 
     @Getter
     @Builder
+    @Jacksonized
     public static class OriginalPreference {
         private OriginalCondition condition;
         private YearMonth targetDate;
@@ -30,6 +33,7 @@ public class GoalRecommendationResponse {
     /** 사용자가 입력한 원래 조건을 그대로 담는 객체 — Condition과 구분 */
     @Getter
     @Builder
+    @Jacksonized
     public static class OriginalCondition {
         private String regionCode;
         private String regionName;
@@ -45,6 +49,7 @@ public class GoalRecommendationResponse {
 
     @Getter
     @Builder
+    @Jacksonized
     public static class FinancialContext {
         /** 현재 주거 목표 계산에 활용 가능한 자산(원) */
         private long currentAvailableAmount;
@@ -52,6 +57,7 @@ public class GoalRecommendationResponse {
 
     @Getter
     @Builder
+    @Jacksonized
     public static class RecommendationItem {
         /** 이 대안을 만든 추천 알고리즘 */
         private AlgorithmType type;
@@ -71,6 +77,7 @@ public class GoalRecommendationResponse {
 
     @Getter
     @Builder
+    @Jacksonized
     public static class Condition {
         private String regionCode;
         private String regionName;
@@ -102,6 +109,7 @@ public class GoalRecommendationResponse {
 
     @Getter
     @Builder
+    @Jacksonized
     public static class CalculationBasis {
         /**
          * 사용자가 설정한 목표 시점까지 준비 가능한 총 금액(원).
@@ -114,6 +122,7 @@ public class GoalRecommendationResponse {
 
     @Getter
     @Builder
+    @Jacksonized
     public static class LoanXPlan {
         private long targetAmount;
         private YearMonth targetDate;
@@ -122,6 +131,7 @@ public class GoalRecommendationResponse {
 
     @Getter
     @Builder(toBuilder = true)
+    @Jacksonized
     public static class LoanOPlan {
         /** DSR 기준 최대 대출 가능액 */
         private long loanAmount;

--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationService.java
@@ -27,4 +27,14 @@ public interface GoalRecommendationService {
      * @return 알고리즘별 추천 대안 (대안을 내지 못한 알고리즘은 제외되므로 알고리즘 수보다 적을 수 있다)
      */
     GoalRecommendationResponse recommend(long memberId, GoalRecommendationRequest request);
+
+    /**
+     * {@link #recommend}로 계산해 저장해 둔 직전 추천 결과를 재계산 없이 그대로 돌려준다.
+     *
+     * @param memberId 요청 회원 ID
+     * @return 저장된 추천 결과
+     * @throws com.team.independence.common.exception.BusinessException 저장된 결과가 없으면
+     *         {@code GOAL_RECOMMENDATION_NOT_FOUND}
+     */
+    GoalRecommendationResponse getSavedRecommendation(long memberId);
 }

--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
@@ -35,6 +35,7 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
     private final AssetSummaryService assetSummaryService;
     private final RegionMapper regionMapper;
     private final ObjectProvider<RecommendationAlgorithm> algorithmProvider;
+    private final GoalRecommendationStore recommendationStore;
 
     @Override
     @Transactional(readOnly = true)
@@ -65,13 +66,24 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
             throw new BusinessException(ErrorCode.GOAL_RECOMMENDATION_NO_CANDIDATE);
         }
 
-        return GoalRecommendationResponse.builder()
+        GoalRecommendationResponse response = GoalRecommendationResponse.builder()
                 .originalPreference(buildOriginalPreference(request, monthlySaving))
                 .financialContext(GoalRecommendationResponse.FinancialContext.builder()
                         .currentAvailableAmount(currentAvailableAmount)
                         .build())
                 .recommendations(recommendations)
                 .build();
+
+        // 결과 화면 재진입 시 재계산 없이 그대로 돌려주기 위해 저장한다
+        recommendationStore.save(memberId, response);
+        return response;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public GoalRecommendationResponse getSavedRecommendation(long memberId) {
+        return recommendationStore.find(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GOAL_RECOMMENDATION_NOT_FOUND));
     }
 
     private GoalRecommendationResponse.OriginalPreference buildOriginalPreference(

--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationStore.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationStore.java
@@ -1,0 +1,56 @@
+package com.team.independence.goal.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.independence.goal.dto.GoalRecommendationResponse;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 조건 기반 목표 추천 결과를 Redis에 캐싱한다.
+ * Key: goal:recommendation:{memberId} (TTL: 1일 — 근거 없음, 임의로 정함)
+ *
+ * 아직 목표를 생성하지 않은 단계라 goalId가 없어 memberId로 키를 잡는다.
+ * 조건 입력(recommend) 시 저장하고, 결과 화면 재진입(getSaved)에서는 재계산 없이 그대로 조회한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GoalRecommendationStore {
+
+    private static final String KEY_PREFIX = "goal:recommendation:";
+    private static final Duration TTL = Duration.ofDays(1);
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public Optional<GoalRecommendationResponse> find(long memberId) {
+        String json = redisTemplate.opsForValue().get(key(memberId));
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(json, GoalRecommendationResponse.class));
+        } catch (JsonProcessingException e) {
+            log.warn("[목표 추천 캐시] 역직렬화 실패, 캐시 미스로 처리: memberId={}", memberId, e);
+            return Optional.empty();
+        }
+    }
+
+    public void save(long memberId, GoalRecommendationResponse response) {
+        try {
+            String json = objectMapper.writeValueAsString(response);
+            redisTemplate.opsForValue().set(key(memberId), json, TTL);
+        } catch (JsonProcessingException e) {
+            log.warn("[목표 추천 캐시] 직렬화 실패, 캐싱 건너뜀: memberId={}", memberId, e);
+        }
+    }
+
+    private String key(long memberId) {
+        return KEY_PREFIX + memberId;
+    }
+}


### PR DESCRIPTION
# feat: 저장된 목표 추천 결과 재조회 API 추가 (GET /goals/recommendation)

## #️⃣ 연관된 이슈

- #116

close #116

> ⚠️ 이 PR은 `fix/goal-recommendations-get-method`(#114) 위에 쌓여 있습니다. **#114가 먼저 머지되어야** diff가 이 PR의 변경만 남습니다.

## 📝 작업 내용

### 이 기능이 하는 말

**재계산하지 않는 것이 이 API의 정체성입니다.** 조건 입력 화면에서 이미 한 번 계산한 추천 결과를, 결과 화면에 재진입하거나 새로고침할 때 그대로 다시 돌려줍니다.

프론트는 `GET /goals/recommendations`(복수형, 조건 기반 계산)와 `GET /goals/recommendation`(단수형, 저장된 결과 재조회)을 화면 단계별로 나눠 부르고 있었는데, 단수형 쪽이 백엔드에 없어 결과 화면에 들어갈 때마다 400이 났습니다. 이 PR은 그 없는 절반을 채웁니다.

---

## 전체 플로우

```
        [조건 입력 화면] "목표 찾기" 제출
                     │
        GET /goals/recommendations?regionCode=...
                     │
              알고리즘 실행 + 계산
                     │
        ┌────────────┴────────────┐
   응답 반환                  결과를 memberId로 저장
        │                          │
        └────────────┬─────────────┘
                     │
              [결과 화면] 진입
                     │
           ┌─────────┴─────────┐
     처음 진입/새로고침      뒤로가기 등 store에 이미 있음
           │                        │
  GET /goals/recommendation   (재요청 없이 store 값 사용,
           │                    프론트 쪽 로직 — 이 PR 밖)
           │
   ┌───────┴───────┐
 저장된 값 있음     저장된 값 없음
   │                    │
 그대로 반환        404 GOAL_RECOMMENDATION_NOT_FOUND
                   "조건을 다시 입력해 주세요"
```

### 저장된 값이 없을 때 재계산하지 않고 404를 낸 이유

저장된 값이 없다는 건 "조건 계산을 아직 안 했거나, 저장한 지 오래돼 만료됐다"는 뜻입니다. 이 상태에서 서버가 임의로 재계산하려면 조건(`GoalRecommendationRequest`)이 있어야 하는데, 이 API는 파라미터 없이 memberId만 받습니다. 조건이 없으니 재계산할 방법이 없고, 그래서 "조건을 다시 입력해 주세요"로 안내해 프론트가 조건 입력 화면으로 되돌릴 수 있게 했습니다.

### 실제로 타는 경로 두 가지

**정상 흐름** — 조건 입력 → 복수형 API 호출 → 저장됨 → 결과 화면 진입 → 단수형 API가 저장된 값 반환
**TTL 만료/직접 진입** — 조건 입력을 건너뛰고 결과 화면 URL로 바로 들어오거나, 1일 넘게 지난 뒤 새로고침 → 저장된 값 없음 → 404

---

## 공식과 상수

이 기능에는 계산 공식이 없습니다. 유일한 상수는 캐시 TTL입니다.

| 상수 | 값 | 근거 |
|---|---|---|
| 추천 결과 캐시 TTL | 1일 | **없음** — 임의로 정했습니다. `MonteCarloSimulationStore`는 목표 조건이 안 바뀌는 한 유효해 30일을 쓰지만, 이 캐시는 목표를 만들기 전 조건 탐색 단계에 걸쳐 있는 값이라 그렇게 오래 남겨둘 근거가 없었습니다. "한 세션 안에서는 확실히 살아있게" 정도로 넉넉히 잡은 값입니다 |

---

## 구현 내용

### 플로우에 코드를 얹은 그림

`＊`가 이번에 새로 만든 것, 나머지는 기존 것을 그대로 씁니다.

```
        GET /goals/recommendations
                     │
        GoalRecommendationServiceImpl.recommend (기존)
                     │
              응답 조립 (기존)
                     │
        GoalRecommendationStore.save(memberId, response) ＊
                     │
                  응답 반환

        GET /goals/recommendation ＊
                     │
        GoalRecommendationController.getSavedRecommendation ＊
                     │
        GoalRecommendationServiceImpl.getSavedRecommendation ＊
                     │
        GoalRecommendationStore.find(memberId) ＊
                     │
           ┌─────────┴─────────┐
        Optional 있음        Optional 없음
           │                     │
        그대로 반환      BusinessException
                       (GOAL_RECOMMENDATION_NOT_FOUND) ＊
```

`GoalRecommendationStore`는 기존 `MonteCarloSimulationStore`(Redis, `StringRedisTemplate` + Jackson 직렬화)와 동일한 패턴을 그대로 따랐습니다. 차이는 키를 `goalId`가 아니라 `memberId`로 잡은 것뿐입니다 — 이 시점엔 아직 목표(Goal)가 생성되지 않아 goalId가 없습니다.

### 그림에 안 드러나는 판단

**캐시 미스를 재계산이 아니라 404로 처리했습니다.** `MonteCarloSimulationStore`는 캐시 미스 시 서비스가 알아서 재계산합니다(조건이 이미 DB의 Goal에 저장돼 있으니까). 이 API는 조건을 받지 않기 때문에 같은 패턴을 쓸 수 없어, 미스를 에러로 노출하고 프론트가 조건 입력 화면으로 되돌리게 했습니다.

### 바깥에 영향이 있는 변경

- ⚠️ **`ErrorCode.GOAL_RECOMMENDATION_NOT_FOUND`(GOAL_013) 추가** — 프론트가 이 코드를 받으면 "조건 다시 입력" 화면으로 유도하는 처리가 필요합니다.
- **신규 엔드포인트 `GET /api/v1/goals/recommendation`** — 프론트가 이미 호출하고 있던 URL이라 계약 변경은 없고, 없던 걸 채운 것입니다.