### PR TITLE
perf: 추천 알고리즘 쿼리 최적화 — DB 집계 이전·bulk 조회·병렬 실행

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/src/main/java/com/team/independence/config/RootConfig.java
+++ b/src/main/java/com/team/independence/config/RootConfig.java
@@ -163,4 +163,15 @@ public class RootConfig {
         return executor;
     }
 
+    @Bean("algorithmExecutor")
+    public Executor algorithmExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(3);
+        executor.setMaxPoolSize(6);
+        executor.setQueueCapacity(20);
+        executor.setThreadNamePrefix("algo-rec-");
+        executor.initialize();
+        return executor;
+    }
+
 }

--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
@@ -7,13 +7,18 @@ import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
+import com.team.independence.goal.service.RecommendationAlgorithm.MemberFinancialContext;
+import com.team.independence.goal.service.calculator.LoanPlanCalculator;
 import com.team.independence.property.mapper.RegionMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,9 +38,12 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
 
     private final AssetConnectionService assetConnectionService;
     private final AssetSummaryService assetSummaryService;
+    private final LoanPlanCalculator loanPlanCalculator;
     private final RegionMapper regionMapper;
     private final ObjectProvider<RecommendationAlgorithm> algorithmProvider;
     private final GoalRecommendationStore recommendationStore;
+    @Qualifier("algorithmExecutor")
+    private final Executor algorithmExecutor;
 
     @Override
     @Transactional(readOnly = true)
@@ -52,12 +60,23 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
 
         AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
         long monthlySaving = assetSummaryService.getMonthlySavingsOrZero(memberId);
+        long loanPayment   = loanPlanCalculator.calcTotalExistingMonthlyPayment(memberId);
+        MemberFinancialContext ctx = new MemberFinancialContext(netWorth, monthlySaving, loanPayment);
+
         long currentAvailableAmount = netWorth.getInterestBearingAssets()
                 + netWorth.getFlatRecognizedAssets();
 
-        // 대안을 내지 못한 알고리즘은 제외하므로 결과 수가 알고리즘 수보다 적을 수 있다
-        List<GoalRecommendationResponse.RecommendationItem> recommendations = algorithms.stream()
-                .map(algorithm -> runSafely(algorithm, memberId, request))
+        List<CompletableFuture<Optional<GoalRecommendationResponse.RecommendationItem>>> futures =
+                algorithms.stream()
+                        .map(algorithm -> CompletableFuture.supplyAsync(
+                                () -> runSafely(algorithm, memberId, request, ctx),
+                                algorithmExecutor))
+                        .collect(Collectors.toList());
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        List<GoalRecommendationResponse.RecommendationItem> recommendations = futures.stream()
+                .map(CompletableFuture::join)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toList());
@@ -122,13 +141,15 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
      * 다만 모든 알고리즘이 실패하면 결과가 비어 {@code GOAL_RECOMMENDATION_NO_CANDIDATE}로 이어진다.
      */
     private Optional<GoalRecommendationResponse.RecommendationItem> runSafely(
-            RecommendationAlgorithm algorithm, long memberId, GoalRecommendationRequest request) {
+            RecommendationAlgorithm algorithm, long memberId,
+            GoalRecommendationRequest request, MemberFinancialContext ctx) {
         try {
-            return algorithm.recommend(memberId, request);
+            return algorithm.recommend(memberId, request, ctx);
         } catch (Exception e) {
             log.error("추천 알고리즘 실행 실패. algorithm={}, memberId={}",
                     algorithm.getClass().getSimpleName(), memberId, e);
             return Optional.empty();
         }
     }
+
 }

--- a/src/main/java/com/team/independence/goal/service/RecommendationAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/RecommendationAlgorithm.java
@@ -1,5 +1,6 @@
 package com.team.independence.goal.service;
 
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
 import com.team.independence.property.domain.DealType;
