### PR TITLE
fix: HoldOut 알고리즘 계산 방식 오류 및 UX 개선

### DIFF
--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
@@ -42,6 +42,8 @@ public class GoalRecommendationResponse {
         private Long depositMax;
         private Long monthlyRentMin;
         private Long monthlyRentMax;
+        /** 원래 조건의 실거래 중앙값. 조건이 불완전하거나 시세 조회 실패 시 null. */
+        private Long marketMedianAmount;
     }
 
     @Getter

--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
@@ -9,7 +9,10 @@ import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
 import com.team.independence.goal.service.RecommendationAlgorithm.MemberFinancialContext;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
+import com.team.independence.property.dto.RentMedianRequest;
+import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.mapper.RegionMapper;
+import com.team.independence.property.service.RentMedianService;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -39,6 +42,7 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
     private final AssetSummaryService assetSummaryService;
     private final LoanPlanCalculator loanPlanCalculator;
     private final RegionMapper regionMapper;
+    private final RentMedianService rentMedianService;
     private final ObjectProvider<RecommendationAlgorithm> algorithmProvider;
     private final GoalRecommendationStore recommendationStore;
     @Qualifier("algorithmExecutor")
@@ -118,6 +122,7 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
                         .depositMax(request.getDepositMax())
                         .monthlyRentMin(request.getMonthlyRentMin())
                         .monthlyRentMax(request.getMonthlyRentMax())
+                        .marketMedianAmount(resolveBaseMedianAmount(request))
                         .build();
 
         return GoalRecommendationResponse.OriginalPreference.builder()
@@ -125,6 +130,34 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
                 .targetDate(request.getTargetDate())
                 .monthlySaving(monthlySaving)
                 .build();
