### PR TITLE
fix: GoalRecommendationResponse.Condition에 depositMin/depositMax 필드 추가

### DIFF
--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
@@ -85,6 +85,8 @@ public class GoalRecommendationResponse {
         private DealType dealType;
         private int areaMin;
         private int areaMax;
+        private long depositMin;
+        private long depositMax;
 
         /**
          * 월세 중앙값 (원). 전세({@code dealType=JEONSE})면 0.

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -159,6 +159,8 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
                         .dealType(best.candidate.dealType)
                         .areaMin(best.candidate.areaMin)
                         .areaMax(best.candidate.areaMax)
+                        .depositMin(best.candidate.depositMin)
+                        .depositMax(best.candidate.depositMax)
                         .monthlyRent(best.candidate.dealType == DealType.WOLSE
                                 && best.median.getMonthlyRent() != null
                                 && best.median.getMonthlyRent().getQ3() != null

--- a/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
@@ -160,6 +160,8 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
                 .dealType(dealType)
                 .areaMin(areaMin)
                 .areaMax(areaMax)
+                .depositMin(request.getDepositMin() != null ? request.getDepositMin() : 0L)
+                .depositMax(request.getDepositMax() != null ? request.getDepositMax() : DEPOSIT_MAX_DEFAULT)
                 .monthlyRent(monthlyRent)
                 .sampleCount(median.getSampleCount())
                 .marketMedianAmount(projectedDeposit)

--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -163,10 +163,13 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         }
 
         // 2단계: 사용자가 준 조건을 지킨 채, 주지 않은 항목만 움직여 본다
+        long depositMin = request.getDepositMin() != null ? request.getDepositMin() : 0L;
+        long depositMax = request.getDepositMax() != null ? request.getDepositMax() : DEPOSIT_MAX_DEFAULT;
+
         List<Candidate> asRequested = evaluateConditions(regionCode, request, search, true);
         Optional<Candidate> keepingInput = bestWithinTarget(asRequested);
         if (keepingInput.isPresent()) {
-            return Optional.of(assemble(memberId, keepingInput.get(), targetDate, desiredMonths, false, search));
+            return Optional.of(assemble(memberId, keepingInput.get(), targetDate, desiredMonths, false, search, depositMin, depositMax));
         }
 
         // 3단계: 입력한 조건으로는 목표 시점을 못 지킨다. 그때만 조건을 풀고 다시 찾는다.
@@ -180,7 +183,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         }
 
         Candidate chosen = bestWithinTarget(relaxed).orElseGet(() -> cheapest(relaxed));
-        return Optional.of(assemble(memberId, chosen, targetDate, desiredMonths, true, search));
+        return Optional.of(assemble(memberId, chosen, targetDate, desiredMonths, true, search, depositMin, depositMax));
     }
 
     /** 사용자가 지역 외에 조정 가능한 조건을 하나라도 줬는가 */
@@ -421,7 +424,8 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
 
     private GoalRecommendationResponse.RecommendationItem assemble(
             long memberId, Candidate chosen, YearMonth targetDate,
-            long desiredMonths, boolean adjusted, Search search) {
+            long desiredMonths, boolean adjusted, Search search,
+            long depositMin, long depositMax) {
 
         // 화면에 나가는 목표 금액은 환산값이 아니라 실제로 모아야 하는 보증금이다.
         LoanPlans plans = loanPlanCalculator.calculate(memberId, chosen.deposit(), targetDate);
@@ -444,6 +448,8 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
                 .dealType(chosen.dealType())
                 .areaMin(chosen.areaMin())
                 .areaMax(chosen.areaMax())
+                .depositMin(depositMin)
+                .depositMax(depositMax)
                 .monthlyRent(chosen.monthlyRent())
                 .sampleCount(chosen.sampleCount())
                 .marketMedianAmount(chosen.deposit())


### PR DESCRIPTION
## #️⃣연관된 이슈

#118 

## 📝작업 내용

### 문제

추천 플랜을 선택해 POST `/api/v1/goals`로 목표를 저장하면, 보증금 하한·상한을 입력해도 아래 오류가 발생하며 목표가 생성되지 않습니다.

<img width="641" height="824" alt="스크린샷 2026-08-18 오후 2 24 02" src="https://github.com/user-attachments/assets/6022b21c-d55d-439d-9327-7dec265c8974" />


### 원인

`GoalRecommendationResponse.Condition`에 `depositMin`/`depositMax` 필드가 없어서, 프론트가 추천 `Condition`에서 값을 꺼내면 null이 됩니다. 그리고 세 알고리즘 모두 `Condition`을 빌드할 때 이 두 필드를 포함하지 않고 있었습니다.

```java
// AS-IS — 세 알고리즘 공통
GoalRecommendationResponse.Condition.builder()
    .regionCode(...)
    .housingType(housingType)
    .dealType(dealType)
    .areaMin(areaMin)
    .areaMax(areaMax)
    // depositMin, depositMax 없음 ← 원인
    .monthlyRent(monthlyRent)
    .marketMedianAmount(projectedDeposit)
    .build();
```

`GoalSaveRequest`는 `depositMin`/`depositMax`에 `@NotNull`이 걸려 있으므로, null이 들어오면 Bean Validation에서 즉시 거부됩니다. 참고로 `OriginalCondition`에는 해당 필드가 있으나, 이는 사용자 원본 입력을 화면 비교용으로 돌려주는 용도라 목표 저장 흐름과 무관합니다.

### 수정

`GoalRecommendationResponse.Condition`에 `depositMin`/`depositMax`를 추가하고, 세 알고리즘이 실제로 사용한 보증금 필터값을 포함하도록 했습니다.

| 알고리즘 | depositMin | depositMax |
|---|---|---|
| PREFERENCE | 사용자 입력값 (없으면 0) | 사용자 입력값 (없으면 100,000,000,000) |
| REALISTIC | 사용자 입력값 (없으면 0) | 사용자 입력값 (없으면 100,000,000,000) |
| HOLD_OUT | 0 (내부 고정값) | 1,000,000,000,000 (내부 고정값) |

```java
// TO-BE
GoalRecommendationResponse.Condition.builder()
    .regionCode(...)
    .housingType(housingType)
    .dealType(dealType)
    .areaMin(areaMin)
    .areaMax(areaMax)
    .depositMin(request.getDepositMin() != null ? request.getDepositMin() : 0L)
    .depositMax(request.getDepositMax() != null ? request.getDepositMax() : DEPOSIT_MAX_DEFAULT)
    .monthlyRent(monthlyRent)
    .marketMedianAmount(projectedDeposit)
    .build();
```

## 💬리뷰 요구사항(선택)

- 