### PR TITLE
feat: 목표 추천 응답 스펙 정합 + PREFERENCE 카드 2분할 (#128)

### DIFF
--- a/src/main/java/com/team/independence/goal/dto/AlgorithmType.java
+++ b/src/main/java/com/team/independence/goal/dto/AlgorithmType.java
@@ -10,12 +10,12 @@ package com.team.independence.goal.dto;
  * 라벨을 붙이는 데 쓰인다.
  */
 public enum AlgorithmType {
-    /** 선호 우선 — 사용자가 입력한 조건에 그대로 부합하는 목표 */
-    PREFERENCE,
+    /** 선호 우선(저축 고정) — 입력한 조건 그대로, 월 저축액을 고정하고 도달 시점을 계산한 목표 */
+    PREFERENCE_SAVING_FIXED,
+    /** 선호 우선(시점 고정) — 입력한 조건 그대로, 목표 시점을 고정하고 필요한 월 저축액을 역산한 목표 */
+    PREFERENCE_DATE_FIXED,
     /** 현실 우선 — 소득·자산에 비추어 무리 없이 달성 가능한 목표 */
     REALISTIC,
-    /** 가성비 우선 — 같은 예산으로 더 나은 조건을 얻을 수 있는 목표 */
-    VALUE,
     /** 미래 가능성 우선 — 더 모은 뒤에 도달할 수 있는 더 좋은 목표 */
     HOLD_OUT
 }

--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationRequest.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationRequest.java
@@ -3,6 +3,7 @@ package com.team.independence.goal.dto;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import java.time.YearMonth;
+import org.springframework.format.annotation.DateTimeFormat;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -78,7 +79,8 @@ public class GoalRecommendationRequest {
     @PositiveOrZero(message = "최대 월세는 0 이상이어야 합니다.")
     private Long monthlyRentMax;
 
-    /** 선택. 목표 시점. null이면 알고리즘이 판단 */
+    /** 선택. 목표 시점(yyyy-MM). null이면 알고리즘이 판단 */
+    @DateTimeFormat(pattern = "yyyy-MM")
     private YearMonth targetDate;
 
     @AssertTrue(message = "최소 평수는 최대 평수보다 클 수 없습니다.")

--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationRequest.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationRequest.java
@@ -5,6 +5,7 @@ import com.team.independence.property.domain.HousingType;
 import java.time.YearMonth;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
@@ -36,6 +37,16 @@ public class GoalRecommendationRequest {
     @NotBlank(message = "지역 코드는 필수입니다.")
     @Pattern(regexp = "\\d{2}|\\d{5}", message = "지역 코드는 시도 2자리 또는 시군구 5자리여야 합니다.")
     private String regionCode;
+
+    /**
+     * 월 저축액(원). 필수.
+     *
+     * <p>예산 계산의 핵심 입력이라 사용자가 직접 넘긴다. 서버가 보관한 asset_summary 캐시가 아니라
+     * 이 값을 그대로 쓴다 — 추천 화면에서 사용자가 저축액을 조정해 시나리오를 보기 때문이다.
+     */
+    @NotNull(message = "월 저축액은 필수입니다.")
+    @PositiveOrZero(message = "월 저축액은 0 이상이어야 합니다.")
+    private Long monthlySavings;
 
     /** 선택. null이면 전 주거유형 탐색 */
     private HousingType propertyType;

--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
@@ -16,9 +16,6 @@ public class GoalRecommendationResponse {
     /** 사용자가 요청한 원래 희망 조건 — 세 추천 카드와 비교 기준으로 사용 */
     private OriginalPreference originalPreference;
 
-    /** 세 추천에 공통으로 사용된 재무 계산 기준 */
-    private FinancialContext financialContext;
-
     private List<RecommendationItem> recommendations;
 
     @Getter
@@ -50,25 +47,14 @@ public class GoalRecommendationResponse {
     @Getter
     @Builder
     @Jacksonized
-    public static class FinancialContext {
-        /** 현재 주거 목표 계산에 활용 가능한 자산(원) */
-        private long currentAvailableAmount;
-    }
-
-    @Getter
-    @Builder
-    @Jacksonized
     public static class RecommendationItem {
         /** 이 대안을 만든 추천 알고리즘 */
         private AlgorithmType type;
-        private String title;
-        private String reason;
         /**
          * 추천 주거 조건. 후보를 찾지 못한 경우 null.
          * 프론트엔드는 이 필드가 null인지 확인해 카드를 비활성 스타일로 표시한다.
          */
         private Condition condition;
-        private CalculationBasis calculationBasis;
         /** 대출 없는 플랜 */
         private LoanXPlan loanX;
         /** 대출 있는 플랜 */
@@ -107,19 +93,6 @@ public class GoalRecommendationResponse {
 
         /** 이 추천 조건의 실거래 중앙값(원). 플랜 계산의 기준이 된 시세. */
         private long marketMedianAmount;
-    }
-
-    @Getter
-    @Builder
-    @Jacksonized
-    public static class CalculationBasis {
-        /**
-         * 사용자가 설정한 목표 시점까지 준비 가능한 총 금액(원).
-         *
-         * <p>REALISTIC 타입만 값을 가진다. "이 금액에 맞는 조건을 찾았다"는 설명에 사용.
-         * PREFERENCE · HOLD_OUT은 이 방식으로 조건을 찾지 않으므로 null.
-         */
-        private Long reachableAmountAtTargetDate;
     }
 
     @Getter

--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
@@ -11,7 +11,6 @@ import com.team.independence.goal.service.RecommendationAlgorithm.MemberFinancia
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
 import com.team.independence.property.mapper.RegionMapper;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
@@ -63,10 +62,7 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
         long loanPayment   = loanPlanCalculator.calcTotalExistingMonthlyPayment(memberId);
         MemberFinancialContext ctx = new MemberFinancialContext(netWorth, monthlySaving, loanPayment);
 
-        long currentAvailableAmount = netWorth.getInterestBearingAssets()
-                + netWorth.getFlatRecognizedAssets();
-
-        List<CompletableFuture<Optional<GoalRecommendationResponse.RecommendationItem>>> futures =
+        List<CompletableFuture<List<GoalRecommendationResponse.RecommendationItem>>> futures =
                 algorithms.stream()
                         .map(algorithm -> CompletableFuture.supplyAsync(
                                 () -> runSafely(algorithm, memberId, request, ctx),
@@ -77,8 +73,7 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
 
         List<GoalRecommendationResponse.RecommendationItem> recommendations = futures.stream()
                 .map(CompletableFuture::join)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(List::stream)
                 .collect(Collectors.toList());
 
         if (recommendations.isEmpty()) {
@@ -87,9 +82,6 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
 
         GoalRecommendationResponse response = GoalRecommendationResponse.builder()
                 .originalPreference(buildOriginalPreference(request, monthlySaving))
-                .financialContext(GoalRecommendationResponse.FinancialContext.builder()
-                        .currentAvailableAmount(currentAvailableAmount)
-                        .build())
                 .recommendations(recommendations)
                 .build();
 
@@ -140,7 +132,7 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
      * <p>알고리즘들은 서로 독립적이라 하나의 오류가 전체 응답을 막을 이유가 없다.
      * 다만 모든 알고리즘이 실패하면 결과가 비어 {@code GOAL_RECOMMENDATION_NO_CANDIDATE}로 이어진다.
      */
-    private Optional<GoalRecommendationResponse.RecommendationItem> runSafely(
+    private List<GoalRecommendationResponse.RecommendationItem> runSafely(
             RecommendationAlgorithm algorithm, long memberId,
             GoalRecommendationRequest request, MemberFinancialContext ctx) {
         try {
@@ -148,7 +140,7 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
         } catch (Exception e) {
             log.error("추천 알고리즘 실행 실패. algorithm={}, memberId={}",
                     algorithm.getClass().getSimpleName(), memberId, e);
-            return Optional.empty();
+            return List.of();
         }
     }
 

--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
@@ -58,7 +58,8 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
         }
 
         AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
-        long monthlySaving = assetSummaryService.getMonthlySavingsOrZero(memberId);
+        // 월 저축액은 서버 캐시(asset_summary)가 아니라 요청 값을 그대로 쓴다 (@NotNull이라 항상 존재)
+        long monthlySaving = request.getMonthlySavings();
         long loanPayment   = loanPlanCalculator.calcTotalExistingMonthlyPayment(memberId);
         MemberFinancialContext ctx = new MemberFinancialContext(netWorth, monthlySaving, loanPayment);
 

--- a/src/main/java/com/team/independence/goal/service/RecommendationAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/RecommendationAlgorithm.java
@@ -8,7 +8,7 @@ import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.dto.PriceModelRequest;
 import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
-import java.util.Optional;
+import java.util.List;
 
 /**
  * 추천 알고리즘 하나. 구현체 하나가 곧 추천 카드 한 장을 만든다.
@@ -20,7 +20,9 @@ import java.util.Optional;
  * <p>지켜야 할 공통 계약은 두 가지뿐이다.
  * <ul>
  *   <li>입력: {@code memberId}와 {@link GoalRecommendationRequest}만 받는다</li>
- *   <li>출력: {@link GoalRecommendationResponse.RecommendationItem} 한 건을 만든다</li>
+ *   <li>출력: {@link GoalRecommendationResponse.RecommendationItem} 목록을 만든다.
+ *       보통 한 장이지만, 같은 조건을 다른 방식으로 계산한 여러 장을 낼 수도 있다
+ *       (예: PREFERENCE는 저축 고정·시점 고정 두 장). 낼 카드가 없으면 빈 목록</li>
  * </ul>
  *
  * <p>단, 응답의 loanX / loanO 플랜은 직접 계산하지 말고 반드시
@@ -41,10 +43,10 @@ import java.util.Optional;
  *     private final com.team.independence.goal.service.calculator.LoanPlanCalculator loanPlanCalculator;
  *     // 그 외 이 알고리즘에만 필요한 의존성은 자유롭게 추가
  *
- *     public Optional&lt;RecommendationItem&gt; recommend(long memberId, GoalRecommendationRequest req) {
+ *     public List&lt;RecommendationItem&gt; recommend(long memberId, GoalRecommendationRequest req) {
  *         // 1. 자기 방식대로 추천할 주거 조건과 목표 시점을 정한다
  *         // 2. loanPlanCalculator.calculate(memberId, 필요금액, 목표시점)으로 플랜 두 개를 받는다
- *         // 3. type(AlgorithmType.VALUE), title, reason, condition을 채워 조립한다
+ *         // 3. type, condition을 채워 조립해 List로 반환한다
  *     }
  * }
  * </pre>
@@ -77,16 +79,16 @@ public interface RecommendationAlgorithm {
     int[][] SIZE_BUCKETS = {{26, 40}, {20, 25}, {15, 19}, {10, 14}, {4, 9}};
 
     /**
-     * 회원과 요청 조건을 바탕으로 추천 대안 한 건을 만든다.
+     * 회원과 요청 조건을 바탕으로 추천 대안을 만든다.
      *
      * <p>결과의 {@code type}에는 이 알고리즘에 해당하는
      * {@link com.team.independence.goal.dto.AlgorithmType} 값을 채워야 한다.
      *
      * @param memberId 요청 회원 ID
      * @param request  추천 요청 파라미터
-     * @return 추천 대안. 제시할 만한 대안이 없으면 {@link Optional#empty()}
+     * @return 추천 대안 목록. 제시할 만한 대안이 없으면 빈 목록
      */
-    Optional<GoalRecommendationResponse.RecommendationItem> recommend(
+    List<GoalRecommendationResponse.RecommendationItem> recommend(
             long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx);
 
     static String label(HousingType housingType) {

--- a/src/main/java/com/team/independence/goal/service/RecommendationAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/RecommendationAlgorithm.java
@@ -45,7 +45,7 @@ import java.util.List;
  *
  *     public List&lt;RecommendationItem&gt; recommend(long memberId, GoalRecommendationRequest req) {
  *         // 1. 자기 방식대로 추천할 주거 조건과 목표 시점을 정한다
- *         // 2. loanPlanCalculator.calculate(memberId, 필요금액, 목표시점)으로 플랜 두 개를 받는다
+ *         // 2. loanPlanCalculator.calculate(memberId, 필요금액, 목표시점, 순저축액)으로 플랜 두 개를 받는다
  *         // 3. type, condition을 채워 조립해 List로 반환한다
  *     }
  * }

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * "더 기다리면 더 넓은 평수로 이사할 수 있어요" 카드를 만드는 HoldOut 추천 알고리즘.
@@ -86,7 +85,7 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
     private final MonteCarloService  monteCarloService;
 
     @Override
-    public Optional<GoalRecommendationResponse.RecommendationItem> recommend(
+    public List<GoalRecommendationResponse.RecommendationItem> recommend(
             long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx
     ) {
         Goal activeGoal = goalMapper.findActiveByMemberId(memberId);
@@ -95,7 +94,7 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
                 : null;
 
         BaseCondition base = resolveCondition(request, housing, activeGoal);
-        if (base == null) return Optional.empty();
+        if (base == null) return List.of();
 
         YearMonth now = YearMonth.now();
         AssetNetWorthBreakdown netWorth = ctx.netWorth();
@@ -136,10 +135,8 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
 
         if (best == null) {
             log.info("[HoldOut] 적합한 후보 없음 — soft-fail 반환 memberId={} regionCode={}", memberId, base.regionCode);
-            return Optional.of(GoalRecommendationResponse.RecommendationItem.builder()
+            return List.of(GoalRecommendationResponse.RecommendationItem.builder()
                     .type(AlgorithmType.HOLD_OUT)
-                    .title(buildInfeasibleTitle(base))
-                    .reason(buildInfeasibleReason(base, n))
                     .build());
         }
 
@@ -157,10 +154,8 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
             loanO = loanO.toBuilder().shortenedMonths(shortened).build();
         }
 
-        return Optional.of(GoalRecommendationResponse.RecommendationItem.builder()
+        return List.of(GoalRecommendationResponse.RecommendationItem.builder()
                 .type(AlgorithmType.HOLD_OUT)
-                .title(buildTitle(base, best, n, regionExpanded))
-                .reason(buildReason(base, best, n, regionExpanded))
                 .condition(GoalRecommendationResponse.Condition.builder()
                         .regionCode(best.median.getRegionCode())
                         .regionName(best.median.getRegionName())
@@ -176,9 +171,6 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
                                 ? best.median.getMonthlyRent().getQ3() : 0L)
                         .sampleCount(best.median.getSampleCount())
                         .marketMedianAmount(best.futurePrice)
-                        .build())
-                .calculationBasis(GoalRecommendationResponse.CalculationBasis.builder()
-                        .reachableAmountAtTargetDate(null)
                         .build())
                 .loanX(plans.getLoanX())
                 .loanO(loanO)
@@ -339,137 +331,6 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
     private double calcConditionImprovementScore(double baseMidArea, double candidateMidArea) {
         double delta = candidateMidArea - baseMidArea;
         return Math.min(1.0, Math.max(0.0, 0.5 + delta / 20.0));
-    }
-
-    // ─── 메시지 빌더 ─────────────────────────────────────────────────────────────
-
-    /** feasible=false 카드 제목 — 후보를 전혀 찾지 못한 경우 */
-    private String buildInfeasibleTitle(BaseCondition base) {
-        return base.areaMin != null && base.areaMax != null
-                ? "더 기다려도 더 넓은 평수로 이사하기 어려워요"
-                : "현재 저축 계획으로는 원하는 조건 달성이 어려워요";
-    }
-
-    /** feasible=false 카드 이유 — 총 탐색 기간(n + PATIENCE_BONUS)을 기준으로 설명 */
-    private String buildInfeasibleReason(BaseCondition base, long n) {
-        String waitStr = formatMonths(n + PATIENCE_BONUS);
-        if (base.areaMin != null && base.areaMax != null) {
-            return String.format(
-                    "%s을 기다려도 현재 저축 계획으로는 %d~%d평보다 넓은 집을 마련하기 어려워요. 저축액을 늘리거나 조건을 조정해 보세요.",
-                    waitStr, base.areaMin, base.areaMax);
-        }
-        String housingLabel = base.housingType != null ? RecommendationAlgorithm.label(base.housingType) : "주택";
-        String dealLabel    = base.dealType    != null ? RecommendationAlgorithm.label(base.dealType)    : "";
-        String typePart     = dealLabel.isEmpty() ? housingLabel : housingLabel + " " + dealLabel;
-        return String.format(
-                "%s을 기다려도 현재 저축 계획으로는 요청하신 지역의 %s을 마련하기 어려워요. 저축액을 늘리거나 조건을 조정해 보세요.",
-                waitStr, typePart);
-    }
-
-    /**
-     * 상황별 카드 제목.
-     *
-     * <table>
-     *   <tr><th>상황</th><th>제목</th></tr>
-     *   <tr><td>m=0 · 평수 지정</td><td>현재 계획으로도 더 넓은 평수를 노려볼 수 있어요</td></tr>
-     *   <tr><td>m=0 · 평수 미지정</td><td>현재 저축 계획으로도 더 좋은 조건의 집이 가능해요</td></tr>
-     *   <tr><td>지역 확장 · m>0</td><td>N 더 기다리면 원하는 조건으로 이사할 수 있어요</td></tr>
-     *   <tr><td>같은 지역 · 평수 지정 · m>0</td><td>N 더 기다리면 더 넓은 집으로 이사할 수 있어요</td></tr>
-     *   <tr><td>같은 지역 · 평수 미지정 · m>0</td><td>N 더 기다리면 더 좋은 조건의 집을 마련할 수 있어요</td></tr>
-     * </table>
-     */
-    private String buildTitle(BaseCondition base, ScoredCandidate best, long n, boolean regionExpanded) {
-        boolean sizeSpecified = base.areaMin != null && base.areaMax != null;
-        long m = best.m;
-
-        if (m == 0) {
-            return sizeSpecified
-                    ? "현재 계획으로도 더 넓은 평수를 노려볼 수 있어요"
-                    : "현재 저축 계획으로도 더 좋은 조건의 집이 가능해요";
-        }
-        if (regionExpanded) {
-            return formatMonths(m) + " 더 기다리면 원하는 조건으로 이사할 수 있어요";
-        }
-        return sizeSpecified
-                ? formatMonths(m) + " 더 기다리면 더 넓은 집으로 이사할 수 있어요"
-                : formatMonths(m) + " 더 기다리면 더 좋은 조건의 집을 마련할 수 있어요";
-    }
-
-    /**
-     * 상황별 카드 이유 문구.
-     *
-     * <table>
-     *   <tr><th>상황</th><th>핵심 메시지</th></tr>
-     *   <tr><td>m=0 · 평수 지정</td><td>"현재 목표 저축이면 A평 → B평 업그레이드 가능"</td></tr>
-     *   <tr><td>m=0 · 평수 미지정</td><td>"현재 예산으로 지역 유형 B평 가능"</td></tr>
-     *   <tr><td>지역 확장 · m>0 · 평수 지정</td><td>"요청 지역 예산 초과 → N 저축하면 시도 내 B평 가능"</td></tr>
-     *   <tr><td>지역 확장 · m>0 · 평수 미지정</td><td>"요청 지역 예산 초과 → N 저축하면 시도 내 유형 B평 가능"</td></tr>
-     *   <tr><td>같은 지역 · 평수 지정 · 목표 있음</td><td>"목표 시점보다 N 더 기다리면 A평 → B평"</td></tr>
-     *   <tr><td>같은 지역 · 평수 지정 · 목표 없음</td><td>"N 저축하면 A평 → B평"</td></tr>
-     *   <tr><td>같은 지역 · 평수 미지정</td><td>"N 저축하면 지역 유형 B평 마련 가능"</td></tr>
-     * </table>
-     */
-    private String buildReason(BaseCondition base, ScoredCandidate best, long n, boolean regionExpanded) {
-        boolean sizeSpecified = base.areaMin != null && base.areaMax != null;
-        boolean hasTarget = n > 0;
-        long m = best.m;
-        String regionName = best.median.getRegionName();
-        String housingLabel = RecommendationAlgorithm.label(best.candidate.housingType);
-        String dealLabel    = RecommendationAlgorithm.label(best.candidate.dealType);
-        int rMin = best.candidate.areaMin;
-        int rMax = best.candidate.areaMax;
-
-        // m=0: 현재 계획으로도 이미 업그레이드 가능
-        if (m == 0) {
-            if (sizeSpecified) {
-                return String.format(
-                        "현재 목표대로 저축하면 %s %d~%d평에서 %d~%d평으로 넓혀서 이사할 수도 있어요.",
-                        housingLabel, base.areaMin, base.areaMax, rMin, rMax);
-            }
-            return String.format(
-                    "현재 저축 계획으로 %s %s %d~%d평이 %s에서 가능해요.",
-                    housingLabel, dealLabel, rMin, rMax, regionName);
-        }
-
-        String waitStr = formatMonths(m);
-
-        // 지역 확장(요청 시군구 → 상위 시도)으로 찾은 경우
-        if (regionExpanded) {
-            if (sizeSpecified) {
-                return String.format(
-                        "요청하신 지역은 현재 예산을 초과하지만, %s 더 저축하면 %s에서 %s %s %d~%d평으로 이사할 수 있어요.",
-                        waitStr, regionName, housingLabel, dealLabel, rMin, rMax);
-            }
-            return String.format(
-                    "요청하신 지역은 현재 예산을 초과하지만, %s 더 저축하면 %s에서 %s %s %d~%d평이 가능해요.",
-                    waitStr, regionName, housingLabel, dealLabel, rMin, rMax);
-        }
-
-        // 같은 지역, 평수 지정
-        if (sizeSpecified) {
-            String waitPrefix = hasTarget
-                    ? "목표 시점보다 " + waitStr + " 더 기다리면"
-                    : waitStr + " 저축하면";
-            return String.format(
-                    "%s %s에서 %d~%d평에서 %d~%d평으로 넓혀서 이사할 수 있어요.",
-                    waitPrefix, regionName, base.areaMin, base.areaMax, rMin, rMax);
-        }
-
-        // 같은 지역, 평수 미지정
-        String waitPrefix = hasTarget
-                ? "목표 시점보다 " + waitStr + " 더 기다리면"
-                : waitStr + " 저축하면";
-        return String.format(
-                "%s %s %s %s %d~%d평을 마련할 수 있어요.",
-                waitPrefix, regionName, housingLabel, dealLabel, rMin, rMax);
-    }
-
-    private String formatMonths(long months) {
-        long years = months / 12;
-        long rem   = months % 12;
-        if (years == 0) return months + "개월";
-        if (rem   == 0) return years  + "년";
-        return years + "년 " + rem + "개월";
     }
 
     // ─── resolveCondition ────────────────────────────────────────────────────────

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -145,7 +145,7 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
                 best.futurePrice, best.m, String.format("%.4f", best.score), regionExpanded);
 
         YearMonth targetDate = now.plusMonths(best.totalMonths);
-        LoanPlans plans = loanPlanCalculator.calculate(memberId, best.futurePrice, targetDate);
+        LoanPlans plans = loanPlanCalculator.calculate(memberId, best.futurePrice, targetDate, best.effectiveSaving);
 
         GoalRecommendationResponse.LoanOPlan loanO = plans.getLoanO();
         if (loanO != null) {

--- a/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
@@ -17,7 +17,7 @@ import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.service.RentMedianService;
 import java.time.YearMonth;
-import java.util.Optional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -81,7 +81,7 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
     private final MonteCarloService monteCarloService;
 
     @Override
-    public Optional<GoalRecommendationResponse.RecommendationItem> recommend(
+    public List<GoalRecommendationResponse.RecommendationItem> recommend(
             long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx) {
 
         YearMonth targetDate = request.getTargetDate() != null
@@ -106,14 +106,14 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
         } catch (RuntimeException e) {
             log.warn("실거래 조회에 실패해 선호 조건을 추천하지 못했습니다. memberId={}, regionCode={}",
                     memberId, request.getRegionCode(), e);
-            return Optional.empty();
+            return List.of();
         }
 
         // 표본이 적은 것은 그대로 두지만, 한 건도 없으면 보여줄 금액 자체가 없다.
         if (median.getSampleCount() == 0 || median.getDeposit().getMedian() == null) {
             log.info("선호 조건에 해당하는 실거래가 없습니다. memberId={}, regionCode={}",
                     memberId, request.getRegionCode());
-            return Optional.empty();
+            return List.of();
         }
 
         long deposit = median.getDeposit().getMedian();
@@ -136,18 +136,7 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
                     memberId, request.getRegionCode(), e);
         }
 
-        LoanPlans plans = loanPlanCalculator.calculate(memberId, projectedDeposit, targetDate);
-
-        GoalRecommendationResponse.LoanOPlan loanO = plans.getLoanO();
-        if (loanO != null) {
-            Long reachMonths = budgetCalculator.monthsToReach(netWorth, effectiveSaving, projectedDeposit);
-            if (reachMonths != null) {
-                Long shortened = loanPlanCalculator.calcShortenedMonths(
-                        memberId, netWorth, effectiveSaving, projectedDeposit, reachMonths);
-                loanO = loanO.toBuilder().shortenedMonths(shortened).build();
-            }
-        }
-
+        // 두 카드가 공유하는 조건. 같은 시세·같은 조건을 계산 방향만 달리해 보여준다.
         GoalRecommendationResponse.Condition condition = GoalRecommendationResponse.Condition.builder()
                 .regionCode(median.getRegionCode())
                 .regionName(median.getRegionName())
@@ -162,19 +151,40 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
                 .marketMedianAmount(projectedDeposit)
                 .build();
 
-        return Optional.of(GoalRecommendationResponse.RecommendationItem.builder()
-                .type(AlgorithmType.PREFERENCE)
-                .title(String.format("%s %s", median.getRegionName(), RecommendationAlgorithm.label(housingType)))
-                .reason(String.format("최근 6개월 실거래 %d건 기준 %s %s %d~%d평 %s 시세입니다.",
-                        median.getSampleCount(), median.getRegionName(), RecommendationAlgorithm.label(housingType),
-                        areaMin, areaMax, RecommendationAlgorithm.label(dealType)))
-                .condition(condition)
-                .calculationBasis(GoalRecommendationResponse.CalculationBasis.builder()
-                        .reachableAmountAtTargetDate(null)
-                        .build())
-                .loanX(plans.getLoanX())
-                .loanO(loanO)
-                .build());
+        // ① 저축 고정 — 사용자의 월 저축액을 그대로 두고 도달 시점을 계산
+        LoanPlans savingFixedPlans = loanPlanCalculator.calculateSavingFixed(
+                memberId, projectedDeposit, netWorth, effectiveSaving);
+        GoalRecommendationResponse.RecommendationItem savingFixedCard =
+                GoalRecommendationResponse.RecommendationItem.builder()
+                        .type(AlgorithmType.PREFERENCE_SAVING_FIXED)
+                        .condition(condition)
+                        .loanX(savingFixedPlans.getLoanX())
+                        .loanO(savingFixedPlans.getLoanO())
+                        .build();
+
+        // ② 시점 고정 — 목표 시점을 고정하고 필요한 월 저축액을 역산.
+        // 목표 시점을 입력하지 않았으면 고정할 시점이 없어 조건 없는(null) 카드를 낸다.
+        GoalRecommendationResponse.RecommendationItem dateFixedCard;
+        if (request.getTargetDate() != null) {
+            LoanPlans dateFixedPlans = loanPlanCalculator.calculate(memberId, projectedDeposit, targetDate);
+            GoalRecommendationResponse.LoanOPlan dateFixedLoanO = dateFixedPlans.getLoanO();
+            if (dateFixedLoanO != null) {
+                // 시점을 고정한 카드라 대출은 개월을 줄이는 게 아니라 필요 저축액을 낮춘다 → 단축 개월은 0
+                dateFixedLoanO = dateFixedLoanO.toBuilder().shortenedMonths(0L).build();
+            }
+            dateFixedCard = GoalRecommendationResponse.RecommendationItem.builder()
+                    .type(AlgorithmType.PREFERENCE_DATE_FIXED)
+                    .condition(condition)
+                    .loanX(dateFixedPlans.getLoanX())
+                    .loanO(dateFixedLoanO)
+                    .build();
+        } else {
+            dateFixedCard = GoalRecommendationResponse.RecommendationItem.builder()
+                    .type(AlgorithmType.PREFERENCE_DATE_FIXED)
+                    .build();
+        }
+
+        return List.of(savingFixedCard, dateFixedCard);
     }
 
     private RentMedianRequest buildMedianRequest(

--- a/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
@@ -166,7 +166,7 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
         // 목표 시점을 입력하지 않았으면 고정할 시점이 없어 조건 없는(null) 카드를 낸다.
         GoalRecommendationResponse.RecommendationItem dateFixedCard;
         if (request.getTargetDate() != null) {
-            LoanPlans dateFixedPlans = loanPlanCalculator.calculate(memberId, projectedDeposit, targetDate);
+            LoanPlans dateFixedPlans = loanPlanCalculator.calculate(memberId, projectedDeposit, targetDate, effectiveSaving);
             GoalRecommendationResponse.LoanOPlan dateFixedLoanO = dateFixedPlans.getLoanO();
             if (dateFixedLoanO != null) {
                 // 시점을 고정한 카드라 대출은 개월을 줄이는 게 아니라 필요 저축액을 낮춘다 → 단축 개월은 0

--- a/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
@@ -106,14 +106,16 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
         } catch (RuntimeException e) {
             log.warn("실거래 조회에 실패해 선호 조건을 추천하지 못했습니다. memberId={}, regionCode={}",
                     memberId, request.getRegionCode(), e);
-            return List.of();
+            return emptyCards();
         }
 
         // 표본이 적은 것은 그대로 두지만, 한 건도 없으면 보여줄 금액 자체가 없다.
+        // 카드를 빼지 않고 condition=null로 내보내, 프론트가 4슬롯(두 PREFERENCE·REALISTIC·HOLD_OUT)을
+        // 항상 같은 자리에 그리도록 한다.
         if (median.getSampleCount() == 0 || median.getDeposit().getMedian() == null) {
             log.info("선호 조건에 해당하는 실거래가 없습니다. memberId={}, regionCode={}",
                     memberId, request.getRegionCode());
-            return List.of();
+            return emptyCards();
         }
 
         long deposit = median.getDeposit().getMedian();
@@ -185,6 +187,18 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
         }
 
         return List.of(savingFixedCard, dateFixedCard);
+    }
+
+    /**
+     * 데이터가 없을 때도 카드를 빼지 않고 두 장 모두 condition=null로 내보낸다.
+     * 프론트가 4슬롯(PREFERENCE 2 · REALISTIC · HOLD_OUT)을 항상 같은 자리에 그리도록 하기 위함이다.
+     */
+    private java.util.List<GoalRecommendationResponse.RecommendationItem> emptyCards() {
+        return java.util.List.of(
+                GoalRecommendationResponse.RecommendationItem.builder()
+                        .type(AlgorithmType.PREFERENCE_SAVING_FIXED).build(),
+                GoalRecommendationResponse.RecommendationItem.builder()
+                        .type(AlgorithmType.PREFERENCE_DATE_FIXED).build());
     }
 
     private RentMedianRequest buildMedianRequest(

--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -144,7 +144,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
     private final MonteCarloService monteCarloService;
 
     @Override
-    public Optional<GoalRecommendationResponse.RecommendationItem> recommend(
+    public List<GoalRecommendationResponse.RecommendationItem> recommend(
             long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx) {
 
         YearMonth targetDate = resolveTargetDate(request);
@@ -160,7 +160,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         if (regionCode == null) {
             log.warn("추천 가능한 시군구를 찾지 못했습니다. memberId={}, regionCode={}",
                     memberId, request.getRegionCode());
-            return Optional.empty();
+            return List.of();
         }
 
         // 시군구 확정 후 (주거유형, 거래유형, 평수) 40개 조합을 bulk 1회 쿼리로 선조회
@@ -176,7 +176,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         List<Candidate> asRequested = evaluateConditions(regionCode, request, search, true, bulkMedians);
         Optional<Candidate> keepingInput = bestWithinTarget(asRequested);
         if (keepingInput.isPresent()) {
-            return Optional.of(assemble(memberId, keepingInput.get(), targetDate, desiredMonths, false, search, depositMin, depositMax));
+            return List.of(assemble(memberId, keepingInput.get(), targetDate, search, depositMin, depositMax));
         }
 
         // 3단계: 입력한 조건으로는 목표 시점을 못 지킨다. 그때만 조건을 풀고 다시 찾는다.
@@ -186,11 +186,11 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
                 : asRequested;
         if (relaxed.isEmpty()) {
             log.warn("실거래 표본이 있는 조합이 없습니다. memberId={}, regionCode={}", memberId, regionCode);
-            return Optional.empty();
+            return List.of();
         }
 
         Candidate chosen = bestWithinTarget(relaxed).orElseGet(() -> cheapest(relaxed));
-        return Optional.of(assemble(memberId, chosen, targetDate, desiredMonths, true, search, depositMin, depositMax));
+        return List.of(assemble(memberId, chosen, targetDate, search, depositMin, depositMax));
     }
 
     /** 사용자가 지역 외에 조정 가능한 조건을 하나라도 줬는가 */
@@ -486,8 +486,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
     // ===== 응답 조립 =====
 
     private GoalRecommendationResponse.RecommendationItem assemble(
-            long memberId, Candidate chosen, YearMonth targetDate,
-            long desiredMonths, boolean adjusted, Search search,
+            long memberId, Candidate chosen, YearMonth targetDate, Search search,
             long depositMin, long depositMax) {
 
         // 화면에 나가는 목표 금액은 환산값이 아니라 실제로 모아야 하는 보증금이다.
@@ -500,9 +499,6 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
                     chosen.deposit(), chosen.reachMonths());
             loanO = loanO.toBuilder().shortenedMonths(shortened).build();
         }
-
-        long reachableAmountAtTargetDate =
-                budgetCalculator.calculate(search.netWorth, search.effectiveSaving, desiredMonths);
 
         GoalRecommendationResponse.Condition condition = GoalRecommendationResponse.Condition.builder()
                 .regionCode(chosen.regionCode())
@@ -520,51 +516,10 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
 
         return GoalRecommendationResponse.RecommendationItem.builder()
                 .type(AlgorithmType.REALISTIC)
-                .title(buildTitle(chosen, desiredMonths))
-                .reason(buildReason(chosen, desiredMonths, adjusted))
                 .condition(condition)
-                .calculationBasis(GoalRecommendationResponse.CalculationBasis.builder()
-                        .reachableAmountAtTargetDate(reachableAmountAtTargetDate)
-                        .build())
                 .loanX(plans.getLoanX())
                 .loanO(loanO)
                 .build();
-    }
-
-    private String buildTitle(Candidate chosen, long desiredMonths) {
-        if (chosen.withinTarget()) {
-            return String.format("%d개월 안에 갈 수 있는 %s %s",
-                    desiredMonths, chosen.regionName(), RecommendationAlgorithm.label(chosen.housingType()));
-        }
-        return String.format("%s에서 가장 가까운 %s", chosen.regionName(), RecommendationAlgorithm.label(chosen.housingType()));
-    }
-
-    /**
-     * 무엇을 왜 그렇게 정했는지 서술한다.
-     *
-     * <p>목표 시점 안에 되는 경우와 못 되는 경우는 카드가 하는 말 자체가 다르므로 문구를 갈라 쓴다.
-     * 후자는 조건을 조정해도 시점을 못 지킨다는 뜻이라, 가능하다고 말하면 거짓이 된다.
-     */
-    private String buildReason(Candidate chosen, long desiredMonths, boolean adjusted) {
-        String condition = String.format("%s %s %d~%d평 %s",
-                chosen.regionName(), RecommendationAlgorithm.label(chosen.housingType()),
-                chosen.areaMin(), chosen.areaMax(), RecommendationAlgorithm.label(chosen.dealType()));
-
-        if (!chosen.withinTarget()) {
-            if (chosen.reachMonths() == null) {
-                return String.format(
-                        "지금 저축 속도로는 %s 조건에 도달하기 어렵습니다. 저축액을 늘리면 목표가 잡힙니다.", condition);
-            }
-            return String.format(
-                    "%d개월 안에 가능한 조건은 찾지 못했습니다. %s가 가장 가까우며 %d개월이 필요합니다.",
-                    desiredMonths, condition, chosen.reachMonths());
-        }
-        if (adjusted) {
-            return String.format(
-                    "입력하신 조건으로는 %d개월을 지키기 어렵습니다. %s로 바꾸면 그 안에 도달할 수 있습니다.",
-                    desiredMonths, condition);
-        }
-        return String.format("%s로 %d개월 안에 도달할 수 있습니다.", condition, desiredMonths);
     }
 
     // ===== 입력 정규화 =====

--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -490,7 +490,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
             long depositMin, long depositMax) {
 
         // 화면에 나가는 목표 금액은 환산값이 아니라 실제로 모아야 하는 보증금이다.
-        LoanPlans plans = loanPlanCalculator.calculate(memberId, chosen.deposit(), targetDate);
+        LoanPlans plans = loanPlanCalculator.calculate(memberId, chosen.deposit(), targetDate, search.effectiveSaving);
 
         GoalRecommendationResponse.LoanOPlan loanO = plans.getLoanO();
         if (loanO != null && chosen.reachMonths() != null) {

--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -160,7 +160,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         if (regionCode == null) {
             log.warn("추천 가능한 시군구를 찾지 못했습니다. memberId={}, regionCode={}",
                     memberId, request.getRegionCode());
-            return List.of();
+            return List.of(emptyCard());
         }
 
         // 시군구 확정 후 (주거유형, 거래유형, 평수) 40개 조합을 bulk 1회 쿼리로 선조회
@@ -186,11 +186,21 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
                 : asRequested;
         if (relaxed.isEmpty()) {
             log.warn("실거래 표본이 있는 조합이 없습니다. memberId={}, regionCode={}", memberId, regionCode);
-            return List.of();
+            return List.of(emptyCard());
         }
 
         Candidate chosen = bestWithinTarget(relaxed).orElseGet(() -> cheapest(relaxed));
         return List.of(assemble(memberId, chosen, targetDate, search, depositMin, depositMax));
+    }
+
+    /**
+     * 후보를 찾지 못했을 때 내보내는 condition=null 카드.
+     * 카드를 빼지 않고 자리를 유지해, 프론트가 4슬롯을 항상 같은 위치에 그리도록 한다.
+     */
+    private GoalRecommendationResponse.RecommendationItem emptyCard() {
+        return GoalRecommendationResponse.RecommendationItem.builder()
+                .type(AlgorithmType.REALISTIC)
+                .build();
     }
 
     /** 사용자가 지역 외에 조정 가능한 조건을 하나라도 줬는가 */

--- a/src/main/java/com/team/independence/goal/service/calculator/LoanPlanCalculator.java
+++ b/src/main/java/com/team/independence/goal/service/calculator/LoanPlanCalculator.java
@@ -86,6 +86,67 @@ public class LoanPlanCalculator {
     }
 
     /**
+     * 월 저축액을 고정하고 도달 시점을 계산하는 플랜.
+     *
+     * <p>{@link #calculate}가 "목표 시점 고정 → 필요 저축액 역산"이라면, 이 메서드는 정확히 반대다.
+     * 사용자의 실제 월 저축액을 그대로 두고 목표 금액에 <b>언제</b> 도달하는지를 계산한다.
+     * 따라서 loanX·loanO의 {@code monthlySaving}에는 (역산값이 아니라) 넘겨받은 월 저축액이 그대로 담기고,
+     * {@code targetDate}가 계산 결과다. 저축액으로 상한(1200개월) 내 도달이 불가능하면 targetDate는 null이다.
+     *
+     * @param requiredAmount 도달해야 할 목표 금액(원)
+     * @param netWorth       현재 순자산 구성
+     * @param monthlySaving  고정할 월 저축액(원)
+     */
+    public LoanPlans calculateSavingFixed(long memberId, long requiredAmount,
+                                          AssetNetWorthBreakdown netWorth, long monthlySaving) {
+        YearMonth now = YearMonth.now();
+
+        Long loanXMonths = budgetCalculator.monthsToReach(netWorth, monthlySaving, requiredAmount);
+        GoalRecommendationResponse.LoanXPlan loanX = GoalRecommendationResponse.LoanXPlan.builder()
+                .targetAmount(requiredAmount)
+                .targetDate(loanXMonths != null ? now.plusMonths(loanXMonths) : null)
+                .monthlySaving(monthlySaving)
+                .build();
+
+        long existingPayment = calcTotalExistingMonthlyPayment(memberId);
+        long loanAmount = Math.min(calcMaxLoanAmount(memberId, existingPayment), requiredAmount);
+        if (loanAmount <= 0) {
+            return LoanPlans.builder().loanX(loanX).loanO(null).build();
+        }
+
+        // 대출금은 즉시 가용 자금으로 편입하고, 신규 대출 월 원리금만큼 저축 여력을 줄여 도달 시점을 다시 계산
+        long loanMonthly = monthlyPaymentForLoan(loanAmount);
+        long savingWithLoan = Math.max(0, monthlySaving - loanMonthly);
+        AssetNetWorthBreakdown netWorthWithLoan = AssetNetWorthBreakdown.builder()
+                .interestBearingAssets(netWorth.getInterestBearingAssets())
+                .flatRecognizedAssets(netWorth.getFlatRecognizedAssets() + loanAmount)
+                .build();
+
+        Long loanOMonths = budgetCalculator.monthsToReach(netWorthWithLoan, savingWithLoan, requiredAmount);
+        if (loanOMonths == null) {
+            return LoanPlans.builder().loanX(loanX).loanO(null).build();
+        }
+
+        Long shortened = loanXMonths != null ? Math.max(0, loanXMonths - loanOMonths) : null;
+        GoalRecommendationResponse.LoanOPlan loanO = GoalRecommendationResponse.LoanOPlan.builder()
+                .loanAmount(loanAmount)
+                .targetAmount(requiredAmount - loanAmount)
+                .targetDate(now.plusMonths(loanOMonths))
+                .monthlySaving(monthlySaving)
+                .shortenedMonths(shortened)
+                .build();
+
+        return LoanPlans.builder().loanX(loanX).loanO(loanO).build();
+    }
+
+    /** 신규 대출 원금의 월 원리금(연 3.5%, 30년 원리금균등). */
+    private long monthlyPaymentForLoan(long loanAmount) {
+        double r = ASSUMED_LOAN_ANNUAL_RATE / 12.0;
+        double factor = Math.pow(1 + r, NEW_LOAN_TERM_MONTHS);
+        return Math.round(loanAmount * r * factor / (factor - 1));
+    }
+
+    /**
      * 기존 대출 계좌 전체의 월 원리금 합계를 반환한다.
      *
      * <p>end_date가 없거나 이미 만기된 대출은 상환 부담 없음으로 처리한다.

--- a/src/main/java/com/team/independence/goal/service/calculator/LoanPlanCalculator.java
+++ b/src/main/java/com/team/independence/goal/service/calculator/LoanPlanCalculator.java
@@ -46,8 +46,12 @@ public class LoanPlanCalculator {
      * <p>DSR 한도가 0이면(소득 미등록·기존 대출 과다) loanO는 null이 된다.
      * 대출 한도가 목표 금액을 초과하는 경우 대출액은 목표 금액으로 캡되며,
      * 자력 부담과 월 저축액은 0이 된다.
+     *
+     * @param effectiveSaving 호출자가 넘기는 월 순저축액(기존 대출 상환액 등을 이미 차감한 값).
+     *                        loanO 달성 가능 여부(capacity) 판정에 쓴다. 서버 캐시가 아니라 이 값을 기준으로
+     *                        삼아, 추천 요청이 넘긴 저축액과 예산 계산이 어긋나지 않게 한다.
      */
-    public LoanPlans calculate(long memberId, long requiredAmount, YearMonth targetDate) {
+    public LoanPlans calculate(long memberId, long requiredAmount, YearMonth targetDate, long effectiveSaving) {
         long months = ChronoUnit.MONTHS.between(YearMonth.now(), targetDate);
         AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
 
@@ -58,7 +62,6 @@ public class LoanPlanCalculator {
                 .monthlySaving(loanXSaving)
                 .build();
 
-        // existingPayment를 먼저 계산해 calcMaxLoanAmount와 capacity check에서 재사용
         long existingPayment = calcTotalExistingMonthlyPayment(memberId);
         long loanAmount = Math.min(calcMaxLoanAmount(memberId, existingPayment), requiredAmount);
         if (loanAmount <= 0) {
@@ -68,10 +71,8 @@ public class LoanPlanCalculator {
         long selfFunded = requiredAmount - loanAmount;
         long loanOSaving = calcMonthlySavingNeeded(netWorth, selfFunded, months);
 
-        // 실제 저축 가능액 초과 시 달성 불가 → loanO null
-        long rawSaving = assetSummaryService.getMonthlySavingsOrZero(memberId);
-        long capacitySaving = Math.max(0, rawSaving - existingPayment);
-        if (loanOSaving > capacitySaving) {
+        // 실제 저축 가능액(호출자가 넘긴 순저축액) 초과 시 달성 불가 → loanO null
+        if (loanOSaving > effectiveSaving) {
             return LoanPlans.builder().loanX(loanX).loanO(null).build();
         }
 

--- a/src/test/java/com/team/independence/goal/service/GoalRecommendationServiceIntegrationTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalRecommendationServiceIntegrationTest.java
@@ -47,6 +47,7 @@ class GoalRecommendationServiceIntegrationTest {
     @DisplayName("[조건 최소] 대출 없는 회원 — regionCode '11110' 만 지정, 나머지는 알고리즘이 채움")
     void 조건_최소_대출없는회원() {
         GoalRecommendationRequest request = new GoalRecommendationRequest();
+        request.setMonthlySavings(1_000_000L);
         request.setRegionCode("11110");
 
         GoalRecommendationResponse response = recommendationService.recommend(MEMBER_NO_LOAN, request);
@@ -59,6 +60,7 @@ class GoalRecommendationServiceIntegrationTest {
     @DisplayName("[조건 최소] 대출 있는 회원 — 기존 대출 월상환액이 차감된 예산으로 추천")
     void 조건_최소_대출있는회원() {
         GoalRecommendationRequest request = new GoalRecommendationRequest();
+        request.setMonthlySavings(1_000_000L);
         request.setRegionCode("11110");
 
         GoalRecommendationResponse response = recommendationService.recommend(MEMBER_WITH_LOAN, request);
@@ -73,6 +75,7 @@ class GoalRecommendationServiceIntegrationTest {
     @DisplayName("[조건 지정] 아파트·전세·15~25평 — 각 알고리즘이 해당 조건 기준으로 추천")
     void 조건_지정_APT_전세() {
         GoalRecommendationRequest request = new GoalRecommendationRequest();
+        request.setMonthlySavings(1_000_000L);
         request.setRegionCode("11110");
         request.setPropertyType(HousingType.APT);
         request.setTradeType(DealType.JEONSE);
@@ -94,6 +97,7 @@ class GoalRecommendationServiceIntegrationTest {
     @DisplayName("[조건 지정] 오피스텔·월세 — 월세 조건 결과에 monthlyRent 포함 여부 확인")
     void 조건_지정_오피스텔_월세() {
         GoalRecommendationRequest request = new GoalRecommendationRequest();
+        request.setMonthlySavings(1_000_000L);
         request.setRegionCode("11110");
         request.setPropertyType(HousingType.OFFICETEL);
         request.setTradeType(DealType.WOLSE);
@@ -118,6 +122,7 @@ class GoalRecommendationServiceIntegrationTest {
     @DisplayName("[시도 탐색] regionCode '11' — 서울 전체에서 최적 시군구를 알고리즘이 선정")
     void 시도코드_서울_광역탐색() {
         GoalRecommendationRequest request = new GoalRecommendationRequest();
+        request.setMonthlySavings(1_000_000L);
         request.setRegionCode("11");
         request.setPropertyType(HousingType.APT);
         request.setTradeType(DealType.JEONSE);
@@ -141,6 +146,7 @@ class GoalRecommendationServiceIntegrationTest {
         YearMonth targetDate = YearMonth.now().plusMonths(24);
 
         GoalRecommendationRequest request = new GoalRecommendationRequest();
+        request.setMonthlySavings(1_000_000L);
         request.setRegionCode("11110");
         request.setTargetDate(targetDate);
 
@@ -166,6 +172,7 @@ class GoalRecommendationServiceIntegrationTest {
     @DisplayName("[대출 플랜] 소득 500만 회원 — loanO 플랜에 대출액·단축 개월수 포함 여부 확인")
     void 대출플랜_소득있는회원() {
         GoalRecommendationRequest request = new GoalRecommendationRequest();
+        request.setMonthlySavings(1_000_000L);
         request.setRegionCode("11110");
         request.setPropertyType(HousingType.APT);
         request.setTradeType(DealType.JEONSE);

--- a/src/test/java/com/team/independence/goal/service/GoalRecommendationServiceIntegrationTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalRecommendationServiceIntegrationTest.java
@@ -85,7 +85,7 @@ class GoalRecommendationServiceIntegrationTest {
         assertThat(response.getRecommendations()).isNotEmpty();
         // PREFERENCE는 입력 조건을 그대로 유지, REALISTIC·HOLDOUT은 조건을 완화할 수 있다
         response.getRecommendations().stream()
-                .filter(item -> item.getType() == com.team.independence.goal.dto.AlgorithmType.PREFERENCE)
+                .filter(item -> item.getType() == com.team.independence.goal.dto.AlgorithmType.PREFERENCE_SAVING_FIXED)
                 .forEach(item ->
                         assertThat(item.getCondition().getHousingType()).isEqualTo(HousingType.APT));
     }
@@ -148,14 +148,16 @@ class GoalRecommendationServiceIntegrationTest {
 
         print("목표 시점 24개월 / member=" + MEMBER_NO_LOAN, response);
         assertThat(response.getRecommendations()).isNotEmpty();
-        // PREFERENCE는 입력 targetDate를 그대로 사용, REALISTIC·HOLDOUT은 실제 도달 시점을 계산한다
+        // PREFERENCE_DATE_FIXED는 입력 targetDate를 그대로 고정, 나머지는 실제 도달 시점을 계산한다
         response.getRecommendations().stream()
-                .filter(item -> item.getType() == com.team.independence.goal.dto.AlgorithmType.PREFERENCE)
+                .filter(item -> item.getType() == com.team.independence.goal.dto.AlgorithmType.PREFERENCE_DATE_FIXED)
+                .filter(item -> item.getLoanX() != null)
                 .forEach(item ->
                         assertThat(item.getLoanX().getTargetDate()).isEqualTo(targetDate));
-        // 모든 알고리즘의 targetDate가 null이 아닌지만 검사
-        response.getRecommendations().forEach(item ->
-                assertThat(item.getLoanX().getTargetDate()).isNotNull());
+        // loanX가 있는 카드는 targetDate가 채워져 있어야 한다
+        response.getRecommendations().stream()
+                .filter(item -> item.getLoanX() != null)
+                .forEach(item -> assertThat(item.getLoanX().getTargetDate()).isNotNull());
     }
 
     // ===== 케이스 5: loanO 플랜 (소득 등록 회원) =====
@@ -187,8 +189,6 @@ class GoalRecommendationServiceIntegrationTest {
 
         for (RecommendationItem item : items) {
             System.out.println("\n  [" + item.getType() + "]");
-            System.out.println("  title  : " + item.getTitle());
-            System.out.println("  reason : " + item.getReason());
 
             if (item.getCondition() != null) {
                 System.out.printf("  조건   : %s %s / %s / %d~%d평 / 표본 %d건%n",

--- a/src/test/java/com/team/independence/goal/service/LoanPlanCalculatorImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/LoanPlanCalculatorImplTest.java
@@ -138,7 +138,7 @@ class LoanPlanCalculatorTest {
         when(memberService.getMember(MEMBER_ID)).thenReturn(profile(null));
         when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(0L, 0L));
 
-        LoanPlans plans = calculator.calculate(MEMBER_ID, 200_000_000L, YearMonth.now().plusMonths(36));
+        LoanPlans plans = calculator.calculate(MEMBER_ID, 200_000_000L, YearMonth.now().plusMonths(36), 5_000_000L);
 
         assertNotNull(plans.getLoanX());
         assertNull(plans.getLoanO(), "대출 한도 0이면 loanO는 null이어야 한다");
@@ -153,7 +153,7 @@ class LoanPlanCalculatorTest {
         when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(0L, 0L));
 
         long requiredAmount = 50_000_000L; // 5천만 (대출 한도보다 훨씬 작음)
-        LoanPlans plans = calculator.calculate(MEMBER_ID, requiredAmount, YearMonth.now().plusMonths(24));
+        LoanPlans plans = calculator.calculate(MEMBER_ID, requiredAmount, YearMonth.now().plusMonths(24), 5_000_000L);
 
         assertNotNull(plans.getLoanO());
         assertEquals(0L, plans.getLoanO().getMonthlySaving(), "대출으로 전액 충당되면 월 저축 0이어야 한다");
@@ -169,7 +169,7 @@ class LoanPlanCalculatorTest {
         when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(10_000_000L, 5_000_000L));
 
         // 현재 자산으로는 부족하고 저축이 필요한 규모
-        LoanPlans plans = calculator.calculate(MEMBER_ID, 200_000_000L, YearMonth.now().plusMonths(48));
+        LoanPlans plans = calculator.calculate(MEMBER_ID, 200_000_000L, YearMonth.now().plusMonths(48), 5_000_000L);
 
         assertNotNull(plans.getLoanO());
         assertTrue(plans.getLoanO().getMonthlySaving() < plans.getLoanX().getMonthlySaving(),
@@ -184,7 +184,7 @@ class LoanPlanCalculatorTest {
 
         long requiredAmount = 150_000_000L;
         YearMonth targetDate = YearMonth.now().plusMonths(30);
-        LoanPlans plans = calculator.calculate(MEMBER_ID, requiredAmount, targetDate);
+        LoanPlans plans = calculator.calculate(MEMBER_ID, requiredAmount, targetDate, 5_000_000L);
 
         assertEquals(requiredAmount, plans.getLoanX().getTargetAmount());
         assertEquals(targetDate, plans.getLoanX().getTargetDate());
@@ -197,7 +197,7 @@ class LoanPlanCalculatorTest {
         // 현재 자산 2억 > 목표 1억
         when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(200_000_000L, 0L));
 
-        LoanPlans plans = calculator.calculate(MEMBER_ID, 100_000_000L, YearMonth.now().plusMonths(24));
+        LoanPlans plans = calculator.calculate(MEMBER_ID, 100_000_000L, YearMonth.now().plusMonths(24), 5_000_000L);
 
         assertEquals(0L, plans.getLoanX().getMonthlySaving(), "자산이 이미 충분하면 저축 0이어야 한다");
     }

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmIntegrationTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmIntegrationTest.java
@@ -17,7 +17,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.YearMonth;
-import java.util.Optional;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -69,28 +69,27 @@ class HoldOutAlgorithmIntegrationTest {
         request.setSizeMax(30);
         request.setTargetDate(YearMonth.now().plusMonths(24)); // n=24개월 기준
 
-        Optional<GoalRecommendationResponse.RecommendationItem> result =
+        List<GoalRecommendationResponse.RecommendationItem> result =
                 holdOutAlgorithm.recommend(TEST_MEMBER_ID, request, buildCtx(TEST_MEMBER_ID));
 
         System.out.println("=== HoldOut 결과 ===");
-        if (result.isPresent()) {
-            GoalRecommendationResponse.RecommendationItem item = result.get();
+        if (!result.isEmpty()) {
+            GoalRecommendationResponse.RecommendationItem item = result.get(0);
             System.out.println("type   : " + item.getType());
-            System.out.println("title  : " + item.getTitle());
-            System.out.println("reason : " + item.getReason());
-            System.out.println("조건   : " + item.getCondition().getRegionName()
+            System.out.println("조건   : " + (item.getCondition() == null ? "null(soft-fail)"
+                    : item.getCondition().getRegionName()
                     + " / " + item.getCondition().getHousingType()
                     + " / " + item.getCondition().getDealType()
                     + " / " + item.getCondition().getAreaMin()
-                    + "~" + item.getCondition().getAreaMax() + "평");
+                    + "~" + item.getCondition().getAreaMax() + "평"));
             System.out.println("loanX  : " + item.getLoanX());
             System.out.println("loanO  : " + item.getLoanO());
         } else {
-            System.out.println("추천 결과 없음 (Optional.empty)");
+            System.out.println("추천 결과 없음 (빈 목록)");
         }
 
-        // 데이터가 충분하면 결과가 있어야 함 (로컬 DB 데이터에 따라 달라짐)
-        result.ifPresent(item -> assertNotNull(item.getCondition()));
+        // 데이터가 충분하면 카드가 있어야 함 (로컬 DB 데이터에 따라 달라짐)
+        if (!result.isEmpty()) assertNotNull(result.get(0));
     }
 
     /**
@@ -102,13 +101,12 @@ class HoldOutAlgorithmIntegrationTest {
         GoalRecommendationRequest request = new GoalRecommendationRequest();
         // 조건 미입력 → active goal의 housing 조건 사용
 
-        Optional<GoalRecommendationResponse.RecommendationItem> result =
+        List<GoalRecommendationResponse.RecommendationItem> result =
                 holdOutAlgorithm.recommend(TEST_MEMBER_ID, request, buildCtx(TEST_MEMBER_ID));
 
         System.out.println("=== HoldOut (goal fallback) 결과 ===");
-        if (result.isPresent()) {
-            GoalRecommendationResponse.RecommendationItem item = result.get();
-            System.out.println("reason : " + item.getReason());
+        if (!result.isEmpty() && result.get(0).getCondition() != null) {
+            GoalRecommendationResponse.RecommendationItem item = result.get(0);
             System.out.println("조건   : " + item.getCondition().getRegionName()
                     + " " + item.getCondition().getAreaMin()
                     + "~" + item.getCondition().getAreaMax() + "평");

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
@@ -26,8 +26,8 @@ import com.team.independence.property.dto.RentMedianResponse.Quartile;
 import com.team.independence.property.service.RentMedianService;
 import java.time.YearMonth;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -111,10 +111,10 @@ class HoldOutAlgorithmTest {
         // 요청: 20~25평 → 업그레이드 버킷인 26~40평(areaMin=26 > areaMax=25)만 허용
         put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getCondition().getAreaMin()).isEqualTo(26);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(26);
     }
 
     @Test
@@ -125,10 +125,10 @@ class HoldOutAlgorithmTest {
         MemberFinancialContext ctx = ctxWithLoan(9_000_000L);
         put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getCondition()).isNull();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNull();
     }
 
     @Test
@@ -148,10 +148,10 @@ class HoldOutAlgorithmTest {
         request.setSizeMax(25);
         request.setTargetDate(NOW);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getCondition()).isNull();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNull();
     }
 
     @Test
@@ -161,19 +161,19 @@ class HoldOutAlgorithmTest {
         MemberFinancialContext ctx = ctxWithLoan(15_000_000L);
         put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getCondition()).isNull();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNull();
     }
 
     @Test
     @DisplayName("시장 데이터가 없으면 soft-fail 카드를 반환한다")
     void returnsEmptyWhenNoMarketData() {
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getCondition()).isNull();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNull();
     }
 
     // ===== 평수 업그레이드 필터 =====
@@ -185,10 +185,10 @@ class HoldOutAlgorithmTest {
         put("11110", HousingType.APT, DealType.JEONSE, 15, 19, 2 * 억, 0);
         put("11110", HousingType.APT, DealType.JEONSE, 20, 25, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getCondition()).isNull();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNull();
     }
 
     @Test
@@ -197,11 +197,11 @@ class HoldOutAlgorithmTest {
         // 요청 sizeMax=25 → 26~40(areaMin=26 > 25)만 허용
         put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getCondition().getAreaMin()).isEqualTo(26);
-        assertThat(result.get().getCondition().getAreaMax()).isEqualTo(40);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(26);
+        assertThat(result.get(0).getCondition().getAreaMax()).isEqualTo(40);
     }
 
     @Test
@@ -216,10 +216,10 @@ class HoldOutAlgorithmTest {
         request.setTradeType(DealType.JEONSE);
         request.setTargetDate(NOW);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getCondition().getAreaMin()).isEqualTo(15);
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(15);
     }
 
     // ===== 지역 확장 폴백 =====
@@ -230,10 +230,10 @@ class HoldOutAlgorithmTest {
         // 11110(종로구)에는 데이터 없고 11(서울)에만 26~40평 데이터 있음
         put("11", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getCondition().getRegionCode()).isEqualTo("11");
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition().getRegionCode()).isEqualTo("11");
     }
 
     @Test
@@ -243,10 +243,10 @@ class HoldOutAlgorithmTest {
         put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
         put("11",    HousingType.APT, DealType.JEONSE, 26, 40, 1 * 억, 0); // 더 저렴하지만 탐색 안 됨
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getCondition().getRegionCode()).isEqualTo("11110");
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition().getRegionCode()).isEqualTo("11110");
     }
 
     @Test
@@ -263,10 +263,10 @@ class HoldOutAlgorithmTest {
         request.setSizeMax(25);
         request.setTargetDate(NOW);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getCondition()).isNull();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNull();
     }
 
     // ===== 메시지 =====
@@ -283,21 +283,22 @@ class HoldOutAlgorithmTest {
         request.setSizeMin(20);
         request.setSizeMax(25);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getReason()).contains("저축하면").contains("26~40평");
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(26);
+        assertThat(result.get(0).getCondition().getAreaMax()).isEqualTo(40);
     }
 
     @Test
-    @DisplayName("지역 확장으로 찾은 경우: reason에 '요청하신 지역'과 확장된 지역명이 포함된다")
+    @DisplayName("지역 확장으로 찾은 경우: 확장된 시도 내 후보로 조건이 채워진다")
     void reasonMentionsOriginalRegionWhenExpanded() {
         put("11", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
 
-        Optional<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
-        assertThat(result).isPresent();
-        assertThat(result.get().getReason()).contains("요청하신 지역");
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNotNull();
     }
 
     // ===== 헬퍼 =====

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
@@ -96,7 +96,7 @@ class HoldOutAlgorithmTest {
                 .build();
         ctx = new MemberFinancialContext(defaultNetWorth, 10_000_000L, 0L);
         when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(null);
-        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any()))
+        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), anyLong()))
                 .thenReturn(LoanPlans.builder().build());
         when(rentMedianService.getBulkMedian(anyString(), anyString(), anyString()))
                 .thenAnswer(call -> toBulkMap(call.getArgument(0)));

--- a/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
@@ -77,6 +77,8 @@ class PreferenceAlgorithmTest {
 
         when(loanPlanCalculator.calculate(anyLong(), anyLong(), any()))
                 .thenReturn(LoanPlans.builder().build());
+        when(loanPlanCalculator.calculateSavingFixed(anyLong(), anyLong(), any(), anyLong()))
+                .thenReturn(LoanPlans.builder().build());
         stubMedian(2 * 억, 0, 120);
     }
 
@@ -98,7 +100,7 @@ class PreferenceAlgorithmTest {
         assertThat(sent.getAreaMin()).isEqualTo(10);
         assertThat(sent.getAreaMax()).isEqualTo(14);
 
-        assertThat(item.getType()).isEqualTo(AlgorithmType.PREFERENCE);
+        assertThat(item.getType()).isEqualTo(AlgorithmType.PREFERENCE_SAVING_FIXED);
         assertThat(item.getCondition().getHousingType()).isEqualTo(HousingType.OFFICETEL);
         assertThat(item.getCondition().getAreaMin()).isEqualTo(10);
     }
@@ -150,7 +152,6 @@ class PreferenceAlgorithmTest {
         RecommendationItem item = recommend(request("11110"));
 
         assertThat(item.getCondition().getSampleCount()).isEqualTo(2);
-        assertThat(item.getReason()).contains("2건");
     }
 
     @Test
@@ -164,7 +165,8 @@ class PreferenceAlgorithmTest {
         RecommendationItem item = recommend(request);
 
         assertThat(item.getCondition().getMonthlyRent()).isEqualTo(40 * 만);
-        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(1000 * 만), any());
+        // 환산값이 아니라 실제 보증금(1,000만)을 플랜 계산기로 넘긴다. targetDate가 없어 저축 고정 경로만 탄다.
+        verify(loanPlanCalculator).calculateSavingFixed(eq(MEMBER_ID), eq(1000 * 만), any(), anyLong());
     }
 
     @Test
@@ -183,11 +185,39 @@ class PreferenceAlgorithmTest {
         assertThat(algorithm.recommend(MEMBER_ID, request("11110"), ctx)).isEmpty();
     }
 
+    @Test
+    @DisplayName("목표 시점이 없으면 저축 고정은 정상, 시점 고정은 조건 없는 카드로 두 장을 낸다")
+    void splitsIntoTwoCardsAndDateFixedIsNullWithoutTargetDate() {
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request("11110"), ctx);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getType()).isEqualTo(AlgorithmType.PREFERENCE_SAVING_FIXED);
+        assertThat(result.get(0).getCondition()).isNotNull();
+        assertThat(result.get(1).getType()).isEqualTo(AlgorithmType.PREFERENCE_DATE_FIXED);
+        assertThat(result.get(1).getCondition()).isNull();
+    }
+
+    @Test
+    @DisplayName("목표 시점이 있으면 두 카드 모두 조건을 채우고, 시점 고정은 그 시점으로 플랜을 계산한다")
+    void bothCardsHaveConditionWhenTargetDateGiven() {
+        GoalRecommendationRequest request = request("11110");
+        request.setTargetDate(java.time.YearMonth.now().plusMonths(24));
+
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(1).getType()).isEqualTo(AlgorithmType.PREFERENCE_DATE_FIXED);
+        assertThat(result.get(1).getCondition()).isNotNull();
+        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(2 * 억), any());
+    }
+
     // ===== 헬퍼 =====
 
+    /** 두 카드 중 첫 번째(SAVING_FIXED). 조건은 두 카드가 공유하므로 조건 검증엔 어느 쪽이든 무방하다. */
     private RecommendationItem recommend(GoalRecommendationRequest request) {
-        return algorithm.recommend(MEMBER_ID, request, ctx)
-                .orElseThrow(() -> new AssertionError("추천 결과가 비어 있습니다"));
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
+        if (result.isEmpty()) throw new AssertionError("추천 결과가 비어 있습니다");
+        return result.get(0);
     }
 
     private GoalRecommendationRequest request(String regionCode) {

--- a/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
@@ -75,7 +75,7 @@ class PreferenceAlgorithmTest {
                 .build();
         ctx = new MemberFinancialContext(defaultNetWorth, 10_000_000L, 0L);
 
-        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any()))
+        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), anyLong()))
                 .thenReturn(LoanPlans.builder().build());
         when(loanPlanCalculator.calculateSavingFixed(anyLong(), anyLong(), any(), anyLong()))
                 .thenReturn(LoanPlans.builder().build());
@@ -208,7 +208,7 @@ class PreferenceAlgorithmTest {
         assertThat(result).hasSize(2);
         assertThat(result.get(1).getType()).isEqualTo(AlgorithmType.PREFERENCE_DATE_FIXED);
         assertThat(result.get(1).getCondition()).isNotNull();
-        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(2 * 억), any());
+        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(2 * 억), any(), anyLong());
     }
 
     // ===== 헬퍼 =====

--- a/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
@@ -170,19 +170,27 @@ class PreferenceAlgorithmTest {
     }
 
     @Test
-    @DisplayName("실거래가 한 건도 없으면 추천하지 않는다")
-    void returnsEmptyWhenNoTransaction() {
+    @DisplayName("실거래가 한 건도 없으면 카드를 빼지 않고 condition=null 두 장을 낸다")
+    void returnsNullCardsWhenNoTransaction() {
         stubMedian(0, 0, 0);
 
-        assertThat(algorithm.recommend(MEMBER_ID, request("11110"), ctx)).isEmpty();
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request("11110"), ctx);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(RecommendationItem::getType)
+                .containsExactly(AlgorithmType.PREFERENCE_SAVING_FIXED, AlgorithmType.PREFERENCE_DATE_FIXED);
+        assertThat(result).allSatisfy(item -> assertThat(item.getCondition()).isNull());
     }
 
     @Test
-    @DisplayName("실거래 조회가 실패해도 예외를 밖으로 던지지 않는다")
-    void returnsEmptyWhenLookUpFails() {
+    @DisplayName("실거래 조회가 실패해도 예외를 던지지 않고 condition=null 두 장을 낸다")
+    void returnsNullCardsWhenLookUpFails() {
         doThrow(new IllegalStateException("조회 실패")).when(rentMedianService).getMedian(any());
 
-        assertThat(algorithm.recommend(MEMBER_ID, request("11110"), ctx)).isEmpty();
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request("11110"), ctx);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).allSatisfy(item -> assertThat(item.getCondition()).isNull());
     }
 
     @Test

--- a/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
@@ -337,12 +337,14 @@ class RealisticAlgorithmTest {
     }
 
     @Test
-    @DisplayName("실거래 표본이 아무 조합에도 없으면 추천하지 않는다")
-    void returnsEmptyWhenNoMarketData() {
+    @DisplayName("실거래 표본이 아무 조합에도 없으면 카드를 빼지 않고 condition=null 한 장을 낸다")
+    void returnsNullCardWhenNoMarketData() {
         List<RecommendationItem> result = algorithm.recommend(
                 MEMBER_ID, request("11110", HousingType.APT, DealType.JEONSE), ctx);
 
-        assertThat(result).isEmpty();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getType()).isEqualTo(AlgorithmType.REALISTIC);
+        assertThat(result.get(0).getCondition()).isNull();
     }
 
     // ===== 헬퍼 =====

--- a/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -158,7 +157,7 @@ class RealisticAlgorithmTest {
         RecommendationItem item = algorithm.recommend(MEMBER_ID,
                 request("11110", HousingType.APT, DealType.JEONSE),
                 new MemberFinancialContext(defaultNetWorth, 20_000_000L, 0L))
-                .orElseThrow(() -> new AssertionError("추천 결과가 비어 있습니다"));
+                .get(0);
 
         assertThat(item.getCondition().getAreaMin()).isEqualTo(20);
     }
@@ -176,7 +175,6 @@ class RealisticAlgorithmTest {
 
         // 가장 싼 것 = 목표 시점에 가장 가까운 것
         assertThat(item.getCondition().getAreaMin()).isEqualTo(4);
-        assertThat(item.getReason()).contains("40개월이 필요합니다");
     }
 
     @Test
@@ -264,9 +262,10 @@ class RealisticAlgorithmTest {
         RecommendationItem item = algorithm.recommend(MEMBER_ID,
                 request("11110", HousingType.APT, DealType.JEONSE),
                 new MemberFinancialContext(defaultNetWorth, 0L, 0L))
-                .orElseThrow(() -> new AssertionError("추천 결과가 비어 있습니다"));
+                .get(0);
 
-        assertThat(item.getReason()).contains("도달하기 어렵습니다");
+        // 저축 0이어도 가장 가까운 후보(가장 싼 조건) 카드는 나온다
+        assertThat(item.getCondition()).isNotNull();
     }
 
     @Test
@@ -285,7 +284,6 @@ class RealisticAlgorithmTest {
 
         assertThat(item.getCondition().getHousingType()).isEqualTo(HousingType.OFFICETEL);
         assertThat(item.getCondition().getAreaMin()).isEqualTo(10);
-        assertThat(item.getReason()).doesNotContain("입력하신 조건으로는");
     }
 
     @Test
@@ -306,7 +304,6 @@ class RealisticAlgorithmTest {
         assertThat(item.getCondition().getRegionCode()).isEqualTo("11110");
         assertThat(item.getCondition().getHousingType()).isEqualTo(HousingType.OFFICETEL);
         assertThat(item.getCondition().getAreaMin()).isEqualTo(10);
-        assertThat(item.getReason()).contains("입력하신 조건으로는");
     }
 
     @Test
@@ -342,7 +339,7 @@ class RealisticAlgorithmTest {
     @Test
     @DisplayName("실거래 표본이 아무 조합에도 없으면 추천하지 않는다")
     void returnsEmptyWhenNoMarketData() {
-        Optional<RecommendationItem> result = algorithm.recommend(
+        List<RecommendationItem> result = algorithm.recommend(
                 MEMBER_ID, request("11110", HousingType.APT, DealType.JEONSE), ctx);
 
         assertThat(result).isEmpty();
@@ -352,7 +349,7 @@ class RealisticAlgorithmTest {
 
     private RecommendationItem recommend(GoalRecommendationRequest request) {
         return algorithm.recommend(MEMBER_ID, request, ctx)
-                .orElseThrow(() -> new AssertionError("추천 결과가 비어 있습니다"));
+                .get(0);
     }
 
     private GoalRecommendationRequest request(String regionCode, HousingType housingType, DealType dealType) {

--- a/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
@@ -123,7 +123,7 @@ class RealisticAlgorithmTest {
             return toResponse(asked);
         });
 
-        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any()))
+        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), anyLong()))
                 .thenReturn(LoanPlans.builder().build());
     }
 
@@ -142,7 +142,7 @@ class RealisticAlgorithmTest {
         assertThat(item.getCondition().getAreaMin()).isEqualTo(15);
         assertThat(item.getCondition().getAreaMax()).isEqualTo(19);
         // 화면에 나가는 목표 금액은 실제 보증금이다.
-        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(2 * 억), any());
+        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(2 * 억), any(), anyLong());
     }
 
     @Test
@@ -194,7 +194,7 @@ class RealisticAlgorithmTest {
         assertThat(item.getCondition().getDealType()).isEqualTo(DealType.WOLSE);
         assertThat(item.getCondition().getMonthlyRent()).isEqualTo(40 * 만);
         // 환산값(1.06억)이 아니라 실제로 모아야 하는 보증금(1,000만)을 넘긴다.
-        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(1000 * 만), any());
+        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(1000 * 만), any(), anyLong());
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

- #128

close #128 

## 📝작업 내용

목표 추천 리스트 조회 API(`GET /api/v1/goals/recommendations`) 응답을 명세서에 맞게 정리하고, PREFERENCE 추천을 **저축 고정 / 시점 고정** 두 카드로 분리했습니다.

**응답 구조 정리 (명세서 반영)**
- 응답 DTO에서 `financialContext` / `title` / `reason` / `calculationBasis` 제거 → `RecommendationItem = { type, condition, loanX, loanO }`
- `AlgorithmType` 재정의: `PREFERENCE`·`VALUE` 제거, `PREFERENCE_SAVING_FIXED`·`PREFERENCE_DATE_FIXED` 추가
- 인터페이스 `RecommendationAlgorithm.recommend()` → `List<RecommendationItem>` 반환 (한 알고리즘이 카드 여러 장)

**PreferenceAlgorithm 2카드 분리 (핵심)**
- `PREFERENCE_SAVING_FIXED`: 월 저축액 고정 → 도달 시점 계산
- `PREFERENCE_DATE_FIXED`: 목표 시점 고정 → 필요 월 저축액 역산 (targetDate 미입력 시 `condition: null`)
- 같은 조건(median·MC 1회)을 공유해 계산 방향만 다르게

**요청/계산 정합**
- `monthlySavings`를 요청 파라미터로 받음 (`@NotNull`). 서버 캐시(asset_summary)가 아니라 요청 값을 사용
- `targetDate`에 `@DateTimeFormat(pattern = "yyyy-MM")` 추가 (GET 쿼리 바인딩)
- `LoanPlanCalculator.calculate`에 `effectiveSaving` 인자 추가 → loanO 감당 여부 판정을 요청 저축액 기준으로 통일
- `LoanPlanCalculator.calculateSavingFixed` 신설 (저축 고정 → 도달 시점 계산)

**일관성**
- 데이터가 없을 때 카드를 빼지 않고 `condition: null`로 반환 (HOLD_OUT과 동일하게 4슬롯 유지 → 프론트 카드 자리 고정)
- `RealisticAlgorithm` / `HoldOutAlgorithm`: 시그니처 `List`화 + title/reason/calculationBasis 세팅·죽은 헬퍼 제거 (내부 로직 불변)

**테스트**
- 세 알고리즘 단위 테스트 + LoanPlanCalculator 테스트를 새 API/시그니처에 맞게 갱신, PREFERENCE 2분할·null 케이스 테스트 추가

## 🧪 로컬(profile=local) 테스트 시 주의 (중요)

추천 API는 실 DB를 타므로, 아래 3가지를 먼저 맞춰야 카드가 정상적으로 나옵니다. **아래는 이 PR과 무관한 기존 데이터/환경 이슈**지만, 모르면 "카드가 사라지는" 현상을 겪을 수 있어 남깁니다.

1. **테스트 회원에 연동 자산이 있어야 함** (기본 회원 = member 1, `DevAuthInterceptor`)
   - 없으면 `ASSET_001 자산 연동이 필요합니다`. `connected_account` → `asset_account` 시드 필요.

2. **그 회원의 `occupation_type` / `income_bracket`이 현재 enum 값이어야 함** ⚠️
   - `zMockTestUsers.sql`은 구 코드(`EMPLOYEE`, `M2_TO_3M` 등)를 넣는데, 현재 enum은 `OFFICE_WORKER` / `INCOME_DECILE_*` 라서 `getMember`가 `EnumTypeHandler`에서 예외 → `runSafely`가 삼켜 **PREFERENCE·REALISTIC 카드가 통째로 빠져 보임** (null 카드로도 안 가려짐 — 예외 경로라서).
   - 교정(테스트 회원 id 기준):
     ```sql
     UPDATE member
        SET occupation_type = 'OFFICE_WORKER',
            income_bracket  = 'INCOME_DECILE_6_7'
      WHERE id = 1;
     ```

3. **HOLD_OUT만 빠지면 MySQL `/tmp` 여유 확인**
   - 시도(2자리) 확장 시 서울 전체 실거래로 대용량 임시테이블을 만들어 `/tmp`가 꽉 차면 실패. `docker system df` / 디스크 확보.

> 위 2번(mock ↔ enum 불일치)은 별도 이슈로 다룰 예정입니다. 근본책은 `zMockTestUsers.sql`을 현재 enum으로 갱신하거나, 알 수 없는 값을 폴백하는 관대한 TypeHandler 도입입니다.

### 스크린샷

<img width="1171" height="761" alt="image" src="https://github.com/user-attachments/assets/02311c5d-ecd2-4068-b4e9-a25c5574b87c" />

## 💬리뷰 요구사항

- **`calculateSavingFixed`의 loanO 산식**: 대출금을 즉시 가용 자금으로 편입하고 신규 대출 월 원리금만큼 저축을 차감해 도달월을 재계산하는 방식으로, 기존 `calcShortenedMonths`의 대출 처리와 동일하게 맞췄습니다. 의도와 맞는지 봐주세요.
- **인터페이스 `List`화**에 맞춰 Realistic/HoldOut 시그니처도 함께 수정했습니다(로직 불변). HoldOut 담당자 확인 부탁드려요.
- `targetDate` 미입력 시 `PREFERENCE_DATE_FIXED`를 `condition: null`로 내보내는 처리 방향.