### PR TITLE
perf: 시도 단위 목표 추천 요청 타임아웃 해소 (PriceModel 캐싱 + selectRegion 경량화)

### DIFF
--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -224,23 +224,62 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
                 ? request.getTradeType() : REFERENCE_DEAL_TYPE;
         int[] size = inputSize(request) != null ? inputSize(request) : SIZE_BUCKETS[REFERENCE_SIZE_BUCKET];
 
-        List<Candidate> ranked = new ArrayList<>();
+        // 시군구 순위 비교는 raw median으로 충분하다. MC 투영을 하면 같은 시도 내 구들이 비슷한
+        // 비율로 오르기 때문에 순위가 거의 바뀌지 않으면서, 구마다 priceModel 36개월 쿼리와
+        // MC 시뮬레이션이 추가되어 응답 시간이 크게 늘어난다.
+        String bestCode = null;
+        long bestAmount = Long.MIN_VALUE;
+        String cheapestCode = null;
+        long cheapestAmount = Long.MAX_VALUE;
+
         for (String code : sigunguCodes) {
-            evaluate(code, housingType, dealType, size[0], size[1], request, search)
-                    .ifPresent(ranked::add);
+            Long amount = quickMedianAmount(code, housingType, dealType, size[0], size[1], request, search);
+            if (amount == null) {
+                continue;
+            }
+            if (amount < cheapestAmount) {
+                cheapestCode = code;
+                cheapestAmount = amount;
+            }
+            Long reachMonths = budgetCalculator.monthsToReach(search.netWorth, search.effectiveSaving, amount);
+            boolean withinTarget = reachMonths != null
+                    && (double) reachMonths / search.desiredMonths <= MAX_REACH_RATIO;
+            if (withinTarget && amount > bestAmount) {
+                bestCode = code;
+                bestAmount = amount;
+            }
         }
-        if (ranked.isEmpty()) {
+
+        return bestCode != null ? bestCode : cheapestCode;
+    }
+
+    /**
+     * 시군구 순위 비교용 raw 환산보증금. priceModel, MC를 생략하고 getMedian 1회만 호출한다.
+     * 결과를 search.evaluated에 저장하지 않아 evaluateConditions에서 전체 평가를 재실행한다.
+     *
+     * @return 환산보증금(원). 표본 부족이면 null.
+     */
+    private Long quickMedianAmount(
+            String regionCode, HousingType housingType, DealType dealType,
+            int areaMin, int areaMax, GoalRecommendationRequest request, Search search) {
+
+        RentMedianResponse median;
+        try {
+            median = rentMedianService.getMedian(
+                    buildMedianRequest(regionCode, housingType, dealType, areaMin, areaMax, request));
+        } catch (RuntimeException e) {
+            log.debug("시군구 시세 조회 실패, 건너뜀. regionCode={}", regionCode, e);
             return null;
         }
 
-        // 예산에 맞는 곳 중 가장 좋은(비싼) 곳. 없으면 가장 싼 곳.
-        return ranked.stream()
-                .filter(Candidate::withinTarget)
-                .max(Comparator.comparingLong(Candidate::comparableAmount))
-                .orElseGet(() -> ranked.stream()
-                        .min(Comparator.comparingLong(Candidate::comparableAmount))
-                        .orElseThrow(IllegalStateException::new))
-                .regionCode();
+        if (median.getSampleCount() < MIN_SAMPLE_COUNT || median.getDeposit().getMedian() == null) {
+            return null;
+        }
+
+        long deposit = median.getDeposit().getMedian();
+        long monthlyRent = dealType == DealType.WOLSE && median.getMonthlyRent().getMedian() != null
+                ? median.getMonthlyRent().getMedian() : 0L;
+        return toComparableAmount(deposit, monthlyRent);
     }
 
     // ===== 2단계: 조건 =====

--- a/src/main/java/com/team/independence/property/dto/PriceModelResponse.java
+++ b/src/main/java/com/team/independence/property/dto/PriceModelResponse.java
@@ -4,9 +4,11 @@ import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
 
 @Getter
 @Builder