+    }
+
+    /**
+     * 원래 희망 조건의 실거래 중앙값을 조회한다.
+     * 주거유형·거래유형·최소 평수가 하나라도 없으면 조회 불가이므로 null 반환.
+     */
+    private Long resolveBaseMedianAmount(GoalRecommendationRequest request) {
+        if (request.getPropertyType() == null
+                || request.getTradeType() == null
+                || request.getSizeMin() == null) {
+            return null;
+        }
+        try {
+            RentMedianRequest medianReq = new RentMedianRequest();
+            medianReq.setRegionCode(request.getRegionCode());
+            medianReq.setHousingType(request.getPropertyType());
+            medianReq.setDealType(request.getTradeType());
+            medianReq.setAreaMin(request.getSizeMin());
+            medianReq.setAreaMax(request.getSizeMax());
+            medianReq.setDepositMin(0L);
+            medianReq.setDepositMax(Long.MAX_VALUE);
+
+            RentMedianResponse median = rentMedianService.getMedian(medianReq);
+            return (median.getDeposit() != null) ? median.getDeposit().getQ3() : null;
+        } catch (Exception e) {
+            log.warn("[OriginalPreference] 기준 시세 조회 실패 — null 처리. regionCode={}", request.getRegionCode(), e);
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -1,14 +1,10 @@
 package com.team.independence.goal.service.algorithm;
 
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
-import com.team.independence.goal.domain.Goal;
-import com.team.independence.goal.domain.GoalHousing;
 import com.team.independence.goal.dto.AlgorithmType;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
 import com.team.independence.goal.dto.LoanPlans;
-import com.team.independence.goal.mapper.GoalHousingMapper;
-import com.team.independence.goal.mapper.GoalMapper;
 import com.team.independence.goal.service.MonteCarloEngine;
 import com.team.independence.goal.service.MonteCarloService;
 import com.team.independence.goal.service.calculator.BudgetCalculator;
@@ -21,7 +17,6 @@ import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.service.RentMedianService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.YearMonth;
@@ -33,12 +28,13 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * "더 기다리면 더 넓은 평수로 이사할 수 있어요" 카드를 만드는 HoldOut 추천 알고리즘.
+ * "조금 더 준비하면 더 넓은 평수로 이사할 수 있어요" 카드를 만드는 HoldOut 추천 알고리즘.
  *
- * <h3>핵심 가치</h3>
- * 사용자가 지정한 조건(주거유형·거래유형)은 그대로 유지하되,
- * {@link #PATIENCE_BONUS} 개월 더 인내하면 <b>더 넓은 평수</b>를 얻을 수 있음을 보여준다.
- * 주거유형·거래유형의 "더 좋다"는 기준은 주관적이지만, 평수는 크면 클수록 명확한 업그레이드다.
+ * <h3>핵심 계산 방식</h3>
+ * 월 저축액을 고정하고, 업그레이드된 조건에 언제 도달하는지를 계산한다
+ * ({@link com.team.independence.goal.service.calculator.LoanPlanCalculator#calculateSavingFixed}).
+ * loanX·loanO의 {@code monthlySaving}에는 입력 저축액이 그대로 담기고,
+ * {@code targetDate}가 계산 결과다.
  *
  * <h3>평수 업그레이드 필터</h3>
  * 사용자가 평수를 지정했으면 {@link RecommendationAlgorithm#SIZE_BUCKETS} 중
@@ -46,18 +42,13 @@ import java.util.Map;
  * 같은 평수대를 반환하면 "더 기다려서 얻는 이득"이 없으므로 제외한다.
  * 평수를 지정하지 않은 경우에는 필터 없이 전체 버킷을 탐색하고 스코어링에서 큰 버킷을 선호한다.
  *
- * <h3>지역 확장 폴백</h3>
+ * <h3>지역 확장</h3>
  * 요청 지역이 시군구(5자리)이고 업그레이드 후보가 없으면 상위 시도(2자리)로 확장해 재탐색한다.
- * 이때 "요청 지역은 예산 초과지만 인내하면 인근 지역에서 가능" 메시지를 내보낸다.
  *
- * <h3>기준 조건 결정 우선순위</h3>
- * <ol>
- *   <li>request에 조건이 있으면 사용 (regionCode만 필수, 나머지는 null 허용)</li>
- *   <li>없으면 활성 목표의 GoalHousing 사용</li>
- *   <li>regionCode마저 없으면 Optional.empty()</li>
- * </ol>
+ * <h3>기준 조건</h3>
+ * request 값을 그대로 사용한다. 평수 미지정 시 {@link #DEFAULT_AREA_MIN}·{@link #DEFAULT_AREA_MAX}로
+ * 채워 업그레이드 비교 기준을 확보한다. 주거유형·거래유형 미지정 시 전체 타입을 탐색한다.
  */
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class HoldOutAlgorithm implements RecommendationAlgorithm {
@@ -66,21 +57,19 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
     private static final long WIDE_DEPOSIT_MAX  = 1_000_000_000_000L;
     private static final int  MAX_MC_ITERATIONS = 3;
 
-    /** RentMedianServiceImpl과 동일한 집계 구간 */
     private static final int MONTHS = 6;
     private static final DateTimeFormatter YM = DateTimeFormatter.ofPattern("yyyyMM");
 
-    /**
-     * 추가 인내 허용 개월 수.
-     * targetDate 이후(또는 targetDate 미지정 시 지금부터) 최대 48개월(4년)까지 탐색한다.
-     */
+    /** targetDate 이후(또는 targetDate 미지정 시 지금부터) 최대 48개월(4년)까지 탐색 */
     private static final long PATIENCE_BONUS   = 48;
     private static final long DEFAULT_RENT_MAX = 2_000_000L;
 
+    /** 평수 미지정 시 업그레이드 기준이 되는 기본 면적 구간 (평) */
+    private static final int DEFAULT_AREA_MIN = 10;
+    private static final int DEFAULT_AREA_MAX = 14;
+
     private final LoanPlanCalculator loanPlanCalculator;
     private final BudgetCalculator   budgetCalculator;
-    private final GoalMapper         goalMapper;
-    private final GoalHousingMapper  goalHousingMapper;
     private final RentMedianService  rentMedianService;
     private final MonteCarloService  monteCarloService;
 
@@ -88,13 +77,7 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
     public List<GoalRecommendationResponse.RecommendationItem> recommend(
             long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx
     ) {
-        Goal activeGoal = goalMapper.findActiveByMemberId(memberId);
-        GoalHousing housing = (activeGoal != null)
-                ? goalHousingMapper.findByGoalId(activeGoal.getId())
-                : null;
-
-        BaseCondition base = resolveCondition(request, housing, activeGoal);
-        if (base == null) return List.of();
+        BaseCondition base = resolveCondition(request);
 
         YearMonth now = YearMonth.now();
         AssetNetWorthBreakdown netWorth = ctx.netWorth();
@@ -103,7 +86,6 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
         long n = base.targetDate != null
                 ? Math.max(0, ChronoUnit.MONTHS.between(now, base.targetDate))
                 : 0L;
-        long window = n + PATIENCE_BONUS;
 
         String endYm   = now.format(YM);
         String startYm = now.minusMonths(MONTHS - 1).format(YM);
@@ -111,8 +93,7 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
         // 1차: 요청 지역에서 평수 업그레이드 후보 탐색 (bulk 1회 쿼리)
         Map<String, RentMedianResponse> bulkMedians =
                 rentMedianService.getBulkMedian(base.regionCode, startYm, endYm);
-        List<FetchedCandidate> pool = buildPool(generateCandidates(base), base, netWorth, baseSaving, window, bulkMedians);
-        boolean regionExpanded = false;
+        List<FetchedCandidate> pool = buildPool(generateCandidates(base), base, bulkMedians);
 
         // 2차: 시군구(5자리)로 요청했지만 pool이 비었으면 상위 시도(2자리)로 확장 (bulk 1회 추가)
         if (pool.isEmpty() && base.regionCode.length() > 2) {
@@ -122,8 +103,7 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
             BaseCondition sidoBase = new BaseCondition(
                     sidoCode, base.housingType, base.dealType,
                     base.areaMin, base.areaMax, base.rentMin, base.rentMax, base.targetDate);
-            pool = buildPool(generateCandidates(sidoBase), base, netWorth, baseSaving, window, sidoBulkMedians);
-            regionExpanded = !pool.isEmpty();
+            pool = buildPool(generateCandidates(sidoBase), base, sidoBulkMedians);
         }
 
         ScoredCandidate best = null;
@@ -134,25 +114,15 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
         }
 
         if (best == null) {
-            log.info("[HoldOut] 적합한 후보 없음 — soft-fail 반환 memberId={} regionCode={}", memberId, base.regionCode);
             return List.of(GoalRecommendationResponse.RecommendationItem.builder()
                     .type(AlgorithmType.HOLD_OUT)
                     .build());
         }
 
-        log.info("[HoldOut] 최종 선택 memberId={} {} futurePrice={} m={}개월 score={} regionExpanded={}",
-                memberId, best.candidate.label(),
-                best.futurePrice, best.m, String.format("%.4f", best.score), regionExpanded);
-
-        YearMonth targetDate = now.plusMonths(best.totalMonths);
-        LoanPlans plans = loanPlanCalculator.calculate(memberId, best.futurePrice, targetDate, best.effectiveSaving);
+        LoanPlans plans = loanPlanCalculator.calculateSavingFixed(
+                memberId, best.futurePrice, netWorth, best.effectiveSaving);
 
         GoalRecommendationResponse.LoanOPlan loanO = plans.getLoanO();
-        if (loanO != null) {
-            Long shortened = loanPlanCalculator.calcShortenedMonths(
-                    memberId, netWorth, best.effectiveSaving, best.futurePrice, best.totalMonths);
-            loanO = loanO.toBuilder().shortenedMonths(shortened).build();
-        }
 
         return List.of(GoalRecommendationResponse.RecommendationItem.builder()
                 .type(AlgorithmType.HOLD_OUT)
@@ -209,18 +179,19 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
     }
 
     /**
-     * 시세 조회 → 평수 업그레이드 필터 → 예산 상한 필터.
+     * 시세 조회 → 평수 업그레이드 필터.
      *
      * <p><b>평수 업그레이드 필터</b>: 사용자가 지정한 {@code base.areaMax}보다
-     * {@code areaMin}이 큰 버킷만 허용한다. 같은 평수대를 반환하면 "더 기다려서 더 넓게"라는
-     * HoldOut의 가치를 전달할 수 없기 때문이다.
+     * {@code areaMin}이 큰 버킷만 허용한다.
      * 평수 미지정 시에는 필터 없이 전체 버킷을 탐색한다.
      *
      * <p>지역 확장 시에도 {@code base}는 항상 사용자의 원래 요청 기준을 사용한다.
      * 평수 기준은 지역이 바뀌어도 변하지 않는다.
+     *
+     * <p>예산 상한 필터는 적용하지 않는다. 현재 예산으로 감당 안 되는 후보도 스코어링에서
+     * AM이 낮아져 자연스럽게 순위가 밀리며, 실거래 데이터 자체가 없는 경우에만 null을 반환한다.
      */
     private List<FetchedCandidate> buildPool(List<HousingCondition> candidates, BaseCondition base,
-                                              AssetNetWorthBreakdown netWorth, long baseSaving, long horizon,
                                               Map<String, RentMedianResponse> bulkMedians) {
         List<FetchedCandidate> pool = new ArrayList<>();
         for (HousingCondition candidate : candidates) {
@@ -232,13 +203,6 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
             if (median == null || median.getSampleCount() < MIN_SAMPLE_COUNT) continue;
             if (median.getDeposit().getQ3() == null) continue;
 
-            long effectiveSaving = baseSaving;
-            if (candidate.dealType == DealType.WOLSE) {
-                Long rentQ3 = median.getMonthlyRent() != null ? median.getMonthlyRent().getQ3() : null;
-                if (rentQ3 != null) effectiveSaving = Math.max(0, baseSaving - rentQ3);
-            }
-            if (median.getDeposit().getQ3() > budgetCalculator.calculate(netWorth, effectiveSaving, horizon)) continue;
-
             pool.add(new FetchedCandidate(candidate, median));
         }
         return pool;
@@ -246,7 +210,7 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
 
     /**
      * 스코어: 0.35×cIS + 0.30×WP + 0.20×AM + 0.15×SP
-     * m > PATIENCE_BONUS 이면 null 반환 (MC 수렴 후 실제 도달 개월이 window를 넘는 경우).
+     * 실거래 데이터가 없어 calcBudgetMetrics가 null을 반환하는 경우에만 null 반환.
      */
     private ScoredCandidate evaluate(FetchedCandidate fc, BaseCondition base,
                                      AssetNetWorthBreakdown netWorth, long baseSaving, long n) {
@@ -257,10 +221,10 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
 
         BudgetMetrics metrics = calcBudgetMetrics(candidate, median, netWorth, baseSaving, n);
         if (metrics == null) return null;
-        if (metrics.m > PATIENCE_BONUS) return null;
 
         long maxBudget = budgetCalculator.calculate(netWorth, metrics.effectiveSaving, n + PATIENCE_BONUS);
-        double affordabilityMargin = (double)(maxBudget - metrics.futurePrice) / maxBudget;
+        double affordabilityMargin = Math.max(-1.0,
+                (double)(maxBudget - metrics.futurePrice) / maxBudget);
         double condImprovScore = (base.areaMin == null || base.areaMax == null)
                 ? 0.5
                 : calcConditionImprovementScore((base.areaMin + base.areaMax) / 2.0, candidateMidArea);
@@ -270,13 +234,6 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
                      + 0.30 * waitPenalty
                      + 0.20 * affordabilityMargin
                      + 0.15 * spScore;
-
-        log.debug("{} deposit={} effectiveSaving={} totalMonths={} m={} cIS={} WP={} AM={} SP={} score={}",
-                candidate.label(), metrics.futurePrice, metrics.effectiveSaving, metrics.totalMonths, metrics.m,
-                String.format("%.2f", condImprovScore), String.format("%.3f", waitPenalty),
-                String.format("%.3f", affordabilityMargin),
-                metrics.successProbability != null ? String.format("%.3f", metrics.successProbability) : "null",
-                String.format("%.4f", score));
 
         return new ScoredCandidate(candidate, median, metrics.futurePrice, metrics.effectiveSaving,
                 metrics.totalMonths, metrics.m, score);
@@ -318,7 +275,6 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
                 totalMonths = nextMonths;
             }
         } catch (RuntimeException e) {
-            log.warn("[HoldOut] MC 실패, 현재 시세 폴백 {} : {}", candidate.label(), e.getMessage());
             totalMonths = initialMonths;
             futurePrice = initialPrice;
             successProbability = null;
@@ -335,27 +291,16 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
 
     // ─── resolveCondition ────────────────────────────────────────────────────────
 
-    private BaseCondition resolveCondition(GoalRecommendationRequest req, GoalHousing housing, Goal activeGoal) {
-        String regionCode = pick(req.getRegionCode(), housing != null ? housing.getRegionCode() : null);
-        if (regionCode == null) return null;
-
-        YearMonth targetDate = req.getTargetDate() != null ? req.getTargetDate()
-                : (activeGoal != null && activeGoal.getTargetDate() != null)
-                    ? YearMonth.from(activeGoal.getTargetDate()) : null;
-
+    private BaseCondition resolveCondition(GoalRecommendationRequest req) {
         return new BaseCondition(
-                regionCode,
-                pick(req.getPropertyType(),  housing != null ? housing.getHousingType()    : null),
-                pick(req.getTradeType(),      housing != null ? housing.getDealType()       : null),
-                pick(req.getSizeMin(),        housing != null ? housing.getAreaMin()        : null),
-                pick(req.getSizeMax(),        housing != null ? housing.getAreaMax()        : null),
-                pick(req.getMonthlyRentMin(), housing != null ? housing.getMonthlyRentMin() : null),
-                pick(req.getMonthlyRentMax(), housing != null ? housing.getMonthlyRentMax() : null),
-                targetDate);
-    }
-
-    private <T> T pick(T primary, T fallback) {
-        return primary != null ? primary : fallback;
+                req.getRegionCode(),
+                req.getPropertyType(),
+                req.getTradeType(),
+                req.getSizeMin()        != null ? req.getSizeMin()        : DEFAULT_AREA_MIN,
+                req.getSizeMax()        != null ? req.getSizeMax()        : DEFAULT_AREA_MAX,
+                req.getMonthlyRentMin(),
+                req.getMonthlyRentMax(),
+                req.getTargetDate());
     }
 
     // ─── 내부 타입 ────────────────────────────────────────────────────────────────
@@ -375,13 +320,7 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
         }
 
         PriceModelRequest toPriceModelRequest() {
-            PriceModelRequest req = new PriceModelRequest();
-            req.setRegionCode(regionCode);
-            req.setHousingType(housingType);
-            req.setDealType(dealType);
-            req.setAreaMin(areaMin);
-            req.setAreaMax(areaMax);
-            return req;
+            return RecommendationAlgorithm.buildPriceModelRequest(regionCode, housingType, dealType, areaMin, areaMax);
         }
 
         RentMedianRequest toMedianRequest() {

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
@@ -12,8 +12,6 @@ import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.service.RecommendationAlgorithm.MemberFinancialContext;
 import com.team.independence.goal.dto.GoalRecommendationResponse.RecommendationItem;
 import com.team.independence.goal.dto.LoanPlans;
-import com.team.independence.goal.mapper.GoalHousingMapper;
-import com.team.independence.goal.mapper.GoalMapper;
 import com.team.independence.goal.service.MonteCarloEngine;
 import com.team.independence.goal.service.MonteCarloService;
 import com.team.independence.goal.service.calculator.BudgetCalculator;
@@ -60,8 +58,6 @@ class HoldOutAlgorithmTest {
     private static final YearMonth NOW = YearMonth.now();
 
     @Mock private LoanPlanCalculator loanPlanCalculator;
-    @Mock private GoalMapper goalMapper;
-    @Mock private GoalHousingMapper goalHousingMapper;
     @Mock private RentMedianService rentMedianService;
     @Mock private MonteCarloService monteCarloService;
 
@@ -77,8 +73,7 @@ class HoldOutAlgorithmTest {
     @BeforeEach
     void setUp() {
         algorithm = new HoldOutAlgorithm(
-                loanPlanCalculator, budgetCalculator, goalMapper, goalHousingMapper,
-                rentMedianService, monteCarloService);
+                loanPlanCalculator, budgetCalculator, rentMedianService, monteCarloService);
 
         when(monteCarloService.simulate(any(PriceModelRequest.class), anyLong(), anyLong(), anyInt()))
                 .thenAnswer(call -> {
@@ -95,8 +90,7 @@ class HoldOutAlgorithmTest {
                 .flatRecognizedAssets(0L)
                 .build();
         ctx = new MemberFinancialContext(defaultNetWorth, 10_000_000L, 0L);
-        when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(null);
-        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), anyLong()))
+        when(loanPlanCalculator.calculateSavingFixed(anyLong(), anyLong(), any(AssetNetWorthBreakdown.class), anyLong()))
                 .thenReturn(LoanPlans.builder().build());
         when(rentMedianService.getBulkMedian(anyString(), anyString(), anyString()))
                 .thenAnswer(call -> toBulkMap(call.getArgument(0)));
@@ -121,14 +115,14 @@ class HoldOutAlgorithmTest {
     @DisplayName("기존 대출 월상환액을 월저축액에서 차감한 뒤 예산을 계산한다")
     void deductsExistingLoanPaymentFromSaving() {
         // 월저축 1천만, 대출 월상환 900만 → baseSaving 100만
-        // 2억을 100만/월로 모으면 ~169개월 → PATIENCE_BONUS(48) 초과 → soft-fail
+        // 2억을 100만/월로 모으면 ~169개월 걸리지만 실거래 데이터가 있으므로 추천 카드가 생성된다
         MemberFinancialContext ctx = ctxWithLoan(9_000_000L);
         put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
 
         List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNull();
+        assertThat(result.get(0).getCondition()).isNotNull();
     }
 
     @Test
@@ -136,7 +130,7 @@ class HoldOutAlgorithmTest {
     void deductsRentOnTopOfLoanPayment() {
         // 월저축 1천만, 대출 월상환 500만 → baseSaving 500만
         // 월세 Q3 = 450만 → effectiveSaving 50만
-        // 1억 보증금을 50만/월로 모으면 ~180개월 → PATIENCE_BONUS(48) 초과 → 추천 없음
+        // 1억 보증금을 50만/월로 모으면 ~180개월 걸리지만 실거래 데이터가 있으므로 추천 카드가 생성된다
         MemberFinancialContext ctx = ctxWithLoan(5_000_000L);
         put("11110", HousingType.APT, DealType.WOLSE, 26, 40, 1 * 억, 450 * 만);
 
@@ -151,7 +145,7 @@ class HoldOutAlgorithmTest {
         List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNull();
+        assertThat(result.get(0).getCondition()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

- #132

## 📝작업 내용

### 1. `calculate` → `calculateSavingFixed` 교체

기존 `calculate`는 목표 시점을 고정하고 필요 저축액을 역산하는 방식이라, HoldOut에서 사용 시 세 가지 오류 발생.

| 항목 | 수정 전 | 수정 후 |
|---|---|---|
| `loanX.monthlySaving` | 목표 시점 기준 역산값 | 입력 저축액 그대로 |
| `loanO.targetDate` | `loanX`와 동일 (단축 없음) | `loanX`보다 이른 날짜 (대출 단축 반영) |
| `shortenedMonths` | 항상 0 | 올바른 단축 개월 수 |

### 2. `OriginalCondition.marketMedianAmount` 추가

프론트의 "원래 조건 → 추천 조건" 시세 비교 섹션에 기준 시세를 제공.
주거유형·거래유형·최소평수가 모두 지정된 경우에만 조회하며, 실패 시 null 처리.

### 3. GoalHousing 참조 제거 + 면적 기본값 적용

기준 조건을 request 값만으로 결정하도록 단순화. 평수 미지정 시 `DEFAULT_AREA_MIN=10`, `DEFAULT_AREA_MAX=14`(10~14평) 기본값 적용.

### 4. 예산 상한 필터 및 PATIENCE_BONUS 제약 제거

48개월 예산 상한을 초과하는 후보를 buildPool과 evaluate 두 곳에서 이중으로 제거하던 로직 삭제.
실거래 데이터(sampleCount ≥ 10)가 존재하면 항상 후보로 올라오며, 대신 스코어링 WP·AM이 낮아져 자연스럽게 순위가 밀림.

**soft-fail(condition=null) 발생 조건 변경**

- 수정 전: sampleCount < 10 **또는** 예산 초과(48개월 이내 달성 불가)
- 수정 후: sampleCount < 10 **인 경우에만**

### 5. AM 점수 클램프

예산 필터 제거로 `futurePrice > maxBudget(n+48)` 케이스에서 AM이 음수가 될 수 있음.
`max(-1.0, AM)`으로 클램프해 score 기여 범위를 `[-0.20, +0.20]`으로 고정.