### PR TITLE
fix: `/api/v1/assets/organizations` isConnected 필드 직렬화 및 만료 기관 필터링 수정

### DIFF
--- a/src/main/java/com/team/independence/asset/dto/connection/OrganizationResponse.java
+++ b/src/main/java/com/team/independence/asset/dto/connection/OrganizationResponse.java
@@ -1,5 +1,6 @@
 package com.team.independence.asset.dto.connection;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.team.independence.asset.domain.codef.Institution;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,7 @@ public class OrganizationResponse {
     private String organizationName;
     private String businessType;
     private List<String> supportedLoginTypes;
+    @JsonProperty("isConnected")
     private boolean isConnected;
 
     public static OrganizationResponse from(Institution institution) {

--- a/src/main/resources/mybatis/mapper/asset/InstitutionMapper.xml
+++ b/src/main/resources/mybatis/mapper/asset/InstitutionMapper.xml
@@ -28,6 +28,7 @@
           FROM institution i
           LEFT JOIN connected_institution ci
             ON ci.institution_code = i.code
+           AND ci.status = 'ACTIVE'
            AND ci.connected_account_id = (
                  SELECT id FROM connected_account WHERE member_id = #{memberId}
                )


### PR DESCRIPTION
## #️⃣연관된 이슈

-  #129

## 📝작업 내용

### 버그 1 — `isConnected` JSON 키 이름 오류

`OrganizationResponse`의 `private boolean isConnected` 필드에 Lombok `@Getter`를 사용하면 `isConnected()` 메서드가 생성됩니다. Jackson은 `is` 접두사를 제거하여 응답 JSON 키를 `"connected"`로 직렬화하는 문제가 있었습니다.

`@JsonProperty("isConnected")`를 추가하여 응답 키가 `"isConnected"`로 정확히 내려오도록 수정했습니다.

### 버그 2 — 만료/오류 기관이 `isConnected: true`로 반환

`findAllActiveWithConnectionStatus` 쿼리의 LEFT JOIN에 `ci.status` 조건이 없어, `AUTH_EXPIRED` 또는 `ERROR` 상태인 기관도 `isConnected: true`로 반환되었습니다.

추가 연동 화면에서 프론트가 `isConnected: true` 기관을 숨기면, 재연동이 필요한 기관도 함께 숨겨지는 UX 문제가 발생합니다.

JOIN 조건에 `AND ci.status = 'ACTIVE'`를 추가하여 활성 연동 기관만 `isConnected: true`로 반환하도록 수정했습니다.

## 💬리뷰 요구사항(선택)