+@Jacksonized
 public class PriceModelResponse {
 
     private String regionCode;

--- a/src/main/java/com/team/independence/property/service/PriceModelServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/PriceModelServiceImpl.java
@@ -11,6 +11,7 @@ import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,10 +29,16 @@ public class PriceModelServiceImpl implements PriceModelService {
 
     private final RegionMapper regionMapper;
     private final RentTransactionMapper rentTransactionMapper;
+    private final PriceModelStore priceModelStore;
 
     @Override
     @Transactional(readOnly = true, noRollbackFor = BusinessException.class)
     public PriceModelResponse estimate(PriceModelRequest request) {
+        Optional<PriceModelResponse> cached = priceModelStore.find(request);
+        if (cached.isPresent()) {
+            return cached.get();
+        }
+
         String regionName = regionMapper.findFullNameByCode(request.getRegionCode());
         if (regionName == null) {
             throw new BusinessException(ErrorCode.REGION_NOT_FOUND);
@@ -66,7 +73,7 @@ public class PriceModelServiceImpl implements PriceModelService {
 
         PriceModel model = PriceModel.estimate(monthlyMedians);
 
-        return PriceModelResponse.builder()
+        PriceModelResponse response = PriceModelResponse.builder()
                 .regionCode(request.getRegionCode())
                 .regionName(regionName)
                 .housingType(request.getHousingType())
@@ -78,6 +85,8 @@ public class PriceModelServiceImpl implements PriceModelService {
                 .startYm(startYm)
                 .endYm(endYm)
                 .build();
+        priceModelStore.save(request, response);
+        return response;
     }
 
     /** 한 달치 거래 목록에서 평당 보증금(원/평)의 중앙값을 반환 */

--- a/src/main/java/com/team/independence/property/service/PriceModelStore.java
+++ b/src/main/java/com/team/independence/property/service/PriceModelStore.java
@@ -1,0 +1,58 @@
+package com.team.independence.property.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.property.dto.PriceModelResponse;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 가격 모델(μ, σ) 추정 결과를 Redis에 캐싱한다.
+ * Key: property:priceModel:{regionCode}:{housingType}:{dealType}:{areaMin}:{areaMax} (TTL: 12시간)
+ *
+ * PriceModel은 36개월치 실거래 원본 행을 스캔해 회귀 추정하는 고비용 연산이다.
+ * 데이터는 배치로 일 1회 소량 추가되나 모델 결과는 하루 단위로 거의 변하지 않아 캐싱에 적합하다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PriceModelStore {
+
+    private static final String KEY_PREFIX = "property:priceModel:";
+    private static final Duration TTL = Duration.ofHours(12);
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public Optional<PriceModelResponse> find(PriceModelRequest request) {
+        String json = redisTemplate.opsForValue().get(key(request));
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(json, PriceModelResponse.class));
+        } catch (JsonProcessingException e) {
+            log.warn("[PriceModel 캐시] 역직렬화 실패, 미스로 처리: key={}", key(request), e);
+            return Optional.empty();
+        }
+    }
+
+    public void save(PriceModelRequest request, PriceModelResponse response) {
+        try {
+            String json = objectMapper.writeValueAsString(response);
+            redisTemplate.opsForValue().set(key(request), json, TTL);
+        } catch (JsonProcessingException e) {
+            log.warn("[PriceModel 캐시] 직렬화 실패, 캐싱 건너뜀: key={}", key(request), e);
+        }
+    }
+
+    private String key(PriceModelRequest r) {
+        return KEY_PREFIX + r.getRegionCode() + ":" + r.getHousingType()
+                + ":" + r.getDealType() + ":" + r.getAreaMin() + ":" + r.getAreaMax();
+    }
+}

--- a/src/test/java/com/team/independence/property/service/PriceModelServiceImplTest.java
+++ b/src/test/java/com/team/independence/property/service/PriceModelServiceImplTest.java
@@ -9,6 +9,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.property.domain.DealType;
@@ -49,6 +51,7 @@ class PriceModelServiceImplTest {
 
     @Mock private RegionMapper regionMapper;
     @Mock private RentTransactionMapper rentTransactionMapper;
+    @Mock private PriceModelStore priceModelStore;
 
     @InjectMocks private PriceModelServiceImpl service;
 
@@ -56,6 +59,8 @@ class PriceModelServiceImplTest {
 
     @BeforeEach
     void setUp() {
+        when(priceModelStore.find(any())).thenReturn(Optional.empty());
+
         request = new PriceModelRequest();
         request.setRegionCode(REGION_CODE);
         request.setHousingType(HousingType.APT);


### PR DESCRIPTION
## #️⃣연관된 이슈

#120

## 📝작업 내용

### 배경

서울(시도 코드 2자리 `11`)로 목표 추천 요청(`GET /api/v1/goals/recommendations`) 시 30초 타임아웃이 발생했다.

시도 코드를 전달하면 `RealisticAlgorithm.selectRegion()`이 해당 시도의 **모든 시군구를 순회**하면서, 각 조합마다 아래 세 작업을 순차 실행한다.

| 작업 | 내용 |
|---|---|
| `getMedian` | 최근 6개월 실거래 원본 행 스캔 → 분위값 계산 |
| `PriceModelService.estimate()` | 최근 **36개월** 실거래 원본 행 스캔 → 월별 그룹핑 → 평당 중앙값 시계열 → 로그 선형 회귀로 drift(μ)·vol(σ) 추정 |
| `MonteCarloEngine.simulate()` | 10,000 경로 GBM 시뮬레이션 |

`PriceModelService.estimate()` 결과에는 어떤 캐시도 없어 **매 호출마다 36개월치 데이터를 재스캔**했다. 서울 요청 한 번에 약 314회의 DB 쿼리가 순차 발생해 타임아웃으로 이어졌다.

---

### 변경 1 — `PriceModelStore` 신규 추가 + `PriceModelServiceImpl` 캐시 적용

`PriceModelService.estimate()` 결과(`PriceModelResponse`)를 Redis에 캐싱한다.

- **캐시 키**: `property:priceModel:{regionCode}:{housingType}:{dealType}:{areaMin}:{areaMax}`
- **TTL**: 12시간 (실거래 데이터는 배치로 일 1회 소량 추가되나, 모델 결과는 하루 단위로 거의 변하지 않음)
- 캐시 미스 시 기존 로직 실행 후 저장, 역직렬화 실패 시 캐시 미스로 처리 (기존 `MonteCarloSimulationStore`와 동일 패턴)
- `PriceModelResponse`에 `@Jacksonized` 추가 (`@Builder` 클래스의 Redis 역직렬화에 필요)
- `HoldOutAlgorithm`은 동일한 `PriceModelServiceImpl.estimate()` 경로를 타므로 **별도 수정 없이** 캐시 혜택을 받음

### 변경 2 — `RealisticAlgorithm.selectRegion()` 경량화

시군구 순위 비교 목적으로 priceModel·MC를 실행하는 것은 과도하다.

같은 시도 내 시군구들은 부동산 시장 움직임이 유사해 MC 투영 전후 순위가 거의 바뀌지 않는다. `quickMedianAmount()`를 추출해 `getMedian` 1회만 호출하고 priceModel·MC를 생략한다. 결과를 `search.evaluated` 캐시에 저장하지 않아, 이후 `evaluateConditions`에서 전체 평가(MC 포함)를 재실행한다.

### 개선 효과 (서울, 조건 미지정 기준)

| | 현재 | 개선 후 (콜드 캐시) | 개선 후 (웜 캐시) |
|---|---|---|---|
| DB 쿼리 수 | ≈ 314회 | ≈ 105회 | ≈ 65회 |
| 예상 응답 시간 | 30초+ (타임아웃) | 5초 내외 | 2초 내외 |

## 💬리뷰 요구사항(선택)

- `quickMedianAmount()`에서 시군구 순위 비교 시 MC를 생략하는 것이 추천 품질에 영향을 주지 않는다고 판단했는데, 이견이 있으면 말씀해 주세요.
- PriceModel TTL을 12시간으로 설정했는데 더 길게 잡아도 무방한지 의견 부탁드립니다.