### PR TITLE
perf: rent_transaction 복합 인덱스 추가로 추천 알고리즘 쿼리 성능 개선

### DIFF
--- a/sql/full_schema.sql
+++ b/sql/full_schema.sql
@@ -106,6 +106,7 @@ CREATE TABLE rent_transaction (
     -- (지역, 연월, 유형) 단위 재적재 시 DELETE 대상을 구간으로 좁힌다.
     -- 최좌측 프리픽스가 region_code라 fk_rent_region의 인덱스 요건도 함께 충족.
     KEY idx_rent_reload (region_code, deal_ym, housing_type),
+    KEY idx_rent_query  (region_code, housing_type, deal_type, deal_ym),
     CONSTRAINT fk_rent_region FOREIGN KEY (region_code) REFERENCES region (code)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='실거래 전월세(4종 통합)';
 

--- a/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
+++ b/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
@@ -35,12 +35,15 @@ public interface RentTransactionMapper {
                                          @Param("endYm") String endYm);
 
     /**
-     * HoldOut 알고리즘 전용. 지역·기간 조건만 받아 (주거유형, 거래유형, 평수 버킷)별
-     * 분위값을 한 번의 쿼리로 반환한다. 최대 40행(4유형 × 2거래 × 5버킷).
+     * 지역·기간·주거유형·거래유형을 받아 평수버킷별 분위값을 반환한다. 최대 5행(5버킷).
+     * getBulkMedian에서 8개 조합(4유형 × 2거래)을 순회하며 호출한다.
+     * housing_type, deal_type를 WHERE에 고정해 idx_rent_query 인덱스를 탄다.
      */
-    List<BulkMedianResult> findBulkMedian(@Param("regionCode") String regionCode,
-                                           @Param("startYm") String startYm,
-                                           @Param("endYm") String endYm);
+    List<BulkMedianResult> findBulkMedianByType(@Param("regionCode") String regionCode,
+                                                @Param("housingType") HousingType housingType,
+                                                @Param("dealType") DealType dealType,
+                                                @Param("startYm") String startYm,
+                                                @Param("endYm") String endYm);
 
     /** 가격 모델(μ, σ) 산출용 월별 (거래연월, 보증금, 면적) 목록. 보증금 0 제외 */
     List<MonthlyPricePoint> findAmountsForPriceModel(@Param("regionCode") String regionCode,

--- a/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
@@ -2,6 +2,8 @@ package com.team.independence.property.service;
 
 import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.dto.BulkMedianResult;
 import com.team.independence.property.dto.MedianAggResult;
 import com.team.independence.property.dto.RentMedianRequest;
@@ -80,24 +82,31 @@ public class RentMedianServiceImpl implements RentMedianService {
             throw new BusinessException(ErrorCode.REGION_NOT_FOUND);
         }
 
-        List<BulkMedianResult> rows = rentTransactionMapper.findBulkMedian(regionCode, startYm, endYm);
+        // (주거유형, 거래유형) 조합별로 개별 쿼리를 실행해 idx_rent_query 인덱스를 탄다.
+        // 단일 bulk 쿼리 대비 처리 행 수가 1/8로 줄어 윈도우 함수 비용이 크게 감소한다.
         Map<String, RentMedianResponse> result = new HashMap<>();
-        for (BulkMedianResult r : rows) {
-            String key = r.getHousingType() + "|" + r.getDealType() + "|" + r.getAreaMin();
-            RentMedianResponse response = RentMedianResponse.builder()
-                    .regionCode(regionCode)
-                    .regionName(regionName)
-                    .housingType(r.getHousingType())
-                    .dealType(r.getDealType())
-                    .baseStartYm(startYm)
-                    .baseEndYm(endYm)
-                    .sampleCount(r.getSampleCount())
-                    .deposit(Quartile.of(r.getDepositQ1(), r.getDepositQ2(), r.getDepositQ3()))
-                    .monthlyRent(r.getRentQ2() != null
-                            ? Quartile.of(r.getRentQ1(), r.getRentQ2(), r.getRentQ3())
-                            : Quartile.empty())
-                    .build();
-            result.put(key, response);
+        for (HousingType housingType : HousingType.values()) {
+            for (DealType dealType : DealType.values()) {
+                List<BulkMedianResult> rows = rentTransactionMapper.findBulkMedianByType(
+                        regionCode, housingType, dealType, startYm, endYm);
+                for (BulkMedianResult r : rows) {
+                    String key = housingType + "|" + dealType + "|" + r.getAreaMin();
+                    RentMedianResponse response = RentMedianResponse.builder()
+                            .regionCode(regionCode)
+                            .regionName(regionName)
+                            .housingType(housingType)
+                            .dealType(dealType)
+                            .baseStartYm(startYm)
+                            .baseEndYm(endYm)
+                            .sampleCount(r.getSampleCount())
+                            .deposit(Quartile.of(r.getDepositQ1(), r.getDepositQ2(), r.getDepositQ3()))
+                            .monthlyRent(r.getRentQ2() != null
+                                    ? Quartile.of(r.getRentQ1(), r.getRentQ2(), r.getRentQ3())
+                                    : Quartile.empty())
+                            .build();
+                    result.put(key, response);
+                }
+            }
         }
         return result;
     }

--- a/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
+++ b/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
@@ -94,15 +94,16 @@
         ) t
     </select>
 
-    <!-- HoldOut 전용 bulk 쿼리. 지역·기간만 받아 (주거유형, 거래유형, 평수버킷)별 분위값을 한 번에 반환.
+    <!-- bulk 쿼리. 지역·기간·주거유형·거래유형을 받아 평수버킷별 분위값을 반환.
+         housing_type, deal_type를 WHERE에 추가해 idx_rent_query 인덱스를 타도록 한다.
          평수 버킷 경계(평 → ㎡ floor 환산): 4p=13, 9p=29 / 10p=33, 14p=46 / 15p=49, 19p=62
                                               20p=66, 25p=82 / 26p=85, 40p=132
          버킷 사이 공백(area 30-32, 47-48, 63-65, 83-84)은 WHERE 절에서 제외한다. -->
-    <select id="findBulkMedian" resultType="com.team.independence.property.dto.BulkMedianResult">
+    <select id="findBulkMedianByType" resultType="com.team.independence.property.dto.BulkMedianResult">
         SELECT
-            housing_type,
-            deal_type,
-            bucket_min AS area_min,
+            #{housingType}  AS housing_type,
+            #{dealType}     AS deal_type,
+            bucket_min      AS area_min,
             CASE bucket_min
                 WHEN 4  THEN 9  WHEN 10 THEN 14 WHEN 15 THEN 19
                 WHEN 20 THEN 25 WHEN 26 THEN 40
@@ -116,7 +117,7 @@
             MAX(total) AS sample_count
         FROM (
             SELECT
-                housing_type, deal_type, deposit, monthly_rent,
+                deposit, monthly_rent,
                 CASE
                     WHEN area BETWEEN 13 AND 29  THEN 4
                     WHEN area BETWEEN 33 AND 46  THEN 10
@@ -125,7 +126,7 @@
                     WHEN area BETWEEN 85 AND 132 THEN 26
                 END AS bucket_min,
                 ROW_NUMBER() OVER (
-                    PARTITION BY housing_type, deal_type,
+                    PARTITION BY
                         CASE WHEN area BETWEEN 13 AND 29  THEN 4
                              WHEN area BETWEEN 33 AND 46  THEN 10
                              WHEN area BETWEEN 49 AND 62  THEN 15
@@ -135,7 +136,7 @@
                     ORDER BY deposit
                 ) AS dep_rn,
                 ROW_NUMBER() OVER (
-                    PARTITION BY housing_type, deal_type,
+                    PARTITION BY
                         CASE WHEN area BETWEEN 13 AND 29  THEN 4
                              WHEN area BETWEEN 33 AND 46  THEN 10
                              WHEN area BETWEEN 49 AND 62  THEN 15
@@ -145,7 +146,7 @@
                     ORDER BY monthly_rent
                 ) AS rent_rn,
                 COUNT(*) OVER (
-                    PARTITION BY housing_type, deal_type,
+                    PARTITION BY
                         CASE WHEN area BETWEEN 13 AND 29  THEN 4
                              WHEN area BETWEEN 33 AND 46  THEN 10
                              WHEN area BETWEEN 49 AND 62  THEN 15
@@ -162,6 +163,8 @@
              WHERE region_code = #{regionCode}
                 </otherwise>
             </choose>
+               AND housing_type = #{housingType}
+               AND deal_type    = #{dealType}
                AND deposit &gt; 0
                AND deal_ym BETWEEN #{startYm} AND #{endYm}
                AND (   area BETWEEN 13 AND 29
@@ -170,7 +173,7 @@
                     OR area BETWEEN 66 AND 82
                     OR area BETWEEN 85 AND 132)
         ) t
-        GROUP BY housing_type, deal_type, bucket_min
+        GROUP BY bucket_min
     </select>
 
 </mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈

#126

## 📝작업 내용

`rent_transaction` 테이블에 복합 인덱스를 추가하고, `findBulkMedian` 쿼리를 타입별 8개 쿼리로 분리해 추천 알고리즘의 쿼리 성능을 개선했습니다.

### 문제

추천 알고리즘은 (주거유형 × 거래유형 × 평수버킷) 조합마다 아래 쿼리들을 실행한다.
- `findAmountsForPriceModel`: PriceModel(μ, σ) 산출용 36개월 시계열 조회
- `findAggregatedMedian`: 시세 중앙값 산출용 윈도우 함수 쿼리
- `findBulkMedian`: 시군구 확정 후 40개 조합 일괄 시세 조회

기존 인덱스 `idx_rent_reload (region_code, deal_ym, housing_type)` 는 `deal_ym` 이 range 조건이라 이후 컬럼이 실질적으로 미사용되고, `deal_type` 은 인덱스에 없어 행 단위 필터링이 발생했습니다.

또한 `findBulkMedian` 은 `housing_type`/`deal_type` 조건 없이 시군구 전체 수십만 행을 한 번에 읽고 40개 파티션으로 윈도우 함수를 처리해 37초가 소요됐습니다.

### 변경 내용

**1. 복합 인덱스 추가 (`full_schema.sql`)**

```sql
KEY idx_rent_query (region_code, housing_type, deal_type, deal_ym)
```

equality 3개(`region_code`, `housing_type`, `deal_type`) + range 1개(`deal_ym`) 구조로 `findAmountsForPriceModel`, `findAggregatedMedian` 두 쿼리 모두 최적 인덱스를 탑니다.

**2. `findBulkMedian` → `findBulkMedianByType` 분리 (`RentTransactionMapper.xml`, `RentTransactionMapper.java`)**

`housing_type`, `deal_type` 를 WHERE 조건에 추가해 `idx_rent_query` 인덱스를 타도록 변경했습니다. PARTITION BY 에서 `housing_type`, `deal_type` 를 제거하고(쿼리당 고정값), 처리 행 수를 1/8로 줄입니다.

**3. `getBulkMedian` 루프 변경 (`RentMedianServiceImpl.java`)**

단일 `findBulkMedian` 호출 → `HousingType` × `DealType` 8개 조합 루프로 `findBulkMedianByType` 호출

### 성능 측정 결과 (RDS 실측 / 5.7M 행 / 강남구)

**인덱스 추가 전후**

| 쿼리 | 인덱스 추가 전 | 인덱스 추가 후 | 개선율 |
|---|---|---|---|
| `findAmountsForPriceModel` | 1.13초 | 0.11초 | 90% |
| `findAggregatedMedian` | 1.22초 | 0.16초 | 87% |

**findBulkMedian 분리 전후**

| 쿼리 | 변경 전 | 변경 후 |
|---|---|---|
| `findBulkMedian` (전체 1회) | 37초 | — |
| `findBulkMedianByType` (조합 1개) | — | 1.38초 |
| 8개 조합 합산 | 37초 | ~11초 |

**추천 API 전체 응답 예상 (서울 전체 + 전체 조건 건너뜀)**

| 단계 | 개선 전 | 개선 후 |
|---|---|---|
| 시군구 순위 (25회) | ~30초 | ~4초 |
| getBulkMedian (8회) | 37초 | ~11초 |
| PriceModel + MC (40조합, 캐시 웜) | ~4초 | ~4초 |
| **합계** | **~79초+** | **~19초** |

> RDS 인덱스는 이미 직접 적용 완료했습니다. 이 PR은 `full_schema.sql` 동기화 및 쿼리 분리 코드 반영 목적입니다.

## 💬리뷰 요구사항(선택)

기존 `idx_rent_reload` 는 재적재 DELETE 쿼리 전용으로 유지한다. 새 인덱스와 역할이 다르므로 제거하지 않았다.