### PR TITLE
fix: 실거래 배치 수집 기간 6개월 → 36개월 (PriceModel 요구사항 반영)

### DIFF
--- a/src/main/java/com/team/independence/property/service/RentTransactionSyncServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/RentTransactionSyncServiceImpl.java
@@ -53,7 +53,7 @@ public class RentTransactionSyncServiceImpl implements RentTransactionSyncServic
     private static final DateTimeFormatter DEAL_YM = DateTimeFormatter.ofPattern("yyyyMM");
 
     /** 수집 대상 기간(개월). 이보다 오래된 구간은 순회하지 않을 뿐, 이미 쌓인 데이터는 그대로 둔다. */
-    private static final int TARGET_MONTHS = 6;
+    private static final int TARGET_MONTHS = 36;
 
     /**
      * 이력과 무관하게 항상 재수집하는 최근 기간(개월).


### PR DESCRIPTION
## #️⃣연관된 이슈

#124

## 📝작업 내용

`PriceModelService`는 36개월치 실거래 데이터로 가격 모델(drift·volatility)을 추정하지만, 배치 수집 기간(`TARGET_MONTHS`)이 6개월로 설정되어 있어 데이터가 부족해 정상 동작하지 않았습니다.

`RentTransactionSyncServiceImpl.TARGET_MONTHS`를 6 → 36으로 변경합니다.

- 이미 성공적으로 수집된 월은 `isCollected` 체크로 건너뛰므로 중복 수집 없음
- PR 머지 후 EC2 배치 서버 재기동 시 스케줄러가 즉시 실행되어 나머지 30개월치 적재

## 💬리뷰 요구사항(선택)

36개월치 초기 적재는 국토부 API 호출량이 많아 배치 완료까지 상당 시간이 소요될 수 있습니다.