@@ -51,6 +52,23 @@ import java.util.Optional;
 public interface RecommendationAlgorithm {
 
     /**
+     * 상위에서 한 번만 조회한 회원 재무 정보.
+     *
+     * <p>세 알고리즘이 공통으로 사용하는 자산·저축·대출 데이터를 상위 서비스에서 미리 계산해
+     * 전달한다. 알고리즘마다 동일한 DB 조회를 반복하는 것을 방지한다.
+     */
+    record MemberFinancialContext(
+            AssetNetWorthBreakdown netWorth,
+            long rawMonthlySaving,
+            long loanPayment) {
+
+        /** 기존 대출 월상환액 차감 후 실질 저축 여력 */
+        public long effectiveSaving() {
+            return Math.max(0, rawMonthlySaving - loanPayment);
+        }
+    }
+
+    /**
      * 평수 구간(평). 넓은 쪽이 앞이다.
      *
      * <p>사용자가 평수를 지정하지 않았을 때 후보군으로 쓰는 공유 버킷.
@@ -69,7 +87,7 @@ public interface RecommendationAlgorithm {
      * @return 추천 대안. 제시할 만한 대안이 없으면 {@link Optional#empty()}
      */
     Optional<GoalRecommendationResponse.RecommendationItem> recommend(
-            long memberId, GoalRecommendationRequest request);
+            long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx);
 
     static String label(HousingType housingType) {
         switch (housingType) {

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -1,7 +1,6 @@
 package com.team.independence.goal.service.algorithm;
 
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
-import com.team.independence.asset.service.AssetSummaryService;
 import com.team.independence.goal.domain.Goal;
 import com.team.independence.goal.domain.GoalHousing;
 import com.team.independence.goal.dto.AlgorithmType;
@@ -26,10 +25,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -66,6 +67,10 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
     private static final long WIDE_DEPOSIT_MAX  = 1_000_000_000_000L;
     private static final int  MAX_MC_ITERATIONS = 3;
 
+    /** RentMedianServiceImpl과 동일한 집계 구간 */
+    private static final int MONTHS = 6;
+    private static final DateTimeFormatter YM = DateTimeFormatter.ofPattern("yyyyMM");
+
     /**
      * 추가 인내 허용 개월 수.
      * targetDate 이후(또는 targetDate 미지정 시 지금부터) 최대 48개월(4년)까지 탐색한다.
@@ -73,17 +78,16 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
     private static final long PATIENCE_BONUS   = 48;
     private static final long DEFAULT_RENT_MAX = 2_000_000L;
 
-    private final LoanPlanCalculator  loanPlanCalculator;
-    private final BudgetCalculator    budgetCalculator;
-    private final GoalMapper          goalMapper;
-    private final GoalHousingMapper   goalHousingMapper;
-    private final AssetSummaryService assetSummaryService;
-    private final RentMedianService   rentMedianService;
-    private final MonteCarloService   monteCarloService;
+    private final LoanPlanCalculator loanPlanCalculator;
+    private final BudgetCalculator   budgetCalculator;
+    private final GoalMapper         goalMapper;
+    private final GoalHousingMapper  goalHousingMapper;
+    private final RentMedianService  rentMedianService;
+    private final MonteCarloService  monteCarloService;
 
     @Override
     public Optional<GoalRecommendationResponse.RecommendationItem> recommend(
-            long memberId, GoalRecommendationRequest request
+            long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx
     ) {
         Goal activeGoal = goalMapper.findActiveByMemberId(memberId);
         GoalHousing housing = (activeGoal != null)
@@ -94,27 +98,32 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
         if (base == null) return Optional.empty();
 
         YearMonth now = YearMonth.now();
-        AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
-        long rawMonthlySaving = assetSummaryService.getMonthlySavingsOrZero(memberId);
-        long loanPayment = loanPlanCalculator.calcTotalExistingMonthlyPayment(memberId);
-        long baseSaving = Math.max(0, rawMonthlySaving - loanPayment);
+        AssetNetWorthBreakdown netWorth = ctx.netWorth();
+        long baseSaving = ctx.effectiveSaving();
 
         long n = base.targetDate != null
                 ? Math.max(0, ChronoUnit.MONTHS.between(now, base.targetDate))
                 : 0L;
         long window = n + PATIENCE_BONUS;
 
-        // 1차: 요청 지역에서 평수 업그레이드 후보 탐색
-        List<FetchedCandidate> pool = buildPool(generateCandidates(base), base, netWorth, baseSaving, window);
+        String endYm   = now.format(YM);
+        String startYm = now.minusMonths(MONTHS - 1).format(YM);
+
+        // 1차: 요청 지역에서 평수 업그레이드 후보 탐색 (bulk 1회 쿼리)
+        Map<String, RentMedianResponse> bulkMedians =
+                rentMedianService.getBulkMedian(base.regionCode, startYm, endYm);
+        List<FetchedCandidate> pool = buildPool(generateCandidates(base), base, netWorth, baseSaving, window, bulkMedians);
         boolean regionExpanded = false;
 
-        // 2차: 시군구(5자리)로 요청했지만 pool이 비었으면 상위 시도(2자리)로 확장
+        // 2차: 시군구(5자리)로 요청했지만 pool이 비었으면 상위 시도(2자리)로 확장 (bulk 1회 추가)
         if (pool.isEmpty() && base.regionCode.length() > 2) {
             String sidoCode = base.regionCode.substring(0, 2);
+            Map<String, RentMedianResponse> sidoBulkMedians =
+                    rentMedianService.getBulkMedian(sidoCode, startYm, endYm);
             BaseCondition sidoBase = new BaseCondition(
                     sidoCode, base.housingType, base.dealType,
                     base.areaMin, base.areaMax, base.rentMin, base.rentMax, base.targetDate);
-            pool = buildPool(generateCandidates(sidoBase), base, netWorth, baseSaving, window);
+            pool = buildPool(generateCandidates(sidoBase), base, netWorth, baseSaving, window, sidoBulkMedians);
             regionExpanded = !pool.isEmpty();
         }
 
@@ -219,14 +228,17 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
      * 평수 기준은 지역이 바뀌어도 변하지 않는다.
      */
     private List<FetchedCandidate> buildPool(List<HousingCondition> candidates, BaseCondition base,
-                                              AssetNetWorthBreakdown netWorth, long baseSaving, long horizon) {
+                                              AssetNetWorthBreakdown netWorth, long baseSaving, long horizon,
+                                              Map<String, RentMedianResponse> bulkMedians) {
         List<FetchedCandidate> pool = new ArrayList<>();
         for (HousingCondition candidate : candidates) {
             // 평수 업그레이드 필터: 요청 최대 평수(areaMax) 이하 버킷은 업그레이드가 아니므로 제외
             if (base.areaMin != null && base.areaMax != null && candidate.areaMin <= base.areaMax) continue;
 
-            RentMedianResponse median = fetchAndValidateMedian(candidate);
-            if (median == null) continue;
+            String key = candidate.housingType + "|" + candidate.dealType + "|" + candidate.areaMin;
+            RentMedianResponse median = bulkMedians.get(key);
+            if (median == null || median.getSampleCount() < MIN_SAMPLE_COUNT) continue;
+            if (median.getDeposit().getQ3() == null) continue;
 
             long effectiveSaving = baseSaving;
             if (candidate.dealType == DealType.WOLSE) {
@@ -276,19 +288,6 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
 
         return new ScoredCandidate(candidate, median, metrics.futurePrice, metrics.effectiveSaving,
                 metrics.totalMonths, metrics.m, score);
-    }
-
-    private RentMedianResponse fetchAndValidateMedian(HousingCondition candidate) {
-        RentMedianResponse median;
-        try {
-            median = rentMedianService.getMedian(candidate.toMedianRequest());
-        } catch (RuntimeException e) {
-            log.warn("[HoldOut] 시세 조회 실패 {} : {}", candidate.label(), e.getMessage());
-            return null;
-        }
-        if (median.getSampleCount() < MIN_SAMPLE_COUNT) return null;
-        if (median.getDeposit().getQ3() == null) return null;
-        return median;
     }
 
     private BudgetMetrics calcBudgetMetrics(HousingCondition candidate, RentMedianResponse median,

--- a/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
@@ -1,7 +1,6 @@
 package com.team.independence.goal.service.algorithm;
 
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
-import com.team.independence.asset.service.AssetSummaryService;
 import com.team.independence.goal.dto.AlgorithmType;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
@@ -76,7 +75,6 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
     /** 보증금 필터 미지정 시 사용할 상한(원). 사실상 무제한. */
     private static final long DEPOSIT_MAX_DEFAULT = 100_000_000_000L;
 
-    private final AssetSummaryService assetSummaryService;
     private final RentMedianService rentMedianService;
     private final LoanPlanCalculator loanPlanCalculator;
     private final BudgetCalculator budgetCalculator;
@@ -84,18 +82,15 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
 
     @Override
     public Optional<GoalRecommendationResponse.RecommendationItem> recommend(
-            long memberId, GoalRecommendationRequest request) {
+            long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx) {
 
         YearMonth targetDate = request.getTargetDate() != null
                 ? request.getTargetDate()
                 : YearMonth.now().plusMonths(DEFAULT_TARGET_MONTHS);
         long targetMonths = RecommendationAlgorithm.monthsUntil(targetDate);
 
-        // DSR 차감: 기존 대출 월상환액을 제외한 실질 저축 여력
-        AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
-        long rawMonthlySaving = assetSummaryService.getMonthlySavingsOrZero(memberId);
-        long loanPayment      = loanPlanCalculator.calcTotalExistingMonthlyPayment(memberId);
-        long effectiveSaving  = Math.max(0, rawMonthlySaving - loanPayment);
+        AssetNetWorthBreakdown netWorth = ctx.netWorth();
+        long effectiveSaving  = ctx.effectiveSaving();
 
         HousingType housingType = request.getPropertyType() != null
                 ? request.getPropertyType() : DEFAULT_HOUSING_TYPE;

--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -1,7 +1,6 @@
 package com.team.independence.goal.service.algorithm;
 
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
-import com.team.independence.asset.service.AssetSummaryService;
 import com.team.independence.goal.dto.AlgorithmType;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
@@ -19,6 +18,7 @@ import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.mapper.RegionMapper;
 import com.team.independence.property.service.RentMedianService;
 import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -125,6 +125,10 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
     /** 보증금 필터 미지정 시 사용할 상한(원). 사실상 무제한. */
     private static final long DEPOSIT_MAX_DEFAULT = 100_000_000_000L;
 
+    /** RentMedianServiceImpl과 동일한 집계 구간 */
+    private static final int MONTHS = 6;
+    private static final DateTimeFormatter YM = DateTimeFormatter.ofPattern("yyyyMM");
+
     /**
      * 월세를 목돈으로 환산할 때 쓰는 연 이자율.
      *
@@ -133,7 +137,6 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
      */
     private static final double ANNUAL_INTEREST_RATE = 0.05;
 
-    private final AssetSummaryService assetSummaryService;
     private final RentMedianService rentMedianService;
     private final RegionMapper regionMapper;
     private final LoanPlanCalculator loanPlanCalculator;
@@ -142,15 +145,13 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
 
     @Override
     public Optional<GoalRecommendationResponse.RecommendationItem> recommend(
-            long memberId, GoalRecommendationRequest request) {
+            long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx) {
 
         YearMonth targetDate = resolveTargetDate(request);
         long desiredMonths = RecommendationAlgorithm.monthsUntil(targetDate);
 
-        AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
-        long rawMonthlySaving = assetSummaryService.getMonthlySavingsOrZero(memberId);
-        long loanPayment      = loanPlanCalculator.calcTotalExistingMonthlyPayment(memberId);
-        long effectiveSaving  = Math.max(0, rawMonthlySaving - loanPayment);
+        AssetNetWorthBreakdown netWorth = ctx.netWorth();
+        long effectiveSaving  = ctx.effectiveSaving();
 
         Search search = new Search(memberId, netWorth, effectiveSaving, desiredMonths);
 
@@ -162,11 +163,17 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
             return Optional.empty();
         }
 
+        // 시군구 확정 후 (주거유형, 거래유형, 평수) 40개 조합을 bulk 1회 쿼리로 선조회
+        YearMonth now = YearMonth.now();
+        String endYm   = now.format(YM);
+        String startYm = now.minusMonths(MONTHS - 1).format(YM);
+        Map<String, RentMedianResponse> bulkMedians = rentMedianService.getBulkMedian(regionCode, startYm, endYm);
+
         // 2단계: 사용자가 준 조건을 지킨 채, 주지 않은 항목만 움직여 본다
         long depositMin = request.getDepositMin() != null ? request.getDepositMin() : 0L;
         long depositMax = request.getDepositMax() != null ? request.getDepositMax() : DEPOSIT_MAX_DEFAULT;
 
-        List<Candidate> asRequested = evaluateConditions(regionCode, request, search, true);
+        List<Candidate> asRequested = evaluateConditions(regionCode, request, search, true, bulkMedians);
         Optional<Candidate> keepingInput = bestWithinTarget(asRequested);
         if (keepingInput.isPresent()) {
             return Optional.of(assemble(memberId, keepingInput.get(), targetDate, desiredMonths, false, search, depositMin, depositMax));
@@ -175,7 +182,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         // 3단계: 입력한 조건으로는 목표 시점을 못 지킨다. 그때만 조건을 풀고 다시 찾는다.
         // 준 조건이 하나도 없으면 1차가 이미 전 범위 탐색이라 다시 조회하지 않는다.
         List<Candidate> relaxed = hasInputCondition(request)
-                ? evaluateConditions(regionCode, request, search, false)
+                ? evaluateConditions(regionCode, request, search, false, bulkMedians)
                 : asRequested;
         if (relaxed.isEmpty()) {
             log.warn("실거래 표본이 있는 조합이 없습니다. memberId={}, regionCode={}", memberId, regionCode);
@@ -291,13 +298,14 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
      *                  false면 사용자가 준 항목까지 전부 펼친다.
      */
     private List<Candidate> evaluateConditions(
-            String regionCode, GoalRecommendationRequest request, Search search, boolean keepInput) {
+            String regionCode, GoalRecommendationRequest request, Search search, boolean keepInput,
+            Map<String, RentMedianResponse> bulkMedians) {
 
         List<Candidate> candidates = new ArrayList<>();
         for (int[] size : sizeCandidates(request, keepInput)) {
             for (HousingType housingType : housingTypeCandidates(request, keepInput)) {
                 for (DealType dealType : dealTypeCandidates(request, keepInput)) {
-                    evaluate(regionCode, housingType, dealType, size[0], size[1], request, search)
+                    evaluate(regionCode, housingType, dealType, size[0], size[1], request, search, bulkMedians)
                             .ifPresent(candidates::add);
                 }
             }
@@ -357,6 +365,14 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         return new int[]{request.getSizeMin(), request.getSizeMax()};
     }
 
+    /** SIZE_BUCKETS에 정의된 표준 범위인지 확인. 비표준 범위는 bulk 맵에 없으므로 개별 쿼리가 필요하다. */
+    private boolean isBucketRange(int areaMin, int areaMax) {
+        for (int[] bucket : SIZE_BUCKETS) {
+            if (bucket[0] == areaMin && bucket[1] == areaMax) return true;
+        }
+        return false;
+    }
+
     // ===== 후보 평가 =====
 
     /**
@@ -368,31 +384,39 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
      */
     private Optional<Candidate> evaluate(
             String regionCode, HousingType housingType, DealType dealType,
-            int areaMin, int areaMax, GoalRecommendationRequest request, Search search) {
+            int areaMin, int areaMax, GoalRecommendationRequest request, Search search,
+            Map<String, RentMedianResponse> bulkMedians) {
 
         String key = regionCode + "|" + housingType + "|" + dealType + "|" + areaMin + "|" + areaMax;
         Optional<Candidate> cached = search.evaluated.get(key);
         if (cached != null) {
             return cached;
         }
-        Optional<Candidate> result = lookUp(regionCode, housingType, dealType, areaMin, areaMax, request, search);
+        Optional<Candidate> result = lookUp(regionCode, housingType, dealType, areaMin, areaMax, request, search, bulkMedians);
         search.evaluated.put(key, result);
         return result;
     }
 
     private Optional<Candidate> lookUp(
             String regionCode, HousingType housingType, DealType dealType,
-            int areaMin, int areaMax, GoalRecommendationRequest request, Search search) {
+            int areaMin, int areaMax, GoalRecommendationRequest request, Search search,
+            Map<String, RentMedianResponse> bulkMedians) {
 
-        RentMedianResponse median;
-        try {
-            median = rentMedianService.getMedian(
-                    buildMedianRequest(regionCode, housingType, dealType, areaMin, areaMax, request));
-        } catch (RuntimeException e) {
-            // 지역 코드 오류 등으로 한 조합이 실패해도 나머지 탐색은 계속한다.
-            log.debug("실거래 조회 실패로 조합을 건너뜁니다. regionCode={}, housingType={}, dealType={}",
-                    regionCode, housingType, dealType, e);
-            return Optional.empty();
+        // SIZE_BUCKETS 범위이면 bulk 맵에서 바로 꺼낸다.
+        // 사용자 지정 범위이거나 bulk 결과가 없으면 개별 쿼리로 폴백한다.
+        RentMedianResponse median = isBucketRange(areaMin, areaMax)
+                ? bulkMedians.get(housingType + "|" + dealType + "|" + areaMin)
+                : null;
+
+        if (median == null) {
+            try {
+                median = rentMedianService.getMedian(
+                        buildMedianRequest(regionCode, housingType, dealType, areaMin, areaMax, request));
+            } catch (RuntimeException e) {
+                log.debug("실거래 조회 실패로 조합을 건너뜁니다. regionCode={}, housingType={}, dealType={}",
+                        regionCode, housingType, dealType, e);
+                return Optional.empty();
+            }
         }
 
         if (median.getSampleCount() < MIN_SAMPLE_COUNT || median.getDeposit().getMedian() == null) {

--- a/src/main/java/com/team/independence/property/dto/BulkMedianResult.java
+++ b/src/main/java/com/team/independence/property/dto/BulkMedianResult.java
@@ -1,0 +1,21 @@
+package com.team.independence.property.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import lombok.Data;
+
+/** findBulkMedian 쿼리 결과 DTO — (주거유형, 거래유형, 평수 버킷)별 분위값 1행. */
+@Data
+public class BulkMedianResult {
+    private HousingType housingType;
+    private DealType dealType;
+    private int areaMin;
+    private int areaMax;
+    private Long depositQ1;
+    private Long depositQ2;
+    private Long depositQ3;
+    private Long rentQ1;
+    private Long rentQ2;
+    private Long rentQ3;
+    private int sampleCount;
+}

--- a/src/main/java/com/team/independence/property/dto/MedianAggResult.java
+++ b/src/main/java/com/team/independence/property/dto/MedianAggResult.java
@@ -1,0 +1,16 @@
+package com.team.independence.property.dto;
+
+import lombok.Data;
+
+/** findAggregatedMedian 쿼리 결과 DTO — SQL 윈도우 함수로 계산한 분위값 1행. */
+@Data
+public class MedianAggResult {
+    private Long depositQ1;
+    private Long depositQ2;
+    private Long depositQ3;
+    private Long rentQ1;
+    private Long rentQ2;
+    private Long rentQ3;
+    /** 집계에 사용된 실거래 건수. 해당 조건의 데이터가 없으면 null. */
+    private Integer sampleCount;
+}

--- a/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
+++ b/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
@@ -4,7 +4,8 @@ import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.domain.RentTransaction;
 import com.team.independence.property.dto.MonthlyPricePoint;
-import com.team.independence.property.dto.RentMedianAmount;
+import com.team.independence.property.dto.BulkMedianResult;
+import com.team.independence.property.dto.MedianAggResult;
 import com.team.independence.property.dto.RentMedianRequest;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
@@ -21,17 +22,25 @@ public interface RentTransactionMapper {
                      @Param("housingType") HousingType housingType);
 
     /**
-     * 분위값 계산용 금액 목록. 조건에 맞는 거래가 없으면 빈 리스트를 반환한다.
-     * 정렬은 보증금·월세를 각각 따로 해야 하므로 SQL에서 하지 않는다.
+     * SQL 윈도우 함수로 분위값을 계산해 1행으로 반환한다.
+     * 조건에 맞는 거래가 없으면 sampleCount=null 인 결과 1행을 반환한다.
      *
      * @param areaMinSqm 요청의 평수를 ㎡로 환산한 하한 (버림)
      * @param areaMaxSqm 요청의 평수를 ㎡로 환산한 상한 (버림)
      */
-    List<RentMedianAmount> findAmountsForMedian(@Param("request") RentMedianRequest request,
-                                                @Param("areaMinSqm") long areaMinSqm,
-                                                @Param("areaMaxSqm") long areaMaxSqm,
-                                                @Param("startYm") String startYm,
-                                                @Param("endYm") String endYm);
+    MedianAggResult findAggregatedMedian(@Param("request") RentMedianRequest request,
+                                         @Param("areaMinSqm") long areaMinSqm,
+                                         @Param("areaMaxSqm") long areaMaxSqm,
+                                         @Param("startYm") String startYm,
+                                         @Param("endYm") String endYm);
+
+    /**
+     * HoldOut 알고리즘 전용. 지역·기간 조건만 받아 (주거유형, 거래유형, 평수 버킷)별
+     * 분위값을 한 번의 쿼리로 반환한다. 최대 40행(4유형 × 2거래 × 5버킷).
+     */
+    List<BulkMedianResult> findBulkMedian(@Param("regionCode") String regionCode,
+                                           @Param("startYm") String startYm,
+                                           @Param("endYm") String endYm);
 
     /** 가격 모델(μ, σ) 산출용 월별 (거래연월, 보증금, 면적) 목록. 보증금 0 제외 */
     List<MonthlyPricePoint> findAmountsForPriceModel(@Param("regionCode") String regionCode,

--- a/src/main/java/com/team/independence/property/service/RentMedianService.java
+++ b/src/main/java/com/team/independence/property/service/RentMedianService.java
@@ -2,6 +2,7 @@ package com.team.independence.property.service;
 
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
+import java.util.Map;
 
 public interface RentMedianService {
 
@@ -11,4 +12,13 @@ public interface RentMedianService {
      * @throws com.team.independence.common.exception.BusinessException 지역 코드가 존재하지 않으면
      */
     RentMedianResponse getMedian(RentMedianRequest request);
+
+    /**
+     * HoldOut 알고리즘 전용. 지역·기간만 받아 (주거유형, 거래유형, 평수 버킷)별 분위값을
+     * 한 번의 쿼리로 조회한다.
+     *
+     * @return 키: "{HousingType}|{DealType}|{areaMin평}" 형식의 맵
+     * @throws com.team.independence.common.exception.BusinessException 지역 코드가 존재하지 않으면
+     */
+    Map<String, RentMedianResponse> getBulkMedian(String regionCode, String startYm, String endYm);
 }

--- a/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
@@ -2,7 +2,8 @@ package com.team.independence.property.service;
 
 import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
-import com.team.independence.property.dto.RentMedianAmount;
+import com.team.independence.property.dto.BulkMedianResult;
+import com.team.independence.property.dto.MedianAggResult;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.dto.RentMedianResponse.Quartile;
@@ -10,8 +11,9 @@ import com.team.independence.property.mapper.RegionMapper;
 import com.team.independence.property.mapper.RentTransactionMapper;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 import java.util.List;
-import java.util.function.ToLongFunction;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,12 +46,16 @@ public class RentMedianServiceImpl implements RentMedianService {
         String startYm = start.format(YM);
         String endYm = end.format(YM);
 
-        List<RentMedianAmount> amounts = rentTransactionMapper.findAmountsForMedian(
+        MedianAggResult agg = rentTransactionMapper.findAggregatedMedian(
                 request,
                 toSqm(request.getAreaMin()),
                 toSqm(request.getAreaMax()),
                 startYm,
                 endYm);
+
+        if (agg == null || agg.getSampleCount() == null || agg.getSampleCount() == 0) {
+            return emptyResponse(request.getRegionCode(), regionName, request, startYm, endYm);
+        }
 
         return RentMedianResponse.builder()
                 .regionCode(request.getRegionCode())
@@ -58,55 +64,70 @@ public class RentMedianServiceImpl implements RentMedianService {
                 .dealType(request.getDealType())
                 .baseStartYm(startYm)
                 .baseEndYm(endYm)
-                .sampleCount(amounts.size())
-                .deposit(quartile(amounts, RentMedianAmount::getDeposit))
-                // 전세는 월세가 0으로 적재되어 분위값이 전부 0이 되므로 계산하지 않는다.
-                .monthlyRent(request.usesMonthlyRentFilter()
-                        ? quartile(amounts, RentMedianAmount::getMonthlyRent)
+                .sampleCount(agg.getSampleCount())
+                .deposit(Quartile.of(agg.getDepositQ1(), agg.getDepositQ2(), agg.getDepositQ3()))
+                .monthlyRent(request.usesMonthlyRentFilter() && agg.getRentQ2() != null
+                        ? Quartile.of(agg.getRentQ1(), agg.getRentQ2(), agg.getRentQ3())
                         : Quartile.empty())
                 .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, RentMedianResponse> getBulkMedian(String regionCode, String startYm, String endYm) {
+        String regionName = resolveRegionName(regionCode);
+        if (regionName == null) {
+            throw new BusinessException(ErrorCode.REGION_NOT_FOUND);
+        }
+
+        List<BulkMedianResult> rows = rentTransactionMapper.findBulkMedian(regionCode, startYm, endYm);
+        Map<String, RentMedianResponse> result = new HashMap<>();
+        for (BulkMedianResult r : rows) {
+            String key = r.getHousingType() + "|" + r.getDealType() + "|" + r.getAreaMin();
+            RentMedianResponse response = RentMedianResponse.builder()
+                    .regionCode(regionCode)
+                    .regionName(regionName)
+                    .housingType(r.getHousingType())
+                    .dealType(r.getDealType())
+                    .baseStartYm(startYm)
+                    .baseEndYm(endYm)
+                    .sampleCount(r.getSampleCount())
+                    .deposit(Quartile.of(r.getDepositQ1(), r.getDepositQ2(), r.getDepositQ3()))
+                    .monthlyRent(r.getRentQ2() != null
+                            ? Quartile.of(r.getRentQ1(), r.getRentQ2(), r.getRentQ3())
+                            : Quartile.empty())
+                    .build();
+            result.put(key, response);
+        }
+        return result;
     }
 
     /** 시도 코드 길이(법정동코드 앞 2자리). 이보다 길면 시군구 코드다. */
     private static final int SIDO_CODE_LENGTH = 2;
 
-    /**
-     * 지역 코드에 해당하는 지명을 찾는다. 없으면 null.
-     *
-     * <p>시군구(5자리)는 그 지역의 전체 지명을, 시도(2자리)는 시도명을 돌려준다.
-     * 시도로 조회하면 그 시도의 시군구 실거래를 모두 한 통에 넣고 집계하므로,
-     * 결과는 "어느 구"가 아니라 "그 시도 전체"의 대표값이 된다.
-     */
     private String resolveRegionName(String regionCode) {
         if (regionCode != null && regionCode.length() == SIDO_CODE_LENGTH) {
             return regionMapper.findSidoNameByPrefix(regionCode);
         }
-        // full_name은 NOT NULL이므로 null이면 그 지역 코드가 없다는 뜻이다.
         return regionMapper.findFullNameByCode(regionCode);
     }
 
-    /** 평수를 ㎡로 환산한다. 양쪽 모두 버림이라 하한은 넓어지고 상한은 좁아지는데, 명세서가 정한 규칙이다. */
     private long toSqm(int pyeong) {
         return (long) Math.floor(pyeong * PYEONG_TO_SQM);
     }
 
-    private Quartile quartile(List<RentMedianAmount> amounts, ToLongFunction<RentMedianAmount> amount) {
-        if (amounts.isEmpty()) {
-            return Quartile.empty();
-        }
-        long[] sorted = amounts.stream().mapToLong(amount).sorted().toArray();
-        return Quartile.of(
-                percentile(sorted, 0.25),
-                percentile(sorted, 0.50),
-                percentile(sorted, 0.75));
-    }
-
-    /**
-     * nearest-rank 방식. 보간하지 않으므로 결과가 항상 실제 거래 금액이고,
-     * 표본이 한 자릿수인 조건(단독다가구·비수도권)에서도 값이 왜곡되지 않는다.
-     */
-    private long percentile(long[] sorted, double ratio) {
-        int index = (int) Math.ceil(ratio * sorted.length) - 1;
-        return sorted[Math.max(index, 0)];
+    private RentMedianResponse emptyResponse(String regionCode, String regionName,
+            RentMedianRequest request, String startYm, String endYm) {
+        return RentMedianResponse.builder()
+                .regionCode(regionCode)
+                .regionName(regionName)
+                .housingType(request.getHousingType())
+                .dealType(request.getDealType())
+                .baseStartYm(startYm)
+                .baseEndYm(endYm)
+                .sampleCount(0)
+                .deposit(Quartile.empty())
+                .monthlyRent(Quartile.empty())
+                .build();
     }
 }

--- a/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
+++ b/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
@@ -54,33 +54,123 @@
          ORDER BY deal_ym
     </select>
 
-    <!-- 분위값 계산용 금액 조회. 집계는 애플리케이션에서 하므로 원본 금액만 뽑는다.
-         deposit = 0 은 보증금 없이 기록된 이상치라 집계에서 제외한다. -->
-    <select id="findAmountsForMedian" resultType="com.team.independence.property.dto.RentMedianAmount">
-        SELECT deposit, monthly_rent
-          FROM rent_transaction
-        <!-- 지역 코드가 시도 2자리면 그 시도의 시군구 전체를 한 통에 넣고 집계한다.
-             region_code가 idx_rent_reload의 최좌측이라 프리픽스도 레인지 스캔으로 처리된다. -->
-        <choose>
-            <when test="request.regionCode.length() == 2">
-         WHERE region_code LIKE CONCAT(#{request.regionCode}, '%')
-            </when>
-            <otherwise>
-         WHERE region_code = #{request.regionCode}
-            </otherwise>
-        </choose>
-           AND housing_type = #{request.housingType}
-           AND deal_type = #{request.dealType}
-           AND deal_ym BETWEEN #{startYm} AND #{endYm}
-           AND area BETWEEN #{areaMinSqm} AND #{areaMaxSqm}
-           AND deposit BETWEEN #{request.depositMin} AND #{request.depositMax}
-           AND deposit &gt; 0
-        <if test="request.usesMonthlyRentFilter() and request.monthlyRentMin != null">
-           AND monthly_rent &gt;= #{request.monthlyRentMin}
-        </if>
-        <if test="request.usesMonthlyRentFilter() and request.monthlyRentMax != null">
-           AND monthly_rent &lt;= #{request.monthlyRentMax}
-        </if>
+    <!-- MySQL 8.0 윈도우 함수로 분위값을 DB에서 직접 계산해 1행으로 반환한다.
+         deposit = 0 이상치 제외. 조건에 맞는 데이터가 없으면 sampleCount=null인 1행이 반환된다. -->
+    <select id="findAggregatedMedian" resultType="com.team.independence.property.dto.MedianAggResult">
+        SELECT
+            MAX(CASE WHEN dep_rn  = CEIL(0.25 * total) THEN deposit      END) AS deposit_q1,
+            MAX(CASE WHEN dep_rn  = CEIL(0.50 * total) THEN deposit      END) AS deposit_q2,
+            MAX(CASE WHEN dep_rn  = CEIL(0.75 * total) THEN deposit      END) AS deposit_q3,
+            MAX(CASE WHEN rent_rn = CEIL(0.25 * total) THEN monthly_rent END) AS rent_q1,
+            MAX(CASE WHEN rent_rn = CEIL(0.50 * total) THEN monthly_rent END) AS rent_q2,
+            MAX(CASE WHEN rent_rn = CEIL(0.75 * total) THEN monthly_rent END) AS rent_q3,
+            MAX(total) AS sample_count
+        FROM (
+            SELECT deposit, monthly_rent,
+                   ROW_NUMBER() OVER (ORDER BY deposit)      AS dep_rn,
+                   ROW_NUMBER() OVER (ORDER BY monthly_rent) AS rent_rn,
+                   COUNT(*)     OVER ()                      AS total
+              FROM rent_transaction
+            <choose>
+                <when test="request.regionCode.length() == 2">
+             WHERE region_code LIKE CONCAT(#{request.regionCode}, '%')
+                </when>
+                <otherwise>
+             WHERE region_code = #{request.regionCode}
+                </otherwise>
+            </choose>
+               AND housing_type = #{request.housingType}
+               AND deal_type    = #{request.dealType}
+               AND deal_ym      BETWEEN #{startYm} AND #{endYm}
+               AND area         BETWEEN #{areaMinSqm} AND #{areaMaxSqm}
+               AND deposit      BETWEEN #{request.depositMin} AND #{request.depositMax}
+               AND deposit &gt; 0
+            <if test="request.usesMonthlyRentFilter() and request.monthlyRentMin != null">
+               AND monthly_rent &gt;= #{request.monthlyRentMin}
+            </if>
+            <if test="request.usesMonthlyRentFilter() and request.monthlyRentMax != null">
+               AND monthly_rent &lt;= #{request.monthlyRentMax}
+            </if>
+        ) t
+    </select>
+
+    <!-- HoldOut 전용 bulk 쿼리. 지역·기간만 받아 (주거유형, 거래유형, 평수버킷)별 분위값을 한 번에 반환.
+         평수 버킷 경계(평 → ㎡ floor 환산): 4p=13, 9p=29 / 10p=33, 14p=46 / 15p=49, 19p=62
+                                              20p=66, 25p=82 / 26p=85, 40p=132
+         버킷 사이 공백(area 30-32, 47-48, 63-65, 83-84)은 WHERE 절에서 제외한다. -->
+    <select id="findBulkMedian" resultType="com.team.independence.property.dto.BulkMedianResult">
+        SELECT
+            housing_type,
+            deal_type,
+            bucket_min AS area_min,
+            CASE bucket_min
+                WHEN 4  THEN 9  WHEN 10 THEN 14 WHEN 15 THEN 19
+                WHEN 20 THEN 25 WHEN 26 THEN 40
+            END AS area_max,
+            MAX(CASE WHEN dep_rn  = CEIL(0.25 * total) THEN deposit      END) AS deposit_q1,
+            MAX(CASE WHEN dep_rn  = CEIL(0.50 * total) THEN deposit      END) AS deposit_q2,
+            MAX(CASE WHEN dep_rn  = CEIL(0.75 * total) THEN deposit      END) AS deposit_q3,
+            MAX(CASE WHEN rent_rn = CEIL(0.25 * total) THEN monthly_rent END) AS rent_q1,
+            MAX(CASE WHEN rent_rn = CEIL(0.50 * total) THEN monthly_rent END) AS rent_q2,
+            MAX(CASE WHEN rent_rn = CEIL(0.75 * total) THEN monthly_rent END) AS rent_q3,
+            MAX(total) AS sample_count
+        FROM (
+            SELECT
+                housing_type, deal_type, deposit, monthly_rent,
+                CASE
+                    WHEN area BETWEEN 13 AND 29  THEN 4
+                    WHEN area BETWEEN 33 AND 46  THEN 10
+                    WHEN area BETWEEN 49 AND 62  THEN 15
+                    WHEN area BETWEEN 66 AND 82  THEN 20
+                    WHEN area BETWEEN 85 AND 132 THEN 26
+                END AS bucket_min,
+                ROW_NUMBER() OVER (
+                    PARTITION BY housing_type, deal_type,
+                        CASE WHEN area BETWEEN 13 AND 29  THEN 4
+                             WHEN area BETWEEN 33 AND 46  THEN 10
+                             WHEN area BETWEEN 49 AND 62  THEN 15
+                             WHEN area BETWEEN 66 AND 82  THEN 20
+                             WHEN area BETWEEN 85 AND 132 THEN 26
+                        END
+                    ORDER BY deposit
+                ) AS dep_rn,
+                ROW_NUMBER() OVER (
+                    PARTITION BY housing_type, deal_type,
+                        CASE WHEN area BETWEEN 13 AND 29  THEN 4
+                             WHEN area BETWEEN 33 AND 46  THEN 10
+                             WHEN area BETWEEN 49 AND 62  THEN 15
+                             WHEN area BETWEEN 66 AND 82  THEN 20
+                             WHEN area BETWEEN 85 AND 132 THEN 26
+                        END
+                    ORDER BY monthly_rent
+                ) AS rent_rn,
+                COUNT(*) OVER (
+                    PARTITION BY housing_type, deal_type,
+                        CASE WHEN area BETWEEN 13 AND 29  THEN 4
+                             WHEN area BETWEEN 33 AND 46  THEN 10
+                             WHEN area BETWEEN 49 AND 62  THEN 15
+                             WHEN area BETWEEN 66 AND 82  THEN 20
+                             WHEN area BETWEEN 85 AND 132 THEN 26
+                        END
+                ) AS total
+              FROM rent_transaction
+            <choose>
+                <when test="regionCode.length() == 2">
+             WHERE region_code LIKE CONCAT(#{regionCode}, '%')
+                </when>
+                <otherwise>
+             WHERE region_code = #{regionCode}
+                </otherwise>
+            </choose>
+               AND deposit &gt; 0
+               AND deal_ym BETWEEN #{startYm} AND #{endYm}
+               AND (   area BETWEEN 13 AND 29
+                    OR area BETWEEN 33 AND 46
+                    OR area BETWEEN 49 AND 62
+                    OR area BETWEEN 66 AND 82
+                    OR area BETWEEN 85 AND 132)
+        ) t
+        GROUP BY housing_type, deal_type, bucket_min
     </select>
 
 </mapper>

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmIntegrationTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmIntegrationTest.java
@@ -1,8 +1,12 @@
 package com.team.independence.goal.service.algorithm;
 
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import com.team.independence.asset.service.AssetSummaryService;
 import com.team.independence.config.RootConfig;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
+import com.team.independence.goal.service.RecommendationAlgorithm.MemberFinancialContext;
+import com.team.independence.goal.service.calculator.LoanPlanCalculator;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import org.junit.jupiter.api.Disabled;
@@ -39,6 +43,17 @@ class HoldOutAlgorithmIntegrationTest {
 
     @Autowired
     private HoldOutAlgorithm holdOutAlgorithm;
+    @Autowired
+    private AssetSummaryService assetSummaryService;
+    @Autowired
+    private LoanPlanCalculator loanPlanCalculator;
+
+    private MemberFinancialContext buildCtx(long memberId) {
+        AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
+        long monthlySaving = assetSummaryService.getMonthlySavingsOrZero(memberId);
+        long loanPayment = loanPlanCalculator.calcTotalExistingMonthlyPayment(memberId);
+        return new MemberFinancialContext(netWorth, monthlySaving, loanPayment);
+    }
 
     /**
      * request에 조건을 직접 넣어서 실행.
@@ -55,7 +70,7 @@ class HoldOutAlgorithmIntegrationTest {
         request.setTargetDate(YearMonth.now().plusMonths(24)); // n=24개월 기준
 
         Optional<GoalRecommendationResponse.RecommendationItem> result =
-                holdOutAlgorithm.recommend(TEST_MEMBER_ID, request);
+                holdOutAlgorithm.recommend(TEST_MEMBER_ID, request, buildCtx(TEST_MEMBER_ID));
 
         System.out.println("=== HoldOut 결과 ===");
         if (result.isPresent()) {
@@ -88,7 +103,7 @@ class HoldOutAlgorithmIntegrationTest {
         // 조건 미입력 → active goal의 housing 조건 사용
 
         Optional<GoalRecommendationResponse.RecommendationItem> result =
-                holdOutAlgorithm.recommend(TEST_MEMBER_ID, request);
+                holdOutAlgorithm.recommend(TEST_MEMBER_ID, request, buildCtx(TEST_MEMBER_ID));
 
         System.out.println("=== HoldOut (goal fallback) 결과 ===");
         if (result.isPresent()) {

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
@@ -20,7 +21,6 @@ import com.team.independence.goal.service.calculator.LoanPlanCalculator;
 import com.team.independence.property.dto.PriceModelRequest;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
-import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.dto.RentMedianResponse.Quartile;
 import com.team.independence.property.service.RentMedianService;
@@ -98,7 +98,8 @@ class HoldOutAlgorithmTest {
         when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(null);
         when(loanPlanCalculator.calculate(anyLong(), anyLong(), any()))
                 .thenReturn(LoanPlans.builder().build());
-        when(rentMedianService.getMedian(any())).thenAnswer(call -> toResponse(call.getArgument(0)));
+        when(rentMedianService.getBulkMedian(anyString(), anyString(), anyString()))
+                .thenAnswer(call -> toBulkMap(call.getArgument(0)));
     }
 
     // ===== DSR 차감 관련 =====
@@ -326,31 +327,32 @@ class HoldOutAlgorithmTest {
     }
 
     /**
-     * market에 등록된 조합은 표본 15건으로 응답한다.
-     * HoldOut은 Q3(75분위)를 사용하므로 Q3를 등록한 값으로 설정한다.
-     * 미등록 조합은 표본 0건(MIN_SAMPLE_COUNT 미달)으로 응답해 자연스럽게 필터된다.
+     * market에서 regionCode에 해당하는 항목만 골라 getBulkMedian 반환 형식의 맵으로 변환한다.
+     * 키: "{HousingType}|{DealType}|{areaMin평}" — HoldOutAlgorithm.buildPool과 동일한 형식.
      */
-    private RentMedianResponse toResponse(RentMedianRequest request) {
-        long[] found = market.get(key(request.getRegionCode(), request.getHousingType(),
-                request.getDealType(), request.getAreaMin()));
-
-        RentMedianResponse.RentMedianResponseBuilder builder = RentMedianResponse.builder()
-                .regionCode(request.getRegionCode())
-                .regionName("테스트구")
-                .housingType(request.getHousingType())
-                .dealType(request.getDealType());
-
-        if (found == null) {
-            return builder.sampleCount(0).deposit(Quartile.empty()).monthlyRent(Quartile.empty()).build();
+    private Map<String, RentMedianResponse> toBulkMap(String regionCode) {
+        Map<String, RentMedianResponse> bulk = new HashMap<>();
+        for (Map.Entry<String, long[]> entry : market.entrySet()) {
+            String[] parts = entry.getKey().split("\\|");
+            if (!parts[0].equals(regionCode)) continue;
+            HousingType ht = HousingType.valueOf(parts[1]);
+            DealType dt = DealType.valueOf(parts[2]);
+            int areaMin = Integer.parseInt(parts[3]);
+            long[] vals = entry.getValue();
+            long q3Deposit = vals[0];
+            long q3MonthlyRent = vals[1];
+            bulk.put(ht + "|" + dt + "|" + areaMin, RentMedianResponse.builder()
+                    .regionCode(regionCode)
+                    .regionName("테스트구")
+                    .housingType(ht)
+                    .dealType(dt)
+                    .sampleCount(15)
+                    .deposit(Quartile.of(q3Deposit * 8 / 10, q3Deposit * 9 / 10, q3Deposit))
+                    .monthlyRent(q3MonthlyRent > 0
+                            ? Quartile.of(q3MonthlyRent * 8 / 10, q3MonthlyRent * 9 / 10, q3MonthlyRent)
+                            : Quartile.empty())
+                    .build());
         }
-        long q3Deposit = found[0];
-        long q3MonthlyRent = found[1];
-        return builder
-                .sampleCount(15)
-                .deposit(Quartile.of(q3Deposit * 8 / 10, q3Deposit * 9 / 10, q3Deposit))
-                .monthlyRent(q3MonthlyRent > 0
-                        ? Quartile.of(q3MonthlyRent * 8 / 10, q3MonthlyRent * 9 / 10, q3MonthlyRent)
-                        : Quartile.empty())
-                .build();
+        return bulk;
     }
 }

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
@@ -7,9 +7,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
-
-import com.team.independence.asset.service.AssetSummaryService;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
+import com.team.independence.goal.service.RecommendationAlgorithm.MemberFinancialContext;
 import com.team.independence.goal.dto.GoalRecommendationResponse.RecommendationItem;
 import com.team.independence.goal.dto.LoanPlans;
 import com.team.independence.goal.mapper.GoalHousingMapper;
@@ -63,13 +62,14 @@ class HoldOutAlgorithmTest {
     @Mock private LoanPlanCalculator loanPlanCalculator;
     @Mock private GoalMapper goalMapper;
     @Mock private GoalHousingMapper goalHousingMapper;
-    @Mock private AssetSummaryService assetSummaryService;
     @Mock private RentMedianService rentMedianService;
     @Mock private MonteCarloService monteCarloService;
 
     private final BudgetCalculator budgetCalculator = new BudgetCalculator();
 
     private HoldOutAlgorithm algorithm;
+    private AssetNetWorthBreakdown defaultNetWorth;
+    private MemberFinancialContext ctx;
 
     /** "regionCode|주거유형|거래유형|최소평수" → {Q3 보증금, Q3 월세} */
     private Map<String, long[]> market;
@@ -78,7 +78,7 @@ class HoldOutAlgorithmTest {
     void setUp() {
         algorithm = new HoldOutAlgorithm(
                 loanPlanCalculator, budgetCalculator, goalMapper, goalHousingMapper,
-                assetSummaryService, rentMedianService, monteCarloService);
+                rentMedianService, monteCarloService);
 
         when(monteCarloService.simulate(any(PriceModelRequest.class), anyLong(), anyLong(), anyInt()))
                 .thenAnswer(call -> {
@@ -90,14 +90,12 @@ class HoldOutAlgorithmTest {
                 });
         market = new HashMap<>();
 
+        defaultNetWorth = AssetNetWorthBreakdown.builder()
+                .interestBearingAssets(0L)
+                .flatRecognizedAssets(0L)
+                .build();
+        ctx = new MemberFinancialContext(defaultNetWorth, 10_000_000L, 0L);
         when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(null);
-        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(
-                AssetNetWorthBreakdown.builder()
-                        .interestBearingAssets(0L)
-                        .flatRecognizedAssets(0L)
-                        .build());
-        when(assetSummaryService.getMonthlySavingsOrZero(MEMBER_ID)).thenReturn(10_000_000L);
-        when(loanPlanCalculator.calcTotalExistingMonthlyPayment(MEMBER_ID)).thenReturn(0L);
         when(loanPlanCalculator.calculate(anyLong(), anyLong(), any()))
                 .thenReturn(LoanPlans.builder().build());
         when(rentMedianService.getMedian(any())).thenAnswer(call -> toResponse(call.getArgument(0)));
@@ -112,7 +110,7 @@ class HoldOutAlgorithmTest {
         // 요청: 20~25평 → 업그레이드 버킷인 26~40평(areaMin=26 > areaMax=25)만 허용
         put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"));
+        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
         assertThat(result).isPresent();
         assertThat(result.get().getCondition().getAreaMin()).isEqualTo(26);
@@ -123,10 +121,10 @@ class HoldOutAlgorithmTest {
     void deductsExistingLoanPaymentFromSaving() {
         // 월저축 1천만, 대출 월상환 900만 → baseSaving 100만
         // 2억을 100만/월로 모으면 ~169개월 → PATIENCE_BONUS(48) 초과 → soft-fail
-        when(loanPlanCalculator.calcTotalExistingMonthlyPayment(MEMBER_ID)).thenReturn(9_000_000L);
+        MemberFinancialContext ctx = ctxWithLoan(9_000_000L);
         put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"));
+        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
         assertThat(result).isPresent();
         assertThat(result.get().getCondition()).isNull();
@@ -138,7 +136,7 @@ class HoldOutAlgorithmTest {
         // 월저축 1천만, 대출 월상환 500만 → baseSaving 500만
         // 월세 Q3 = 450만 → effectiveSaving 50만
         // 1억 보증금을 50만/월로 모으면 ~180개월 → PATIENCE_BONUS(48) 초과 → 추천 없음
-        when(loanPlanCalculator.calcTotalExistingMonthlyPayment(MEMBER_ID)).thenReturn(5_000_000L);
+        MemberFinancialContext ctx = ctxWithLoan(5_000_000L);
         put("11110", HousingType.APT, DealType.WOLSE, 26, 40, 1 * 억, 450 * 만);
 
         GoalRecommendationRequest request = new GoalRecommendationRequest();
@@ -149,7 +147,7 @@ class HoldOutAlgorithmTest {
         request.setSizeMax(25);
         request.setTargetDate(NOW);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request);
+        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
 
         assertThat(result).isPresent();
         assertThat(result.get().getCondition()).isNull();
@@ -159,10 +157,10 @@ class HoldOutAlgorithmTest {
     @DisplayName("대출 월상환액이 월저축액보다 커도 저축액이 음수가 되지 않는다")
     void clipsNegativeSavingToZero() {
         // 대출 1500만 > 저축 1000만 → baseSaving = 0 → 현재 자산(0원)으로 2억 도달 불가 → soft-fail
-        when(loanPlanCalculator.calcTotalExistingMonthlyPayment(MEMBER_ID)).thenReturn(15_000_000L);
+        MemberFinancialContext ctx = ctxWithLoan(15_000_000L);
         put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"));
+        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
         assertThat(result).isPresent();
         assertThat(result.get().getCondition()).isNull();
@@ -171,7 +169,7 @@ class HoldOutAlgorithmTest {
     @Test
     @DisplayName("시장 데이터가 없으면 soft-fail 카드를 반환한다")
     void returnsEmptyWhenNoMarketData() {
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"));
+        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
         assertThat(result).isPresent();
         assertThat(result.get().getCondition()).isNull();
@@ -186,7 +184,7 @@ class HoldOutAlgorithmTest {
         put("11110", HousingType.APT, DealType.JEONSE, 15, 19, 2 * 억, 0);
         put("11110", HousingType.APT, DealType.JEONSE, 20, 25, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"));
+        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
         assertThat(result).isPresent();
         assertThat(result.get().getCondition()).isNull();
@@ -198,7 +196,7 @@ class HoldOutAlgorithmTest {
         // 요청 sizeMax=25 → 26~40(areaMin=26 > 25)만 허용
         put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"));
+        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
         assertThat(result).isPresent();
         assertThat(result.get().getCondition().getAreaMin()).isEqualTo(26);
@@ -217,7 +215,7 @@ class HoldOutAlgorithmTest {
         request.setTradeType(DealType.JEONSE);
         request.setTargetDate(NOW);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request);
+        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
 
         assertThat(result).isPresent();
         assertThat(result.get().getCondition().getAreaMin()).isEqualTo(15);
@@ -231,7 +229,7 @@ class HoldOutAlgorithmTest {
         // 11110(종로구)에는 데이터 없고 11(서울)에만 26~40평 데이터 있음
         put("11", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"));
+        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
         assertThat(result).isPresent();
         assertThat(result.get().getCondition().getRegionCode()).isEqualTo("11");
@@ -244,7 +242,7 @@ class HoldOutAlgorithmTest {
         put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
         put("11",    HousingType.APT, DealType.JEONSE, 26, 40, 1 * 억, 0); // 더 저렴하지만 탐색 안 됨
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"));
+        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
         assertThat(result).isPresent();
         assertThat(result.get().getCondition().getRegionCode()).isEqualTo("11110");
@@ -264,7 +262,7 @@ class HoldOutAlgorithmTest {
         request.setSizeMax(25);
         request.setTargetDate(NOW);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request);
+        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
 
         assertThat(result).isPresent();
         assertThat(result.get().getCondition()).isNull();
@@ -284,7 +282,7 @@ class HoldOutAlgorithmTest {
         request.setSizeMin(20);
         request.setSizeMax(25);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request);
+        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
 
         assertThat(result).isPresent();
         assertThat(result.get().getReason()).contains("저축하면").contains("26~40평");
@@ -295,13 +293,17 @@ class HoldOutAlgorithmTest {
     void reasonMentionsOriginalRegionWhenExpanded() {
         put("11", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"));
+        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
         assertThat(result).isPresent();
         assertThat(result.get().getReason()).contains("요청하신 지역");
     }
 
     // ===== 헬퍼 =====
+
+    private MemberFinancialContext ctxWithLoan(long loanPayment) {
+        return new MemberFinancialContext(defaultNetWorth, 10_000_000L, loanPayment);
+    }
 
     private GoalRecommendationRequest aptJeonseRequest(String regionCode) {
         GoalRecommendationRequest request = new GoalRecommendationRequest();

--- a/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
@@ -9,8 +9,9 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.team.independence.asset.service.AssetSummaryService;
+import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
 import com.team.independence.goal.dto.AlgorithmType;
+import com.team.independence.goal.service.RecommendationAlgorithm.MemberFinancialContext;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse.RecommendationItem;
 import com.team.independence.goal.dto.LoanPlans;
@@ -49,8 +50,6 @@ class PreferenceAlgorithmTest {
     private static final long 만 = 10_000L;
 
     @Mock
-    private AssetSummaryService assetSummaryService;
-    @Mock
     private RentMedianService rentMedianService;
     @Mock
     private LoanPlanCalculator loanPlanCalculator;
@@ -60,14 +59,21 @@ class PreferenceAlgorithmTest {
     private MonteCarloService monteCarloService;
 
     private PreferenceAlgorithm algorithm;
+    private AssetNetWorthBreakdown defaultNetWorth;
+    private MemberFinancialContext ctx;
 
     /** 실제로 나간 실거래 조회 조건 */
     private List<RentMedianRequest> asked;
 
     @BeforeEach
     void setUp() {
-        algorithm = new PreferenceAlgorithm(assetSummaryService, rentMedianService, loanPlanCalculator, budgetCalculator, monteCarloService);
+        algorithm = new PreferenceAlgorithm(rentMedianService, loanPlanCalculator, budgetCalculator, monteCarloService);
         asked = new ArrayList<>();
+        defaultNetWorth = AssetNetWorthBreakdown.builder()
+                .interestBearingAssets(0L)
+                .flatRecognizedAssets(0L)
+                .build();
+        ctx = new MemberFinancialContext(defaultNetWorth, 10_000_000L, 0L);
 
         when(loanPlanCalculator.calculate(anyLong(), anyLong(), any()))
                 .thenReturn(LoanPlans.builder().build());
@@ -166,7 +172,7 @@ class PreferenceAlgorithmTest {
     void returnsEmptyWhenNoTransaction() {
         stubMedian(0, 0, 0);
 
-        assertThat(algorithm.recommend(MEMBER_ID, request("11110"))).isEmpty();
+        assertThat(algorithm.recommend(MEMBER_ID, request("11110"), ctx)).isEmpty();
     }
 
     @Test
@@ -174,13 +180,13 @@ class PreferenceAlgorithmTest {
     void returnsEmptyWhenLookUpFails() {
         doThrow(new IllegalStateException("조회 실패")).when(rentMedianService).getMedian(any());
 
-        assertThat(algorithm.recommend(MEMBER_ID, request("11110"))).isEmpty();
+        assertThat(algorithm.recommend(MEMBER_ID, request("11110"), ctx)).isEmpty();
     }
 
     // ===== 헬퍼 =====
 
     private RecommendationItem recommend(GoalRecommendationRequest request) {
-        return algorithm.recommend(MEMBER_ID, request)
+        return algorithm.recommend(MEMBER_ID, request, ctx)
                 .orElseThrow(() -> new AssertionError("추천 결과가 비어 있습니다"));
     }
 

--- a/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
@@ -10,8 +10,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
-import com.team.independence.asset.service.AssetSummaryService;
 import com.team.independence.goal.dto.AlgorithmType;
+import com.team.independence.goal.service.RecommendationAlgorithm.MemberFinancialContext;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse.RecommendationItem;
 import com.team.independence.goal.dto.LoanPlans;
@@ -61,8 +61,6 @@ class RealisticAlgorithmTest {
     private static final long 만 = 10_000L;
 
     @Mock
-    private AssetSummaryService assetSummaryService;
-    @Mock
     private RentMedianService rentMedianService;
     @Mock
     private RegionMapper regionMapper;
@@ -74,6 +72,8 @@ class RealisticAlgorithmTest {
     private MonteCarloService monteCarloService;
 
     private RealisticAlgorithm algorithm;
+    private AssetNetWorthBreakdown defaultNetWorth;
+    private MemberFinancialContext ctx;
 
     /** "지역|주거유형|거래유형|최소평수" → {보증금, 월세, 표본수} */
     private Map<String, long[]> market;
@@ -84,20 +84,16 @@ class RealisticAlgorithmTest {
     @BeforeEach
     void setUp() {
         algorithm = new RealisticAlgorithm(
-                assetSummaryService, rentMedianService, regionMapper, loanPlanCalculator,
+                rentMedianService, regionMapper, loanPlanCalculator,
                 budgetCalculator, monteCarloService);
         market = new HashMap<>();
         lookedUp = new ArrayList<>();
 
-        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(
-                AssetNetWorthBreakdown.builder()
-                        .interestBearingAssets(0L)
-                        .flatRecognizedAssets(0L)
-                        .build());
-        when(assetSummaryService.getMonthlySavingsOrZero(MEMBER_ID)).thenReturn(MONTHLY_SAVING);
-
-        // 기존 대출 없음 → effectiveSaving = rawMonthlySaving
-        when(loanPlanCalculator.calcTotalExistingMonthlyPayment(MEMBER_ID)).thenReturn(0L);
+        defaultNetWorth = AssetNetWorthBreakdown.builder()
+                .interestBearingAssets(0L)
+                .flatRecognizedAssets(0L)
+                .build();
+        ctx = new MemberFinancialContext(defaultNetWorth, MONTHLY_SAVING, 0L);
 
         // MC: 가격 변화 없음으로 스텁. 선택 로직이 가려지지 않게 priceP50 = initialPrice 반환.
         when(monteCarloService.simulate(any(PriceModelRequest.class), anyLong(), anyLong(), anyInt()))
@@ -159,9 +155,10 @@ class RealisticAlgorithmTest {
         put("11110", HousingType.APT, DealType.JEONSE, 4, 5000 * 만, 0);
 
         // 월 저축 2천만 → 예산 4.8억. 이제 3억짜리도 들어온다.
-        when(assetSummaryService.getMonthlySavingsOrZero(MEMBER_ID)).thenReturn(20_000_000L);
-
-        RecommendationItem item = recommend(request("11110", HousingType.APT, DealType.JEONSE));
+        RecommendationItem item = algorithm.recommend(MEMBER_ID,
+                request("11110", HousingType.APT, DealType.JEONSE),
+                new MemberFinancialContext(defaultNetWorth, 20_000_000L, 0L))
+                .orElseThrow(() -> new AssertionError("추천 결과가 비어 있습니다"));
 
         assertThat(item.getCondition().getAreaMin()).isEqualTo(20);
     }
@@ -262,10 +259,12 @@ class RealisticAlgorithmTest {
     @Test
     @DisplayName("월 저축액이 등록되지 않았으면 도달 불가로 흘러간다")
     void treatsMissingMonthlySavingAsZero() {
-        when(assetSummaryService.getMonthlySavingsOrZero(MEMBER_ID)).thenReturn(0L);
         put("11110", HousingType.APT, DealType.JEONSE, 15, 2 * 억, 0);
 
-        RecommendationItem item = recommend(request("11110", HousingType.APT, DealType.JEONSE));
+        RecommendationItem item = algorithm.recommend(MEMBER_ID,
+                request("11110", HousingType.APT, DealType.JEONSE),
+                new MemberFinancialContext(defaultNetWorth, 0L, 0L))
+                .orElseThrow(() -> new AssertionError("추천 결과가 비어 있습니다"));
 
         assertThat(item.getReason()).contains("도달하기 어렵습니다");
     }
@@ -344,7 +343,7 @@ class RealisticAlgorithmTest {
     @DisplayName("실거래 표본이 아무 조합에도 없으면 추천하지 않는다")
     void returnsEmptyWhenNoMarketData() {
         Optional<RecommendationItem> result = algorithm.recommend(
-                MEMBER_ID, request("11110", HousingType.APT, DealType.JEONSE));
+                MEMBER_ID, request("11110", HousingType.APT, DealType.JEONSE), ctx);
 
         assertThat(result).isEmpty();
     }
@@ -352,7 +351,7 @@ class RealisticAlgorithmTest {
     // ===== 헬퍼 =====
 
     private RecommendationItem recommend(GoalRecommendationRequest request) {
-        return algorithm.recommend(MEMBER_ID, request)
+        return algorithm.recommend(MEMBER_ID, request, ctx)
                 .orElseThrow(() -> new AssertionError("추천 결과가 비어 있습니다"));
     }
 

--- a/src/test/java/com/team/independence/property/service/RentMedianIntegrationTest.java
+++ b/src/test/java/com/team/independence/property/service/RentMedianIntegrationTest.java
@@ -5,11 +5,10 @@ import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.config.RootConfig;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
-import com.team.independence.property.dto.RentMedianAmount;
+import com.team.independence.property.dto.MedianAggResult;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.mapper.RentTransactionMapper;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -68,30 +67,32 @@ class RentMedianIntegrationTest {
      */
     @Test
     void 전세_금액_조회() {
-        List<RentMedianAmount> amounts = rentTransactionMapper.findAmountsForMedian(
+        MedianAggResult agg = rentTransactionMapper.findAggregatedMedian(
                 request(DealType.JEONSE, null, null),
                 AREA_MIN_SQM, AREA_MAX_SQM, DEAL_YM, DEAL_YM);
 
-        System.out.println("전세 조회 건수: " + amounts.size());
-        assertFalse(amounts.isEmpty(), "전세 실거래가 조회되지 않았습니다.");
+        System.out.println("전세 조회 건수: " + agg.getSampleCount());
+        assertNotNull(agg, "집계 결과가 null입니다.");
+        assertTrue(agg.getSampleCount() != null && agg.getSampleCount() > 0, "전세 실거래가 조회되지 않았습니다.");
         assertAll(
-                () -> assertTrue(amounts.stream().allMatch(a -> a.getDeposit() > 0),
+                () -> assertTrue(agg.getDepositQ2() != null && agg.getDepositQ2() > 0,
                         "deposit > 0 필터가 동작하지 않았습니다."),
-                () -> assertTrue(amounts.stream().allMatch(a -> a.getMonthlyRent() == 0),
-                        "전세인데 월세가 0이 아닌 행이 있습니다."));
+                () -> assertTrue(agg.getRentQ2() == null || agg.getRentQ2() == 0,
+                        "전세인데 월세 중앙값이 0이 아닙니다."));
     }
 
-    /** 월세 조건 <if> 분기와 monthly_rent → monthlyRent 매핑을 함께 확인한다. */
+    /** 월세 조건 <if> 분기와 monthly_rent → rentQ2 매핑을 함께 확인한다. */
     @Test
     void 월세_금액_조회() {
-        List<RentMedianAmount> amounts = rentTransactionMapper.findAmountsForMedian(
+        MedianAggResult agg = rentTransactionMapper.findAggregatedMedian(
                 request(DealType.WOLSE, MONTHLY_RENT_MIN, MONTHLY_RENT_MAX),
                 AREA_MIN_SQM, AREA_MAX_SQM, DEAL_YM, DEAL_YM);
 
-        System.out.println("월세 조회 건수: " + amounts.size());
-        assertFalse(amounts.isEmpty(), "월세 실거래가 조회되지 않았습니다.");
-        assertTrue(amounts.stream().allMatch(a -> a.getMonthlyRent() > 0),
-                "월세 거래인데 monthly_rent가 0인 행이 있습니다. 매핑이나 필터를 확인하세요.");
+        System.out.println("월세 조회 건수: " + agg.getSampleCount());
+        assertNotNull(agg, "집계 결과가 null입니다.");
+        assertTrue(agg.getSampleCount() != null && agg.getSampleCount() > 0, "월세 실거래가 조회되지 않았습니다.");
+        assertTrue(agg.getRentQ2() != null && agg.getRentQ2() > 0,
+                "월세 중앙값이 0 이하입니다. 매핑이나 필터를 확인하세요.");
     }
 
     /** 없는 지역 코드는 조회 전에 PROPERTY_001로 끊긴다. */


### PR DESCRIPTION
## #️⃣연관된 이슈

- #122 

## 📝작업 내용

`/api/v1/goals/recommendations` 호출 시 발생하던 불필요한 DB 쿼리를 세 가지 방향으로 줄였습니다.

---

### 1. DB 윈도우 함수로 분위값 집계 이전

**변경 전**  
`findAmountsForMedian`이 조건에 해당하는 모든 행을 애플리케이션으로 전송 → JVM에서 정렬 후 분위값 계산

**변경 후**  
`findAggregatedMedian`이 `ROW_NUMBER()` 윈도우 함수로 Q1·Q2·Q3를 DB에서 직접 계산해 **1행**만 반환

```sql
SELECT
    MAX(CASE WHEN dep_rn = CEIL(0.25 * total) THEN deposit END) AS deposit_q1,
    MAX(CASE WHEN dep_rn = CEIL(0.50 * total) THEN deposit END) AS deposit_q2,
    MAX(CASE WHEN dep_rn = CEIL(0.75 * total) THEN deposit END) AS deposit_q3,
    MAX(total) AS sample_count
FROM (
    SELECT deposit,
           ROW_NUMBER() OVER (ORDER BY deposit) AS dep_rn,
           COUNT(*)     OVER ()                 AS total
    FROM rent_transaction WHERE ...
) t
```

추가로 `findBulkMedian` 쿼리를 추가해 **(주거유형 4 × 거래유형 2 × 평수버킷 5) = 최대 40개 조합**을 단 1회 쿼리로 조회할 수 있도록 했습니다.

---

### 2. 알고리즘 재무 컨텍스트 공유 및 bulk 시세 조회 적용

**변경 전**  
HoldOut·Preference·Realistic 세 알고리즘이 각자 `getNetWorthBreakdown`, `getMonthlySavingsOrZero`, `calcTotalExistingMonthlyPayment`를 독립적으로 호출 → 동일 회원 정보를 3배 중복 조회  
시세 조회도 조합마다 `getMedian()` 개별 호출

**변경 후**  
- `RecommendationAlgorithm` 인터페이스에 `MemberFinancialContext` record 추가  
  → 상위 서비스에서 **1회만 조회** 후 세 알고리즘에 주입
- HoldOut·Realistic은 지역 확정 후 `getBulkMedian()`으로 **bulk 1회 조회** → 맵에서 O(1) 조회로 대체
- Preference는 단일 시세 조회이므로 컨텍스트 공유만 적용

---

### 3. 추천 알고리즘 병렬 실행

**변경 전**  
세 알고리즘을 순차(직렬) 실행

**변경 후**  
`CompletableFuture` + 전용 `algorithmExecutor`(core=3, max=6, queue=20)로 **병렬** 실행  
결과는 알고리즘 등록 순서 보존

```java
// algorithmExecutor bean (RootConfig)
executor.setCorePoolSize(3);
executor.setMaxPoolSize(6);
executor.setQueueCapacity(20);
executor.setThreadNamePrefix("algo-rec-");
```

`lombok.config`에 `@Qualifier`를 copyable annotation으로 추가해 `@RequiredArgsConstructor`와 함께 생성자 주입이 동작하도록 했습니다.

---

### 스크린샷 (선택)

<img width="849" height="29" alt="image" src="https://github.com/user-attachments/assets/ca868dff-3c72-4b6b-a343-872bc71f2ea9" />

<img width="556" height="67" alt="image" src="https://github.com/user-attachments/assets/5dfd6c84-38b0-45be-9630-988de11bb1d2" />

## 💬리뷰 요구사항(선택)