### PR TITLE
feat: LoanSchedule 기반 대출 구간별 예산 반영 + HoldOut 알고리즘 재설계

### DIFF
--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
@@ -8,11 +8,15 @@ import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
 import com.team.independence.goal.service.RecommendationAlgorithm.MemberFinancialContext;
+import com.team.independence.goal.service.algorithm.HoldOutAlgorithm;
+import com.team.independence.goal.service.algorithm.RealisticAlgorithm;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
+import com.team.independence.goal.service.calculator.LoanSchedule;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.mapper.RegionMapper;
 import com.team.independence.property.service.RentMedianService;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -25,13 +29,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * 등록된 추천 알고리즘을 모두 실행해 결과를 모은다.
+ * 등록된 추천 알고리즘을 2-Phase로 실행해 결과를 모은다.
  *
- * <p>추천 로직은 전혀 갖고 있지 않다. 알고리즘 추가·제거 시 이 클래스는 수정하지 않는다.
+ * <h3>실행 순서</h3>
+ * <ul>
+ *   <li><b>Phase 1 (병렬)</b>: RealisticAlgorithm + 기타 알고리즘(PreferenceAlgorithm 등)</li>
+ *   <li><b>Phase 2 (Realistic 완료 후)</b>: HoldOutAlgorithm — Realistic 결과를 기준점으로 사용</li>
+ * </ul>
  *
- * <p>알고리즘 목록을 {@link ObjectProvider}로 받는 이유는, 아직 구현체가 하나도 없는 상태에서도
- * 애플리케이션이 기동되도록 하기 위해서다. {@code List<RecommendationAlgorithm>}를 생성자로 직접
- * 주입하면 후보 빈이 없을 때 기동이 실패해, 알고리즘 담당자들이 서로의 구현을 기다려야 한다.
+ * <p>HoldOut은 Realistic 결과를 기준점으로 삼아 동작하므로 Realistic 완료를 기다렸다가 실행한다.
+ * 다른 알고리즘은 HoldOut 완료와 무관하게 Phase 1에서 병렬로 처리한다.
+ *
+ * <p>알고리즘 하나가 실패해도 나머지 추천은 내려준다.
+ * 모든 알고리즘이 실패하면 {@code GOAL_RECOMMENDATION_NO_CANDIDATE}를 던진다.
  */
 @Slf4j
 @Service
@@ -43,6 +53,9 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
     private final LoanPlanCalculator loanPlanCalculator;
     private final RegionMapper regionMapper;
     private final RentMedianService rentMedianService;
+    private final RealisticAlgorithm realisticAlgorithm;
+    private final HoldOutAlgorithm holdOutAlgorithm;
+    /** Preference 등 Phase 1 나머지 알고리즘 — HoldOut·Realistic은 위에서 직접 주입한다. */
     private final ObjectProvider<RecommendationAlgorithm> algorithmProvider;
     private final GoalRecommendationStore recommendationStore;
     @Qualifier("algorithmExecutor")
@@ -51,35 +64,45 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
     @Override
     @Transactional(readOnly = true)
     public GoalRecommendationResponse recommend(long memberId, GoalRecommendationRequest request) {
-        // 자산이 연동돼 있어야 예산 계산이 가능하다
         assetConnectionService.validateConnectedAccountExists(memberId);
 
-        List<RecommendationAlgorithm> algorithms = algorithmProvider.orderedStream()
-                .collect(Collectors.toList());
-
-        if (algorithms.isEmpty()) {
-            log.warn("등록된 추천 알고리즘이 없습니다. RecommendationAlgorithm 구현체를 추가해야 합니다.");
-        }
-
         AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
-        // 월 저축액은 서버 캐시(asset_summary)가 아니라 요청 값을 그대로 쓴다 (@NotNull이라 항상 존재)
         long monthlySaving = request.getMonthlySavings();
-        long loanPayment   = loanPlanCalculator.calcTotalExistingMonthlyPayment(memberId);
-        MemberFinancialContext ctx = new MemberFinancialContext(netWorth, monthlySaving, loanPayment);
+        List<LoanSchedule> loanSchedules = loanPlanCalculator.getLoanSchedules(memberId);
+        MemberFinancialContext ctx = new MemberFinancialContext(netWorth, monthlySaving, loanSchedules);
 
-        List<CompletableFuture<List<GoalRecommendationResponse.RecommendationItem>>> futures =
-                algorithms.stream()
-                        .map(algorithm -> CompletableFuture.supplyAsync(
-                                () -> runSafely(algorithm, memberId, request, ctx),
-                                algorithmExecutor))
+        // Phase 1: Realistic + 기타(Preference 등) 병렬 실행
+        CompletableFuture<List<GoalRecommendationResponse.RecommendationItem>> realisticFuture =
+                CompletableFuture.supplyAsync(
+                        () -> runSafely(realisticAlgorithm, memberId, request, ctx), algorithmExecutor);
+
+        List<CompletableFuture<List<GoalRecommendationResponse.RecommendationItem>>> otherFutures =
+                algorithmProvider.orderedStream()
+                        .filter(a -> !(a instanceof RealisticAlgorithm) && !(a instanceof HoldOutAlgorithm))
+                        .map(a -> CompletableFuture.supplyAsync(
+                                () -> runSafely(a, memberId, request, ctx), algorithmExecutor))
                         .collect(Collectors.toList());
 
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        // Phase 2: Realistic 완료 후 HoldOut 실행
+        CompletableFuture<List<GoalRecommendationResponse.RecommendationItem>> holdOutFuture =
+                realisticFuture.thenApplyAsync(realisticItems -> {
+                    GoalRecommendationResponse.RecommendationItem realisticItem =
+                            realisticItems.isEmpty() ? null : realisticItems.get(0);
+                    return runHoldOutSafely(memberId, request, ctx, realisticItem);
+                }, algorithmExecutor);
 
-        List<GoalRecommendationResponse.RecommendationItem> recommendations = futures.stream()
-                .map(CompletableFuture::join)
-                .flatMap(List::stream)
-                .collect(Collectors.toList());
+        // 모두 완료 대기
+        List<CompletableFuture<?>> allFutures = new ArrayList<>();
+        allFutures.add(realisticFuture);
+        allFutures.add(holdOutFuture);
+        allFutures.addAll(otherFutures);
+        CompletableFuture.allOf(allFutures.toArray(new CompletableFuture[0])).join();
+
+        // 결과 수집 (순서 고정: Realistic → HoldOut → 기타)
+        List<GoalRecommendationResponse.RecommendationItem> recommendations = new ArrayList<>();
+        recommendations.addAll(realisticFuture.join());
+        recommendations.addAll(holdOutFuture.join());
+        otherFutures.forEach(f -> recommendations.addAll(f.join()));
 
         if (recommendations.isEmpty()) {
             throw new BusinessException(ErrorCode.GOAL_RECOMMENDATION_NO_CANDIDATE);
@@ -90,7 +113,6 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
                 .recommendations(recommendations)
                 .build();
 
-        // 결과 화면 재진입 시 재계산 없이 그대로 돌려주기 위해 저장한다
         recommendationStore.save(memberId, response);
         return response;
     }
@@ -162,9 +184,6 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
 
     /**
      * 알고리즘 하나가 실패해도 나머지 추천은 내려주기 위해 예외를 삼킨다.
-     *
-     * <p>알고리즘들은 서로 독립적이라 하나의 오류가 전체 응답을 막을 이유가 없다.
-     * 다만 모든 알고리즘이 실패하면 결과가 비어 {@code GOAL_RECOMMENDATION_NO_CANDIDATE}로 이어진다.
      */
     private List<GoalRecommendationResponse.RecommendationItem> runSafely(
             RecommendationAlgorithm algorithm, long memberId,
@@ -178,4 +197,14 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
         }
     }
 
+    private List<GoalRecommendationResponse.RecommendationItem> runHoldOutSafely(
+            long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx,
+            GoalRecommendationResponse.RecommendationItem realisticItem) {
+        try {
+            return holdOutAlgorithm.recommend(memberId, request, ctx, realisticItem);
+        } catch (Exception e) {
+            log.error("HoldOut 알고리즘 실행 실패. memberId={}", memberId, e);
+            return List.of();
+        }
+    }
 }

--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -19,6 +19,8 @@ import com.team.independence.goal.mapper.GoalHousingMapper;
 import com.team.independence.goal.mapper.GoalMapper;
 import com.team.independence.goal.service.calculator.BudgetCalculator;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
+import com.team.independence.goal.service.calculator.LoanSchedule;
+import java.util.List;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.dto.RentMedianRequest;
@@ -101,9 +103,10 @@ public class GoalServiceImpl implements GoalService {
 
         long months = monthsUntil(request.getTargetDate()); // 현재 시점부터 목표 시점까지 남은 개월 수 계산
 
-        long effectiveMonthlySavings = calcEffectiveMonthlySaving(memberId, request.getMonthlySavings());
+        List<LoanSchedule> loanSchedules = loanPlanCalculator.getLoanSchedules(memberId);
+        long rawMonthlySavings = request.getMonthlySavings();
         long recognizedAssets = budgetCalculator.calculate(netWorth, 0L, months);
-        long totalBudget = budgetCalculator.calculate(netWorth, effectiveMonthlySavings, months);
+        long totalBudget = budgetCalculator.calculate(netWorth, rawMonthlySavings, loanSchedules, months);
         long projectedSavings = totalBudget - recognizedAssets;
 
         // 사용자 희망 조건에 맞는 실거래 4분위값을 조회
@@ -131,9 +134,9 @@ public class GoalServiceImpl implements GoalService {
             long median = marketStats.getDeposit().getMedian();
             adjustmentSuggestions = GoalDiagnosisResponse.AdjustmentSuggestions.builder()
                     .increaseSavings(calculateIncreaseSavingsSuggestion(
-                            median, netWorth, effectiveMonthlySavings, months))
+                            median, netWorth, rawMonthlySavings, loanSchedules, months))
                     .extendPeriod(calculateExtendPeriodSuggestion(
-                            netWorth, effectiveMonthlySavings, months,
+                            netWorth, rawMonthlySavings, loanSchedules, months,
                             median, request.getTargetDate()))
                     .reduceSize(calculateReduceSizeSuggestion(
                             regionCode, housingType, dealType,
@@ -364,14 +367,8 @@ public class GoalServiceImpl implements GoalService {
     @Override
     public Long calculateEffectiveMonthToReach(long memberId, AssetNetWorthBreakdown netWorth,
                                                long monthlySaving, long targetAmount) {
-        long effective = calcEffectiveMonthlySaving(memberId, monthlySaving);
-        return budgetCalculator.monthsToReach(netWorth, effective, targetAmount);
-    }
-
-    /** 기존 대출 월상환액을 차감한 실질 월저축액. 대출 상환액이 저축액을 초과하면 0으로 처리한다. */
-    private long calcEffectiveMonthlySaving(long memberId, long monthlySaving) {
-        long loanPayment = loanPlanCalculator.calcTotalExistingMonthlyPayment(memberId);
-        return Math.max(0L, monthlySaving - loanPayment);
+        List<LoanSchedule> schedules = loanPlanCalculator.getLoanSchedules(memberId);
+        return budgetCalculator.monthsToReach(netWorth, monthlySaving, schedules, targetAmount);
     }
 
     // 현재 활성 목표에 대한 매물 시세 변화 데이터 조회
@@ -567,8 +564,13 @@ public class GoalServiceImpl implements GoalService {
     }
 
     /** 같은 개월수 기준, budget이 median에 도달하도록 월저축액을 이진탐색으로 역산 */
+    /**
+     * 이진탐색으로 "필요 raw 저축액"을 찾는다.
+     * 대출 스케줄은 고정이므로 rawSaving을 높이는 방향으로만 탐색한다.
+     */
     private GoalDiagnosisResponse.IncreaseSavingsSuggestion calculateIncreaseSavingsSuggestion(
-            long median, AssetNetWorthBreakdown netWorth, long monthlySavings, long months) {
+            long median, AssetNetWorthBreakdown netWorth, long monthlySavings,
+            List<LoanSchedule> loanSchedules, long months) {
         if (months == 0) {
             return null;
         }
@@ -576,7 +578,7 @@ public class GoalServiceImpl implements GoalService {
         long hi = median;
         while (hi - lo > 1) {
             long mid = (lo + hi) / 2;
-            if (budgetCalculator.calculate(netWorth, mid, months) >= median) {
+            if (budgetCalculator.calculate(netWorth, mid, loanSchedules, months) >= median) {
                 hi = mid;
             } else {
                 lo = mid;
@@ -591,11 +593,11 @@ public class GoalServiceImpl implements GoalService {
 
     /** 월저축액 고정, budget이 median에 도달하는 최소 개월수를 탐색(최대 EXTEND_PERIOD_MAX_MONTHS). */
     private GoalDiagnosisResponse.ExtendPeriodSuggestion calculateExtendPeriodSuggestion(
-            AssetNetWorthBreakdown netWorth, long monthlySavings, long months,
-            long median, YearMonth targetDate) {
+            AssetNetWorthBreakdown netWorth, long monthlySavings, List<LoanSchedule> loanSchedules,
+            long months, long median, YearMonth targetDate) {
 
         for (long n = months + 1; n <= EXTEND_PERIOD_MAX_MONTHS; n++) {
-            if (budgetCalculator.calculate(netWorth, monthlySavings, n) >= median) {
+            if (budgetCalculator.calculate(netWorth, monthlySavings, loanSchedules, n) >= median) {
                 long additionalMonths = n - months;
                 return GoalDiagnosisResponse.ExtendPeriodSuggestion.builder()
                         .additionalMonths(additionalMonths)

--- a/src/main/java/com/team/independence/goal/service/RecommendationAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/RecommendationAlgorithm.java
@@ -3,6 +3,7 @@ package com.team.independence.goal.service;
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
+import com.team.independence.goal.service.calculator.LoanSchedule;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.dto.PriceModelRequest;
@@ -62,11 +63,13 @@ public interface RecommendationAlgorithm {
     record MemberFinancialContext(
             AssetNetWorthBreakdown netWorth,
             long rawMonthlySaving,
-            long loanPayment) {
+            List<LoanSchedule> loanSchedules) {
 
-        /** 기존 대출 월상환액 차감 후 실질 저축 여력 */
-        public long effectiveSaving() {
-            return Math.max(0, rawMonthlySaving - loanPayment);
+        /** "지금 시점" 기준 실질 저축 여력 — DSR 계산 등 현재 스냅샷이 필요한 곳에서만 사용 */
+        public long currentEffectiveSaving() {
+            long totalNow = loanSchedules.stream()
+                    .mapToLong(LoanSchedule::monthlyPayment).sum();
+            return Math.max(0, rawMonthlySaving - totalNow);
         }
     }
 

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -1,351 +1,288 @@
 package com.team.independence.goal.service.algorithm;
 
-import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
 import com.team.independence.goal.dto.AlgorithmType;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
 import com.team.independence.goal.dto.LoanPlans;
 import com.team.independence.goal.service.MonteCarloEngine;
 import com.team.independence.goal.service.MonteCarloService;
+import com.team.independence.goal.service.RecommendationAlgorithm;
 import com.team.independence.goal.service.calculator.BudgetCalculator;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
-import com.team.independence.goal.service.RecommendationAlgorithm;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
-import com.team.independence.property.dto.PriceModelRequest;
-import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.service.RentMedianService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 /**
- * "조금 더 준비하면 더 넓은 평수로 이사할 수 있어요" 카드를 만드는 HoldOut 추천 알고리즘.
+ * Realistic 결과를 기준점으로 삼아 변수 하나씩 업그레이드한 조건을 추천하는 HoldOut 알고리즘.
  *
- * <h3>핵심 계산 방식</h3>
- * 월 저축액을 고정하고, 업그레이드된 조건에 언제 도달하는지를 계산한다
- * ({@link com.team.independence.goal.service.calculator.LoanPlanCalculator#calculateSavingFixed}).
- * loanX·loanO의 {@code monthlySaving}에는 입력 저축액이 그대로 담기고,
- * {@code targetDate}가 계산 결과다.
+ * <h3>컨셉</h3>
+ * Realistic이 "지금 저축으로 목표 시점 안에 가능한 조건"을 찾아주면,
+ * HoldOut은 그 결과를 기준점(baseline)으로 삼아 변수 하나만 올린 업그레이드 후보를 탐색한다.
+ * "조금 더 기다리면 한 단계 나은 집을 얻을 수 있다"는 메시지를 만드는 카드다.
  *
- * <h3>평수 업그레이드 필터</h3>
- * 사용자가 평수를 지정했으면 {@link RecommendationAlgorithm#SIZE_BUCKETS} 중
- * {@code areaMin > base.areaMax} 인 버킷만 후보로 허용한다.
- * 같은 평수대를 반환하면 "더 기다려서 얻는 이득"이 없으므로 제외한다.
- * 평수를 지정하지 않은 경우에는 필터 없이 전체 버킷을 탐색하고 스코어링에서 큰 버킷을 선호한다.
+ * <h3>업그레이드 후보 (한 번에 하나씩)</h3>
+ * <ul>
+ *   <li><b>평수</b>: baseline의 areaMax보다 areaMin이 큰 바로 다음 SIZE_BUCKET</li>
+ *   <li><b>주거유형</b>: 현재 타입 바로 상위 (DETACHED → ROW_HOUSE, ROW_HOUSE·OFFICETEL → APT)</li>
+ *   <li><b>거래유형</b>: baseline이 월세인 경우에만 전세로 변경</li>
+ * </ul>
  *
- * <h3>지역 확장</h3>
- * 요청 지역이 시군구(5자리)이고 업그레이드 후보가 없으면 상위 시도(2자리)로 확장해 재탐색한다.
+ * <h3>스코어링</h3>
+ * score = 0.5 × condImprovScore + 0.5 × horizonScore
+ * <ul>
+ *   <li>condImprovScore: 조건 개선 폭 (평수 면적비, 주거유형·거래유형 업그레이드 고정점수)</li>
+ *   <li>horizonScore = 1 / (1 + extraMonths / 24): 추가 대기 개월이 짧을수록 높다</li>
+ * </ul>
+ * extraMonths가 {@link #MAX_EXTRA_MONTHS}를 초과하는 후보는 제외한다.
  *
- * <h3>기준 조건</h3>
- * request 값을 그대로 사용한다. 평수 미지정 시 {@link #DEFAULT_AREA_MIN}·{@link #DEFAULT_AREA_MAX}로
- * 채워 업그레이드 비교 기준을 확보한다. 주거유형·거래유형 미지정 시 전체 타입을 탐색한다.
+ * <h3>실행 순서 의존성</h3>
+ * 이 알고리즘은 Realistic 결과에 의존한다.
+ * {@link com.team.independence.goal.service.GoalRecommendationServiceImpl}에서
+ * Phase 1(Realistic) 완료 후 Phase 2로 실행된다.
+ * 인터페이스 메서드 {@link #recommend(long, GoalRecommendationRequest, MemberFinancialContext)}는
+ * 직접 호출 시 soft-fail 카드를 반환한다.
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class HoldOutAlgorithm implements RecommendationAlgorithm {
 
-    private static final int  MIN_SAMPLE_COUNT  = 10;
-    private static final long WIDE_DEPOSIT_MAX  = 1_000_000_000_000L;
-    private static final int  MAX_MC_ITERATIONS = 3;
+    private static final int    MIN_SAMPLE_COUNT   = 3;
+    private static final long   MAX_EXTRA_MONTHS   = 36L;
+    private static final double ANNUAL_INTEREST_RATE = 0.05;
+    private static final long   DEPOSIT_MAX_DISPLAY  = 1_000_000_000_000L;
 
     private static final int MONTHS = 6;
     private static final DateTimeFormatter YM = DateTimeFormatter.ofPattern("yyyyMM");
-
-    /** targetDate 이후(또는 targetDate 미지정 시 지금부터) 최대 48개월(4년)까지 탐색 */
-    private static final long PATIENCE_BONUS   = 48;
-    private static final long DEFAULT_RENT_MAX = 2_000_000L;
-
-    /** 평수 미지정 시 업그레이드 기준이 되는 기본 면적 구간 (평) */
-    private static final int DEFAULT_AREA_MIN = 10;
-    private static final int DEFAULT_AREA_MAX = 14;
 
     private final LoanPlanCalculator loanPlanCalculator;
     private final BudgetCalculator   budgetCalculator;
     private final RentMedianService  rentMedianService;
     private final MonteCarloService  monteCarloService;
 
+    /** Realistic 결과 없이 직접 호출되면 soft-fail을 반환한다. */
     @Override
     public List<GoalRecommendationResponse.RecommendationItem> recommend(
-            long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx
-    ) {
-        BaseCondition base = resolveCondition(request);
+            long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx) {
+        return List.of(emptyCard());
+    }
 
-        YearMonth now = YearMonth.now();
-        AssetNetWorthBreakdown netWorth = ctx.netWorth();
-        long baseSaving = ctx.effectiveSaving();
+    /**
+     * Realistic 결과를 받아 한 단계 업그레이드된 조건을 추천한다.
+     *
+     * @param realisticItem Phase 1에서 완료된 Realistic 카드. null이거나 condition이 null이면 soft-fail.
+     */
+    public List<GoalRecommendationResponse.RecommendationItem> recommend(
+            long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx,
+            GoalRecommendationResponse.RecommendationItem realisticItem) {
 
-        long n = base.targetDate != null
-                ? Math.max(0, ChronoUnit.MONTHS.between(now, base.targetDate))
-                : 0L;
-
-        String endYm   = now.format(YM);
-        String startYm = now.minusMonths(MONTHS - 1).format(YM);
-
-        // 1차: 요청 지역에서 평수 업그레이드 후보 탐색 (bulk 1회 쿼리)
-        Map<String, RentMedianResponse> bulkMedians =
-                rentMedianService.getBulkMedian(base.regionCode, startYm, endYm);
-        List<FetchedCandidate> pool = buildPool(generateCandidates(base), base, bulkMedians);
-
-        // 2차: 시군구(5자리)로 요청했지만 pool이 비었으면 상위 시도(2자리)로 확장 (bulk 1회 추가)
-        if (pool.isEmpty() && base.regionCode.length() > 2) {
-            String sidoCode = base.regionCode.substring(0, 2);
-            Map<String, RentMedianResponse> sidoBulkMedians =
-                    rentMedianService.getBulkMedian(sidoCode, startYm, endYm);
-            BaseCondition sidoBase = new BaseCondition(
-                    sidoCode, base.housingType, base.dealType,
-                    base.areaMin, base.areaMax, base.rentMin, base.rentMax, base.targetDate);
-            pool = buildPool(generateCandidates(sidoBase), base, sidoBulkMedians);
+        if (realisticItem == null || realisticItem.getCondition() == null) {
+            return List.of(emptyCard());
         }
 
+        GoalRecommendationResponse.Condition baseline = realisticItem.getCondition();
+
+        long baselineComparable = toComparableAmount(
+                baseline.getMarketMedianAmount(), baseline.getMonthlyRent());
+        Long baselineReachMonths = budgetCalculator.monthsToReach(
+                ctx.netWorth(), ctx.rawMonthlySaving(), ctx.loanSchedules(), baselineComparable);
+        if (baselineReachMonths == null) baselineReachMonths = 0L;
+
+        long desiredMonths = request.getTargetDate() != null
+                ? RecommendationAlgorithm.monthsUntil(request.getTargetDate())
+                : 24L;
+
+        YearMonth now = YearMonth.now();
+        String endYm   = now.format(YM);
+        String startYm = now.minusMonths(MONTHS - 1).format(YM);
+        Map<String, RentMedianResponse> bulkMedians =
+                rentMedianService.getBulkMedian(baseline.getRegionCode(), startYm, endYm);
+
+        List<UpgradeCandidate> candidates = buildUpgradeCandidates(baseline);
+
         ScoredCandidate best = null;
-        for (FetchedCandidate fc : pool) {
-            ScoredCandidate scored = evaluate(fc, base, netWorth, baseSaving, n);
+        for (UpgradeCandidate uc : candidates) {
+            ScoredCandidate scored = evaluate(uc, baseline, baselineReachMonths, bulkMedians, ctx, desiredMonths);
             if (scored == null) continue;
-            if (best == null || scored.score > best.score) best = scored;
+            if (best == null || scored.score() > best.score()) best = scored;
         }
 
         if (best == null) {
-            return List.of(GoalRecommendationResponse.RecommendationItem.builder()
-                    .type(AlgorithmType.HOLD_OUT)
-                    .build());
+            return List.of(emptyCard());
         }
 
         LoanPlans plans = loanPlanCalculator.calculateSavingFixed(
-                memberId, best.futurePrice, netWorth, best.effectiveSaving);
-
-        GoalRecommendationResponse.LoanOPlan loanO = plans.getLoanO();
+                memberId, best.deposit(), ctx.netWorth(), ctx.rawMonthlySaving(), ctx.loanSchedules());
 
         return List.of(GoalRecommendationResponse.RecommendationItem.builder()
                 .type(AlgorithmType.HOLD_OUT)
                 .condition(GoalRecommendationResponse.Condition.builder()
-                        .regionCode(best.median.getRegionCode())
-                        .regionName(best.median.getRegionName())
-                        .housingType(best.candidate.housingType)
-                        .dealType(best.candidate.dealType)
-                        .areaMin(best.candidate.areaMin)
-                        .areaMax(best.candidate.areaMax)
-                        .depositMin(best.candidate.depositMin)
-                        .depositMax(best.candidate.depositMax)
-                        .monthlyRent(best.candidate.dealType == DealType.WOLSE
-                                && best.median.getMonthlyRent() != null
-                                && best.median.getMonthlyRent().getQ3() != null
-                                ? best.median.getMonthlyRent().getQ3() : 0L)
-                        .sampleCount(best.median.getSampleCount())
-                        .marketMedianAmount(best.futurePrice)
+                        .regionCode(best.regionCode())
+                        .regionName(best.regionName())
+                        .housingType(best.housingType())
+                        .dealType(best.dealType())
+                        .areaMin(best.areaMin())
+                        .areaMax(best.areaMax())
+                        .depositMin(0L)
+                        .depositMax(DEPOSIT_MAX_DISPLAY)
+                        .monthlyRent(best.monthlyRent())
+                        .sampleCount(best.sampleCount())
+                        .marketMedianAmount(best.deposit())
                         .build())
                 .loanX(plans.getLoanX())
-                .loanO(loanO)
+                .loanO(plans.getLoanO())
                 .build());
     }
 
-    /**
-     * 기준 조건에서 후보 목록을 생성한다.
-     * housingType/dealType이 null이면 가능한 모든 타입 조합을 탐색한다.
-     * 면적은 {@link RecommendationAlgorithm#SIZE_BUCKETS} 공유 버킷을 그대로 사용한다.
-     */
-    private List<HousingCondition> generateCandidates(BaseCondition base) {
-        List<HousingType> types = base.housingType != null
-                ? List.of(base.housingType)
-                : Arrays.asList(HousingType.values());
-        List<DealType> deals = base.dealType != null
-                ? List.of(base.dealType)
-                : Arrays.asList(DealType.values());
+    // ─── 업그레이드 후보 생성 ─────────────────────────────────────────────────────
 
-        List<HousingCondition> candidates = new ArrayList<>();
-        for (HousingType ht : types) {
-            for (DealType dt : deals) {
-                boolean isJeonse = dt == DealType.JEONSE;
-                Long rentMin = isJeonse ? null : base.rentMin;
-                Long rentMax = isJeonse ? null : (base.rentMax != null ? base.rentMax : DEFAULT_RENT_MAX);
-                for (int[] size : SIZE_BUCKETS) {
-                    candidates.add(new HousingCondition(
-                            base.regionCode, ht, dt,
-                            size[0], size[1],
-                            0L, WIDE_DEPOSIT_MAX,
-                            rentMin, rentMax));
-                }
-            }
+    private List<UpgradeCandidate> buildUpgradeCandidates(GoalRecommendationResponse.Condition baseline) {
+        List<UpgradeCandidate> candidates = new ArrayList<>();
+
+        // 평수 업그레이드: baseline.areaMax보다 areaMin이 큰 바로 다음 버킷
+        int[] nextSize = nextSizeBucket(baseline.getAreaMax());
+        if (nextSize != null) {
+            candidates.add(new UpgradeCandidate(
+                    baseline.getRegionCode(), baseline.getHousingType(), baseline.getDealType(),
+                    nextSize[0], nextSize[1], UpgradeType.SIZE));
         }
+
+        // 주거유형 업그레이드: 현재 타입의 바로 상위
+        HousingType nextType = nextHousingType(baseline.getHousingType());
+        if (nextType != null) {
+            candidates.add(new UpgradeCandidate(
+                    baseline.getRegionCode(), nextType, baseline.getDealType(),
+                    baseline.getAreaMin(), baseline.getAreaMax(), UpgradeType.HOUSING_TYPE));
+        }
+
+        // 거래유형 업그레이드: 월세 → 전세
+        if (baseline.getDealType() == DealType.WOLSE) {
+            candidates.add(new UpgradeCandidate(
+                    baseline.getRegionCode(), baseline.getHousingType(), DealType.JEONSE,
+                    baseline.getAreaMin(), baseline.getAreaMax(), UpgradeType.DEAL_TYPE));
+        }
+
         return candidates;
     }
 
-    /**
-     * 시세 조회 → 평수 업그레이드 필터.
-     *
-     * <p><b>평수 업그레이드 필터</b>: 사용자가 지정한 {@code base.areaMax}보다
-     * {@code areaMin}이 큰 버킷만 허용한다.
-     * 평수 미지정 시에는 필터 없이 전체 버킷을 탐색한다.
-     *
-     * <p>지역 확장 시에도 {@code base}는 항상 사용자의 원래 요청 기준을 사용한다.
-     * 평수 기준은 지역이 바뀌어도 변하지 않는다.
-     *
-     * <p>예산 상한 필터는 적용하지 않는다. 현재 예산으로 감당 안 되는 후보도 스코어링에서
-     * AM이 낮아져 자연스럽게 순위가 밀리며, 실거래 데이터 자체가 없는 경우에만 null을 반환한다.
-     */
-    private List<FetchedCandidate> buildPool(List<HousingCondition> candidates, BaseCondition base,
-                                              Map<String, RentMedianResponse> bulkMedians) {
-        List<FetchedCandidate> pool = new ArrayList<>();
-        for (HousingCondition candidate : candidates) {
-            // 평수 업그레이드 필터: 요청 최대 평수(areaMax) 이하 버킷은 업그레이드가 아니므로 제외
-            if (base.areaMin != null && base.areaMax != null && candidate.areaMin <= base.areaMax) continue;
+    // ─── 후보 평가 ────────────────────────────────────────────────────────────────
 
-            String key = candidate.housingType + "|" + candidate.dealType + "|" + candidate.areaMin;
-            RentMedianResponse median = bulkMedians.get(key);
-            if (median == null || median.getSampleCount() < MIN_SAMPLE_COUNT) continue;
-            if (median.getDeposit().getQ3() == null) continue;
+    private ScoredCandidate evaluate(UpgradeCandidate uc, GoalRecommendationResponse.Condition baseline,
+                                      long baselineReachMonths, Map<String, RentMedianResponse> bulkMedians,
+                                      MemberFinancialContext ctx, long desiredMonths) {
+        String key = uc.housingType() + "|" + uc.dealType() + "|" + uc.areaMin();
+        RentMedianResponse median = bulkMedians.get(key);
+        if (median == null || median.getSampleCount() < MIN_SAMPLE_COUNT) return null;
+        if (median.getDeposit() == null || median.getDeposit().getMedian() == null) return null;
 
-            pool.add(new FetchedCandidate(candidate, median));
-        }
-        return pool;
-    }
-
-    /**
-     * 스코어: 0.35×cIS + 0.30×WP + 0.20×AM + 0.15×SP
-     * 실거래 데이터가 없어 calcBudgetMetrics가 null을 반환하는 경우에만 null 반환.
-     */
-    private ScoredCandidate evaluate(FetchedCandidate fc, BaseCondition base,
-                                     AssetNetWorthBreakdown netWorth, long baseSaving, long n) {
-        HousingCondition candidate = fc.candidate;
-        RentMedianResponse median = fc.median;
-
-        double candidateMidArea = (candidate.areaMin + candidate.areaMax) / 2.0;
-
-        BudgetMetrics metrics = calcBudgetMetrics(candidate, median, netWorth, baseSaving, n);
-        if (metrics == null) return null;
-
-        long maxBudget = budgetCalculator.calculate(netWorth, metrics.effectiveSaving, n + PATIENCE_BONUS);
-        double affordabilityMargin = Math.max(-1.0,
-                (double)(maxBudget - metrics.futurePrice) / maxBudget);
-        double condImprovScore = (base.areaMin == null || base.areaMax == null)
-                ? 0.5
-                : calcConditionImprovementScore((base.areaMin + base.areaMax) / 2.0, candidateMidArea);
-        double waitPenalty = 1.0 / (1.0 + metrics.m / 12.0);
-        double spScore = metrics.successProbability != null ? metrics.successProbability : 0.0;
-        double score = 0.35 * condImprovScore
-                     + 0.30 * waitPenalty
-                     + 0.20 * affordabilityMargin
-                     + 0.15 * spScore;
-
-        return new ScoredCandidate(candidate, median, metrics.futurePrice, metrics.effectiveSaving,
-                metrics.totalMonths, metrics.m, score);
-    }
-
-    private BudgetMetrics calcBudgetMetrics(HousingCondition candidate, RentMedianResponse median,
-                                             AssetNetWorthBreakdown netWorth, long baseSaving, long n) {
-        long initialPrice = median.getDeposit().getQ3();
-
-        long effectiveSaving = baseSaving;
-        if (candidate.dealType == DealType.WOLSE) {
-            Long rentQ3 = median.getMonthlyRent() != null ? median.getMonthlyRent().getQ3() : null;
-            if (rentQ3 == null) return null;
-            effectiveSaving = Math.max(0, baseSaving - rentQ3);
+        long deposit = median.getDeposit().getMedian();
+        long monthlyRent = 0L;
+        if (uc.dealType() == DealType.WOLSE) {
+            Long rentMedian = median.getMonthlyRent() != null ? median.getMonthlyRent().getMedian() : null;
+            if (rentMedian == null) return null;
+            monthlyRent = rentMedian;
         }
 
-        Long initialMonths = budgetCalculator.monthsToReach(netWorth, effectiveSaving, initialPrice);
-        if (initialMonths == null) return null;
-        if (initialMonths == 0) {
-            return new BudgetMetrics(initialPrice, effectiveSaving, 0L, 0L, 1.0);
-        }
-
-        Long totalMonths = initialMonths;
-        long futurePrice = initialPrice;
-        Double successProbability = null;
+        // MC로 목표 시점의 예상 가격 투영 — Realistic과 동일한 1회 시뮬레이션
+        long projectedDeposit = deposit;
         try {
-            PriceModelRequest priceReq = candidate.toPriceModelRequest();
-            for (int i = 0; i < MAX_MC_ITERATIONS; i++) {
-                long budget = budgetCalculator.calculate(netWorth, effectiveSaving, totalMonths);
-                MonteCarloEngine.Result mc = monteCarloService.simulate(
-                        priceReq, initialPrice, budget, totalMonths.intValue());
-
-                futurePrice = mc.priceP50();
-                successProbability = mc.successProbability();
-
-                Long nextMonths = budgetCalculator.monthsToReach(netWorth, effectiveSaving, futurePrice);
-                if (nextMonths == null) return null;
-                if (nextMonths.equals(totalMonths)) break;
-                totalMonths = nextMonths;
-            }
+            long budgetAtT = budgetCalculator.calculate(
+                    ctx.netWorth(), ctx.rawMonthlySaving(), ctx.loanSchedules(), desiredMonths);
+            MonteCarloEngine.Result mc = monteCarloService.simulate(
+                    RecommendationAlgorithm.buildPriceModelRequest(
+                            uc.regionCode(), uc.housingType(), uc.dealType(), uc.areaMin(), uc.areaMax()),
+                    deposit, budgetAtT, (int) desiredMonths);
+            projectedDeposit = mc.priceP50();
         } catch (RuntimeException e) {
-            totalMonths = initialMonths;
-            futurePrice = initialPrice;
-            successProbability = null;
+            log.debug("MC 실패, 현재 시세 사용. housingType={}, dealType={}", uc.housingType(), uc.dealType());
         }
 
-        long m = Math.max(0, totalMonths - n);
-        return new BudgetMetrics(futurePrice, effectiveSaving, totalMonths, m, successProbability);
+        long comparableAmount = toComparableAmount(projectedDeposit, monthlyRent);
+        Long upgradeReachMonths = budgetCalculator.monthsToReach(
+                ctx.netWorth(), ctx.rawMonthlySaving(), ctx.loanSchedules(), comparableAmount);
+        if (upgradeReachMonths == null) return null;
+
+        long extraMonths = upgradeReachMonths - baselineReachMonths;
+        if (extraMonths > MAX_EXTRA_MONTHS) return null;
+
+        double condImprovScore = conditionImprovementScore(baseline, uc);
+        double horizonScore    = 1.0 / (1.0 + Math.max(0, extraMonths) / 24.0);
+        double score           = 0.5 * condImprovScore + 0.5 * horizonScore;
+
+        return new ScoredCandidate(
+                uc.regionCode(), median.getRegionName(), uc.housingType(), uc.dealType(),
+                uc.areaMin(), uc.areaMax(), projectedDeposit, monthlyRent,
+                median.getSampleCount(), extraMonths, score);
     }
 
-    private double calcConditionImprovementScore(double baseMidArea, double candidateMidArea) {
-        double delta = candidateMidArea - baseMidArea;
-        return Math.min(1.0, Math.max(0.0, 0.5 + delta / 20.0));
+    private double conditionImprovementScore(GoalRecommendationResponse.Condition baseline, UpgradeCandidate uc) {
+        return switch (uc.upgradeType()) {
+            case SIZE -> {
+                double baseMid    = (baseline.getAreaMin() + baseline.getAreaMax()) / 2.0;
+                double upgradeMid = (uc.areaMin() + uc.areaMax()) / 2.0;
+                yield Math.min(1.0, Math.max(0.0, 0.5 + (upgradeMid - baseMid) / 20.0));
+            }
+            case HOUSING_TYPE -> 0.7;
+            case DEAL_TYPE    -> 0.6;
+        };
     }
 
-    // ─── resolveCondition ────────────────────────────────────────────────────────
+    // ─── 헬퍼 ────────────────────────────────────────────────────────────────────
 
-    private BaseCondition resolveCondition(GoalRecommendationRequest req) {
-        return new BaseCondition(
-                req.getRegionCode(),
-                req.getPropertyType(),
-                req.getTradeType(),
-                req.getSizeMin()        != null ? req.getSizeMin()        : DEFAULT_AREA_MIN,
-                req.getSizeMax()        != null ? req.getSizeMax()        : DEFAULT_AREA_MAX,
-                req.getMonthlyRentMin(),
-                req.getMonthlyRentMax(),
-                req.getTargetDate());
+    /**
+     * baseline.areaMax보다 areaMin이 큰 버킷 중 가장 가까운(areaMin이 가장 작은) 버킷.
+     * 이미 최대 버킷이면 null.
+     */
+    private int[] nextSizeBucket(int baselineAreaMax) {
+        int[] result = null;
+        for (int[] bucket : SIZE_BUCKETS) {
+            if (bucket[0] > baselineAreaMax && (result == null || bucket[0] < result[0])) {
+                result = bucket;
+            }
+        }
+        return result;
+    }
+
+    /** DETACHED(1) → ROW_HOUSE(2), ROW_HOUSE·OFFICETEL(2) → APT(3), APT → null */
+    private HousingType nextHousingType(HousingType current) {
+        return switch (current) {
+            case DETACHED          -> HousingType.ROW_HOUSE;
+            case ROW_HOUSE, OFFICETEL -> HousingType.APT;
+            case APT               -> null;
+        };
+    }
+
+    private long toComparableAmount(long deposit, long monthlyRent) {
+        if (monthlyRent <= 0) return deposit;
+        return deposit + Math.round(monthlyRent * 12 / ANNUAL_INTEREST_RATE);
+    }
+
+    private GoalRecommendationResponse.RecommendationItem emptyCard() {
+        return GoalRecommendationResponse.RecommendationItem.builder()
+                .type(AlgorithmType.HOLD_OUT)
+                .build();
     }
 
     // ─── 내부 타입 ────────────────────────────────────────────────────────────────
 
-    private record BaseCondition(
+    private enum UpgradeType { SIZE, HOUSING_TYPE, DEAL_TYPE }
+
+    private record UpgradeCandidate(
             String regionCode, HousingType housingType, DealType dealType,
-            Integer areaMin, Integer areaMax, Long rentMin, Long rentMax,
-            YearMonth targetDate) { }
-
-    private record HousingCondition(
-            String regionCode, HousingType housingType, DealType dealType, int areaMin,
-            int areaMax, long depositMin, long depositMax, Long monthlyRentMin,
-            Long monthlyRentMax
-    ) {
-        String label() {
-            return housingType + "/" + dealType + " area=[" + areaMin + "," + areaMax + "]";
-        }
-
-        PriceModelRequest toPriceModelRequest() {
-            return RecommendationAlgorithm.buildPriceModelRequest(regionCode, housingType, dealType, areaMin, areaMax);
-        }
-
-        RentMedianRequest toMedianRequest() {
-            RentMedianRequest r = new RentMedianRequest();
-            r.setRegionCode(regionCode);
-            r.setHousingType(housingType);
-            r.setDealType(dealType);
-            r.setAreaMin(areaMin);
-            r.setAreaMax(areaMax);
-            r.setDepositMin(depositMin);
-            r.setDepositMax(depositMax);
-            if (dealType == DealType.WOLSE) {
-                r.setMonthlyRentMin(monthlyRentMin);
-                r.setMonthlyRentMax(monthlyRentMax);
-            }
-            return r;
-        }
-    }
-
-    private record FetchedCandidate(HousingCondition candidate, RentMedianResponse median) {}
-
-    private record BudgetMetrics(long futurePrice, long effectiveSaving, long totalMonths, long m,
-                                  Double successProbability) {}
+            int areaMin, int areaMax, UpgradeType upgradeType) {}
 
     private record ScoredCandidate(
-            HousingCondition candidate, RentMedianResponse median, long futurePrice,
-            long effectiveSaving, long totalMonths, long m, double score) { }
+            String regionCode, String regionName, HousingType housingType, DealType dealType,
+            int areaMin, int areaMax, long deposit, long monthlyRent,
+            int sampleCount, long extraMonths, double score) {}
 }

--- a/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
@@ -90,7 +90,7 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
         long targetMonths = RecommendationAlgorithm.monthsUntil(targetDate);
 
         AssetNetWorthBreakdown netWorth = ctx.netWorth();
-        long effectiveSaving  = ctx.effectiveSaving();
+        long rawMonthlySaving = ctx.rawMonthlySaving();
 
         HousingType housingType = request.getPropertyType() != null
                 ? request.getPropertyType() : DEFAULT_HOUSING_TYPE;
@@ -129,7 +129,7 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
         try {
             PriceModelRequest priceReq = RecommendationAlgorithm.buildPriceModelRequest(
                     median.getRegionCode(), housingType, dealType, areaMin, areaMax);
-            long budgetAtT = budgetCalculator.calculate(netWorth, effectiveSaving, targetMonths);
+            long budgetAtT = budgetCalculator.calculate(netWorth, rawMonthlySaving, ctx.loanSchedules(), targetMonths);
             MonteCarloEngine.Result mc = monteCarloService.simulate(
                     priceReq, deposit, budgetAtT, (int) targetMonths);
             projectedDeposit = mc.priceP50();
@@ -155,7 +155,7 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
 
         // ① 저축 고정 — 사용자의 월 저축액을 그대로 두고 도달 시점을 계산
         LoanPlans savingFixedPlans = loanPlanCalculator.calculateSavingFixed(
-                memberId, projectedDeposit, netWorth, effectiveSaving);
+                memberId, projectedDeposit, netWorth, rawMonthlySaving, ctx.loanSchedules());
         GoalRecommendationResponse.RecommendationItem savingFixedCard =
                 GoalRecommendationResponse.RecommendationItem.builder()
                         .type(AlgorithmType.PREFERENCE_SAVING_FIXED)
@@ -168,7 +168,7 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
         // 목표 시점을 입력하지 않았으면 고정할 시점이 없어 조건 없는(null) 카드를 낸다.
         GoalRecommendationResponse.RecommendationItem dateFixedCard;
         if (request.getTargetDate() != null) {
-            LoanPlans dateFixedPlans = loanPlanCalculator.calculate(memberId, projectedDeposit, targetDate, effectiveSaving);
+            LoanPlans dateFixedPlans = loanPlanCalculator.calculate(memberId, projectedDeposit, targetDate, ctx.currentEffectiveSaving());
             GoalRecommendationResponse.LoanOPlan dateFixedLoanO = dateFixedPlans.getLoanO();
             if (dateFixedLoanO != null) {
                 // 시점을 고정한 카드라 대출은 개월을 줄이는 게 아니라 필요 저축액을 낮춘다 → 단축 개월은 0

--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -151,7 +151,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         long desiredMonths = RecommendationAlgorithm.monthsUntil(targetDate);
 
         AssetNetWorthBreakdown netWorth = ctx.netWorth();
-        long effectiveSaving  = ctx.effectiveSaving();
+        long effectiveSaving  = ctx.currentEffectiveSaving();
 
         Search search = new Search(memberId, netWorth, effectiveSaving, desiredMonths);
 
@@ -502,12 +502,10 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         // 화면에 나가는 목표 금액은 환산값이 아니라 실제로 모아야 하는 보증금이다.
         LoanPlans plans = loanPlanCalculator.calculate(memberId, chosen.deposit(), targetDate, search.effectiveSaving);
 
+        // 날짜 고정 카드라 대출은 시점을 앞당기는 게 아니라 필요 저축액을 낮춘다 → 단축 개월은 0
         GoalRecommendationResponse.LoanOPlan loanO = plans.getLoanO();
-        if (loanO != null && chosen.reachMonths() != null) {
-            Long shortened = loanPlanCalculator.calcShortenedMonths(
-                    memberId, search.netWorth, search.effectiveSaving,
-                    chosen.deposit(), chosen.reachMonths());
-            loanO = loanO.toBuilder().shortenedMonths(shortened).build();
+        if (loanO != null) {
+            loanO = loanO.toBuilder().shortenedMonths(0L).build();
         }
 
         GoalRecommendationResponse.Condition condition = GoalRecommendationResponse.Condition.builder()

--- a/src/main/java/com/team/independence/goal/service/calculator/BudgetCalculator.java
+++ b/src/main/java/com/team/independence/goal/service/calculator/BudgetCalculator.java
@@ -1,6 +1,7 @@
 package com.team.independence.goal.service.calculator;
 
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 /**
@@ -59,6 +60,59 @@ public class BudgetCalculator {
             if (budget >= targetAmount) {
                 return m;
             }
+        }
+        return null;
+    }
+
+    /**
+     * n개월 후 예상 총 예산을 계산한다 — 대출 스케줄 반영 버전.
+     *
+     * <p>매월 아직 상환 중인 대출(remainingMonths >= m)의 월 원리금 합계를 rawSaving에서 차감한 뒤
+     * 복리로 누적한다. 대출이 끝난 달부터는 rawSaving 전액이 저축된다.
+     */
+    public long calculate(AssetNetWorthBreakdown netWorth, long rawSaving,
+                          List<LoanSchedule> loanSchedules, long months) {
+        double r = monthlyInterestRate();
+        long cumulativeSavings = 0L;
+        for (long m = 1; m <= months; m++) {
+            final long month = m;
+            long activePayment = loanSchedules.stream()
+                    .filter(l -> l.remainingMonths() >= month)
+                    .mapToLong(LoanSchedule::monthlyPayment)
+                    .sum();
+            long effectiveThisMonth = Math.max(0, rawSaving - activePayment);
+            cumulativeSavings = Math.round(cumulativeSavings * (1 + r)) + effectiveThisMonth;
+        }
+        return calculateGrownAmount(netWorth.getInterestBearingAssets(), months)
+                + netWorth.getFlatRecognizedAssets()
+                + cumulativeSavings;
+    }
+
+    /**
+     * 예산이 목표 금액에 도달하는 최소 개월수를 탐색한다 — 대출 스케줄 반영 버전.
+     *
+     * <p>매월 활성 대출 상환액만 차감 후 복리 누적. 대출 소멸 이후에는 rawSaving 전액 반영.
+     */
+    public Long monthsToReach(AssetNetWorthBreakdown netWorth, long rawSaving,
+                              List<LoanSchedule> loanSchedules, long targetAmount) {
+        long growingAssets = netWorth.getInterestBearingAssets();
+        long fixedAssets   = netWorth.getFlatRecognizedAssets();
+
+        if (growingAssets + fixedAssets >= targetAmount) return 0L;
+
+        double r = monthlyInterestRate();
+        long cumulativeSavings = 0L;
+        for (long m = 1; m <= MAX_FORECAST_MONTHS; m++) {
+            final long month = m;
+            long activePayment = loanSchedules.stream()
+                    .filter(l -> l.remainingMonths() >= month)
+                    .mapToLong(LoanSchedule::monthlyPayment)
+                    .sum();
+            long effectiveThisMonth = Math.max(0, rawSaving - activePayment);
+            cumulativeSavings = Math.round(cumulativeSavings * (1 + r)) + effectiveThisMonth;
+
+            long budget = calculateGrownAmount(growingAssets, m) + fixedAssets + cumulativeSavings;
+            if (budget >= targetAmount) return m;
         }
         return null;
     }

--- a/src/main/java/com/team/independence/goal/service/calculator/LoanPlanCalculator.java
+++ b/src/main/java/com/team/independence/goal/service/calculator/LoanPlanCalculator.java
@@ -10,6 +10,9 @@ import com.team.independence.member.service.MemberService;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -91,22 +94,28 @@ public class LoanPlanCalculator {
      *
      * <p>{@link #calculate}가 "목표 시점 고정 → 필요 저축액 역산"이라면, 이 메서드는 정확히 반대다.
      * 사용자의 실제 월 저축액을 그대로 두고 목표 금액에 <b>언제</b> 도달하는지를 계산한다.
-     * 따라서 loanX·loanO의 {@code monthlySaving}에는 (역산값이 아니라) 넘겨받은 월 저축액이 그대로 담기고,
+     * loanX·loanO의 {@code monthlySaving}에는 넘겨받은 rawMonthlySaving이 그대로 담기고,
      * {@code targetDate}가 계산 결과다. 저축액으로 상한(1200개월) 내 도달이 불가능하면 targetDate는 null이다.
      *
-     * @param requiredAmount 도달해야 할 목표 금액(원)
-     * @param netWorth       현재 순자산 구성
-     * @param monthlySaving  고정할 월 저축액(원)
+     * <p>도달 시점 계산에는 {@code loanSchedules}를 사용해 대출별 잔여 기간을 구간별로 반영한다.
+     * 대출이 끝난 달부터는 rawMonthlySaving 전액이 저축된다.
+     *
+     * @param requiredAmount    도달해야 할 목표 금액(원)
+     * @param netWorth          현재 순자산 구성
+     * @param rawMonthlySaving  사용자 입력 월 저축액(원) — 카드 표시값
+     * @param loanSchedules     기존 대출 스케줄 목록 — 구간별 계산용
      */
     public LoanPlans calculateSavingFixed(long memberId, long requiredAmount,
-                                          AssetNetWorthBreakdown netWorth, long monthlySaving) {
+                                          AssetNetWorthBreakdown netWorth,
+                                          long rawMonthlySaving,
+                                          List<LoanSchedule> loanSchedules) {
         YearMonth now = YearMonth.now();
 
-        Long loanXMonths = budgetCalculator.monthsToReach(netWorth, monthlySaving, requiredAmount);
+        Long loanXMonths = budgetCalculator.monthsToReach(netWorth, rawMonthlySaving, loanSchedules, requiredAmount);
         GoalRecommendationResponse.LoanXPlan loanX = GoalRecommendationResponse.LoanXPlan.builder()
                 .targetAmount(requiredAmount)
                 .targetDate(loanXMonths != null ? now.plusMonths(loanXMonths) : null)
-                .monthlySaving(monthlySaving)
+                .monthlySaving(rawMonthlySaving)
                 .build();
 
         long existingPayment = calcTotalExistingMonthlyPayment(memberId);
@@ -115,15 +124,15 @@ public class LoanPlanCalculator {
             return LoanPlans.builder().loanX(loanX).loanO(null).build();
         }
 
-        // 대출금은 즉시 가용 자금으로 편입하고, 신규 대출 월 원리금만큼 저축 여력을 줄여 도달 시점을 다시 계산
-        long loanMonthly = monthlyPaymentForLoan(loanAmount);
-        long savingWithLoan = Math.max(0, monthlySaving - loanMonthly);
+        // 대출금은 즉시 가용 자금으로 편입한다.
+        // 신규 대출 상환은 DSR 40% 한도 내에서 별도 소득으로 충당되므로 저축액에서 차감하지 않는다.
+        // 기존 대출 스케줄은 그대로 넘겨 구간별 계산이 계속 반영되도록 한다.
         AssetNetWorthBreakdown netWorthWithLoan = AssetNetWorthBreakdown.builder()
                 .interestBearingAssets(netWorth.getInterestBearingAssets())
                 .flatRecognizedAssets(netWorth.getFlatRecognizedAssets() + loanAmount)
                 .build();
 
-        Long loanOMonths = budgetCalculator.monthsToReach(netWorthWithLoan, savingWithLoan, requiredAmount);
+        Long loanOMonths = budgetCalculator.monthsToReach(netWorthWithLoan, rawMonthlySaving, loanSchedules, requiredAmount);
         if (loanOMonths == null) {
             return LoanPlans.builder().loanX(loanX).loanO(null).build();
         }
@@ -133,19 +142,35 @@ public class LoanPlanCalculator {
                 .loanAmount(loanAmount)
                 .targetAmount(requiredAmount - loanAmount)
                 .targetDate(now.plusMonths(loanOMonths))
-                .monthlySaving(monthlySaving)
+                .monthlySaving(rawMonthlySaving)
                 .shortenedMonths(shortened)
                 .build();
 
         return LoanPlans.builder().loanX(loanX).loanO(loanO).build();
     }
 
-    /** 신규 대출 원금의 월 원리금(연 3.5%, 30년 원리금균등). */
-    private long monthlyPaymentForLoan(long loanAmount) {
+    /**
+     * 대출 계좌별 잔여 상환 스케줄 목록을 반환한다.
+     *
+     * <p>end_date가 없거나 이미 만기된 대출은 제외한다.
+     * 각 건의 월 원리금은 잔액과 잔여 기간으로 {@code ASSUMED_LOAN_ANNUAL_RATE} 기준 역산한다.
+     */
+    public List<LoanSchedule> getLoanSchedules(long memberId) {
         double r = ASSUMED_LOAN_ANNUAL_RATE / 12.0;
-        double factor = Math.pow(1 + r, NEW_LOAN_TERM_MONTHS);
-        return Math.round(loanAmount * r * factor / (factor - 1));
+        return loanAccountService.getLoanAccounts(memberId).stream()
+                .filter(loan -> loan.getLoanBalance() != null && loan.getLoanBalance() > 0
+                        && loan.getEndDate() != null)
+                .map(loan -> {
+                    long remaining = ChronoUnit.MONTHS.between(LocalDate.now(), loan.getEndDate());
+                    if (remaining <= 0) return null;
+                    double f = Math.pow(1 + r, remaining);
+                    long payment = Math.round(loan.getLoanBalance() * r * f / (f - 1));
+                    return new LoanSchedule(payment, remaining);
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
+
 
     /**
      * 기존 대출 계좌 전체의 월 원리금 합계를 반환한다.
@@ -182,39 +207,6 @@ public class LoanPlanCalculator {
 
         // 연금 현가: M × (factor − 1) / (r × factor)
         return (long) (availableMonthly * (factor - 1) / (r * factor));
-    }
-
-    /**
-     * 대출을 받을 경우 단축 가능한 개월 수를 계산한다.
-     *
-     * <p>대출금은 즉시 가용 자금(flatRecognizedAssets)으로 편입하고,
-     * 신규 대출 월 원리금만큼 effectiveSaving을 줄인다.
-     *
-     * @param netWorth               현재 순자산 구성
-     * @param effectiveSaving        대출 전 월 순저축액 (baseSaving − 월세 등)
-     * @param futurePrice            목표 시점의 예측 가격
-     * @param totalMonthsWithoutLoan 대출 없이 도달하는 총 개월 수
-     * @return 단축 개월 수. DSR 한도 0이거나 대출 후에도 달성 불가면 null
-     */
-    public Long calcShortenedMonths(long memberId, AssetNetWorthBreakdown netWorth,
-                                     long effectiveSaving, long futurePrice,
-                                     long totalMonthsWithoutLoan) {
-        long maxLoan = calcMaxLoanAmount(memberId);
-        if (maxLoan <= 0) return null;
-
-        double r = ASSUMED_LOAN_ANNUAL_RATE / 12.0;
-        double factor = Math.pow(1 + r, NEW_LOAN_TERM_MONTHS);
-        long loanMonthly = Math.round(maxLoan * r * factor / (factor - 1));
-
-        long savingWithLoan = Math.max(0, effectiveSaving - loanMonthly);
-        AssetNetWorthBreakdown netWorthWithLoan = AssetNetWorthBreakdown.builder()
-                .interestBearingAssets(netWorth.getInterestBearingAssets())
-                .flatRecognizedAssets(netWorth.getFlatRecognizedAssets() + maxLoan)
-                .build();
-
-        Long monthsWithLoan = budgetCalculator.monthsToReach(netWorthWithLoan, savingWithLoan, futurePrice);
-        if (monthsWithLoan == null) return null;
-        return Math.max(0, totalMonthsWithoutLoan - monthsWithLoan);
     }
 
     // 기존 대출 한 건의 월 원리금 상환액. endDate 기준 잔여 기간으로 역산.

--- a/src/main/java/com/team/independence/goal/service/calculator/LoanSchedule.java
+++ b/src/main/java/com/team/independence/goal/service/calculator/LoanSchedule.java
@@ -1,0 +1,12 @@
+package com.team.independence.goal.service.calculator;
+
+/**
+ * 대출 한 건의 잔여 상환 스케줄.
+ *
+ * <p>단일 합산값(calcTotalExistingMonthlyPayment)으로는 각 대출의 종료 시점이 소실된다.
+ * 구간별 예산 계산에서 "N개월 후 이 대출이 끝나 저축 여력이 늘어난다"는 사실을 반영하기 위해 사용한다.
+ *
+ * @param monthlyPayment   월 원리금 상환액 (원)
+ * @param remainingMonths  오늘 기준 잔여 상환 개월 수
+ */
+public record LoanSchedule(long monthlyPayment, long remainingMonths) {}

--- a/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
@@ -23,7 +23,9 @@ import com.team.independence.goal.mapper.GoalHousingMapper;
 import com.team.independence.goal.mapper.GoalMapper;
 import com.team.independence.goal.service.calculator.BudgetCalculator;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
+import com.team.independence.goal.service.calculator.LoanSchedule;
 import com.team.independence.goal.mapper.SavingRecordMapper;
+import java.util.List;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import java.time.LocalDate;
@@ -75,6 +77,8 @@ class GoalDetailServiceImplTest {
                         new LoanPlanCalculator(null, null, null, null) {
                             @Override
                             public long calcTotalExistingMonthlyPayment(long memberId) { return 0L; }
+                            @Override
+                            public List<LoanSchedule> getLoanSchedules(long memberId) { return List.of(); }
                         }));
     }
 

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplMarketTrendTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplMarketTrendTest.java
@@ -29,7 +29,9 @@ import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.dto.RentMedianResponse.Quartile;
 import com.team.independence.property.service.RegionQueryService;
 import com.team.independence.property.service.RentMedianService;
+import com.team.independence.goal.service.calculator.LoanSchedule;
 import java.time.YearMonth;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -133,7 +135,7 @@ class GoalServiceImplMarketTrendTest {
     @DisplayName("getMarketTrend - 캐시 미스면 refreshMarketTrend로 계산 후 캐시에 저장한다")
     void getMarketTrend_cacheMiss_computesAndCaches() {
         Goal goal = goal(100_000_000L, 90_000_000L, 1_000_000L);
-        when(loanPlanCalculator.calcTotalExistingMonthlyPayment(MEMBER_ID)).thenReturn(0L);
+        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID)).thenReturn(List.of());
         when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(goal);
         when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
         when(goalMarketTrendCacheStore.find(GOAL_ID)).thenReturn(Optional.empty());
@@ -197,7 +199,7 @@ class GoalServiceImplMarketTrendTest {
     @DisplayName("refreshMarketTrend - maintainEta는 재계산하지 않고 goal.target_date를 그대로 반환한다")
     void refreshMarketTrend_maintainEta_usesStoredTargetDateAsIs() {
         Goal goal = goal(1L, 90_000_000L, 1_000_000L); // targetAmount=1원, 사실상 이미 달성
-        when(loanPlanCalculator.calcTotalExistingMonthlyPayment(MEMBER_ID)).thenReturn(0L);
+        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID)).thenReturn(List.of());
         when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
         when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
         when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
@@ -220,7 +222,7 @@ class GoalServiceImplMarketTrendTest {
     @DisplayName("refreshMarketTrend - reflectEta는 상한(240개월) 내 도달 불가능하면 null, maintainEta는 그대로 target_date")
     void refreshMarketTrend_unreachable_reflectEtaIsNull() {
         Goal goal = goal(9_999_999_999L, 90_000_000L, 0L); // 저축 0, 목표는 사실상 도달 불가
-        when(loanPlanCalculator.calcTotalExistingMonthlyPayment(MEMBER_ID)).thenReturn(0L);
+        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID)).thenReturn(List.of());
         when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
         when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
         when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
@@ -243,7 +245,7 @@ class GoalServiceImplMarketTrendTest {
     void refreshMarketTrend_maintainAndReflect_diverge() {
         // targetAmount(100M)가 currentMiddleAmount(10M)보다 훨씬 커서, 반영(reflect) 쪽이 훨씬 빨리 도달해야 한다
         Goal goal = goal(100_000_000L, 90_000_000L, 1_000_000L);
-        when(loanPlanCalculator.calcTotalExistingMonthlyPayment(MEMBER_ID)).thenReturn(0L);
+        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID)).thenReturn(List.of());
         when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
         when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
         when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmIntegrationTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmIntegrationTest.java
@@ -32,6 +32,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  *   <li>테스트에 쓸 memberId의 connected_account, asset_account, asset_summary.monthly_savings 존재</li>
  *   <li>rent_transaction에 해당 region/type/deal 최근 6개월 데이터 10건 이상</li>
  * </ul>
+ *
+ * <p>HoldOut은 Realistic 결과를 기준점으로 동작한다.
+ * 통합 테스트에서는 RealisticAlgorithm을 먼저 실행해 결과를 HoldOut에 전달한다.
  */
 @Disabled("로컬 MySQL + Redis 환경 전용")
 @ExtendWith(SpringExtension.class)
@@ -41,22 +44,19 @@ class HoldOutAlgorithmIntegrationTest {
     /** 테스트에 쓸 회원 ID — 로컬 DB에 맞게 변경 */
     private static final long TEST_MEMBER_ID = 1L;
 
-    @Autowired
-    private HoldOutAlgorithm holdOutAlgorithm;
-    @Autowired
-    private AssetSummaryService assetSummaryService;
-    @Autowired
-    private LoanPlanCalculator loanPlanCalculator;
+    @Autowired private RealisticAlgorithm realisticAlgorithm;
+    @Autowired private HoldOutAlgorithm   holdOutAlgorithm;
+    @Autowired private AssetSummaryService assetSummaryService;
+    @Autowired private LoanPlanCalculator  loanPlanCalculator;
 
     private MemberFinancialContext buildCtx(long memberId) {
         AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
         long monthlySaving = assetSummaryService.getMonthlySavingsOrZero(memberId);
-        long loanPayment = loanPlanCalculator.calcTotalExistingMonthlyPayment(memberId);
-        return new MemberFinancialContext(netWorth, monthlySaving, loanPayment);
+        return new MemberFinancialContext(netWorth, monthlySaving, loanPlanCalculator.getLoanSchedules(memberId));
     }
 
     /**
-     * request에 조건을 직접 넣어서 실행.
+     * Realistic을 먼저 실행한 뒤 그 결과를 HoldOut에 전달한다.
      * regionCode, propertyType, tradeType, sizeMin, sizeMax는 rent_transaction에 실제로 있는 값으로 변경.
      */
     @Test
@@ -67,12 +67,30 @@ class HoldOutAlgorithmIntegrationTest {
         request.setTradeType(DealType.JEONSE);
         request.setSizeMin(20);
         request.setSizeMax(30);
-        request.setTargetDate(YearMonth.now().plusMonths(24)); // n=24개월 기준
+        request.setTargetDate(YearMonth.now().plusMonths(24));
 
+        MemberFinancialContext ctx = buildCtx(TEST_MEMBER_ID);
+
+        // Phase 1: Realistic
+        List<GoalRecommendationResponse.RecommendationItem> realisticResult =
+                realisticAlgorithm.recommend(TEST_MEMBER_ID, request, ctx);
+        GoalRecommendationResponse.RecommendationItem realisticItem =
+                realisticResult.isEmpty() ? null : realisticResult.get(0);
+
+        System.out.println("=== Realistic 결과 ===");
+        System.out.println(realisticItem != null && realisticItem.getCondition() != null
+                ? realisticItem.getCondition().getRegionName()
+                    + " / " + realisticItem.getCondition().getHousingType()
+                    + " / " + realisticItem.getCondition().getDealType()
+                    + " / " + realisticItem.getCondition().getAreaMin()
+                    + "~" + realisticItem.getCondition().getAreaMax() + "평"
+                : "soft-fail (condition null)");
+
+        // Phase 2: HoldOut (Realistic 결과를 기준점으로 사용)
         List<GoalRecommendationResponse.RecommendationItem> result =
-                holdOutAlgorithm.recommend(TEST_MEMBER_ID, request, buildCtx(TEST_MEMBER_ID));
+                holdOutAlgorithm.recommend(TEST_MEMBER_ID, request, ctx, realisticItem);
 
-        System.out.println("=== HoldOut 결과 ===");
+        System.out.println("\n=== HoldOut 결과 ===");
         if (!result.isEmpty()) {
             GoalRecommendationResponse.RecommendationItem item = result.get(0);
             System.out.println("type   : " + item.getType());
@@ -88,30 +106,6 @@ class HoldOutAlgorithmIntegrationTest {
             System.out.println("추천 결과 없음 (빈 목록)");
         }
 
-        // 데이터가 충분하면 카드가 있어야 함 (로컬 DB 데이터에 따라 달라짐)
         if (!result.isEmpty()) assertNotNull(result.get(0));
-    }
-
-    /**
-     * request 조건 없이 active goal 기반으로 실행.
-     * TEST_MEMBER_ID에 ACTIVE 목표와 GoalHousing이 있어야 함.
-     */
-    @Test
-    void goal_fallback() {
-        GoalRecommendationRequest request = new GoalRecommendationRequest();
-        // 조건 미입력 → active goal의 housing 조건 사용
-
-        List<GoalRecommendationResponse.RecommendationItem> result =
-                holdOutAlgorithm.recommend(TEST_MEMBER_ID, request, buildCtx(TEST_MEMBER_ID));
-
-        System.out.println("=== HoldOut (goal fallback) 결과 ===");
-        if (!result.isEmpty() && result.get(0).getCondition() != null) {
-            GoalRecommendationResponse.RecommendationItem item = result.get(0);
-            System.out.println("조건   : " + item.getCondition().getRegionName()
-                    + " " + item.getCondition().getAreaMin()
-                    + "~" + item.getCondition().getAreaMax() + "평");
-        } else {
-            System.out.println("추천 결과 없음 (active goal 없거나 데이터 부족)");
-        }
     }
 }

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
@@ -8,17 +8,20 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import com.team.independence.goal.dto.AlgorithmType;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
-import com.team.independence.goal.service.RecommendationAlgorithm.MemberFinancialContext;
+import com.team.independence.goal.dto.GoalRecommendationResponse;
 import com.team.independence.goal.dto.GoalRecommendationResponse.RecommendationItem;
 import com.team.independence.goal.dto.LoanPlans;
 import com.team.independence.goal.service.MonteCarloEngine;
 import com.team.independence.goal.service.MonteCarloService;
+import com.team.independence.goal.service.RecommendationAlgorithm.MemberFinancialContext;
 import com.team.independence.goal.service.calculator.BudgetCalculator;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
-import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.goal.service.calculator.LoanSchedule;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.PriceModelRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.dto.RentMedianResponse.Quartile;
 import com.team.independence.property.service.RentMedianService;
@@ -40,11 +43,12 @@ import org.mockito.quality.Strictness;
  *
  * <p>BudgetCalculator는 실 구현체를 사용하고, 나머지 외부 의존은 목으로 대체한다.
  *
- * <p>검증 초점
+ * <h3>검증 초점</h3>
  * <ul>
- *   <li>기존 대출 월상환액이 월저축액에서 사전 차감된 채 예산 계산에 전달되는가</li>
- *   <li>사용자가 지정한 areaMax보다 큰 버킷만 업그레이드 후보로 허용하는가</li>
- *   <li>시군구 pool이 비면 상위 시도로 확장하는가</li>
+ *   <li>Realistic 결과(baseline)를 기준으로 정확히 하나의 변수만 바꾼 업그레이드 후보를 탐색하는가</li>
+ *   <li>realisticItem이 null이거나 condition이 null이면 soft-fail을 반환하는가</li>
+ *   <li>추가 대기 개월(extraMonths)이 MAX_EXTRA_MONTHS를 초과하는 후보는 제외되는가</li>
+ *   <li>기존 대출이 BudgetCalculator에 올바르게 반영되는가</li>
  * </ul>
  */
 @ExtendWith(MockitoExtension.class)
@@ -52,9 +56,7 @@ import org.mockito.quality.Strictness;
 class HoldOutAlgorithmTest {
 
     private static final long MEMBER_ID = 1L;
-    private static final long 억 = 100_000_000L;
-    private static final long 만 = 10_000L;
-
+    private static final String REGION = "11110";
     private static final YearMonth NOW = YearMonth.now();
 
     @Mock private LoanPlanCalculator loanPlanCalculator;
@@ -64,10 +66,10 @@ class HoldOutAlgorithmTest {
     private final BudgetCalculator budgetCalculator = new BudgetCalculator();
 
     private HoldOutAlgorithm algorithm;
-    private AssetNetWorthBreakdown defaultNetWorth;
+    private AssetNetWorthBreakdown zeroNetWorth;
     private MemberFinancialContext ctx;
 
-    /** "regionCode|주거유형|거래유형|최소평수" → {Q3 보증금, Q3 월세} */
+    /** market 맵: "regionCode|HousingType|DealType|areaMin" → [중앙값보증금, 중앙값월세] */
     private Map<String, long[]> market;
 
     @BeforeEach
@@ -75,87 +77,49 @@ class HoldOutAlgorithmTest {
         algorithm = new HoldOutAlgorithm(
                 loanPlanCalculator, budgetCalculator, rentMedianService, monteCarloService);
 
+        // MC는 P50 = 입력 가격 그대로 반환 (가격 변동 없음으로 고정)
         when(monteCarloService.simulate(any(PriceModelRequest.class), anyLong(), anyLong(), anyInt()))
                 .thenAnswer(call -> {
-                    long initialPrice = call.getArgument(1);
-                    long budgetAtT = call.getArgument(2);
-                    double successProb = budgetAtT >= initialPrice ? 0.8 : 0.2;
-                    return new MonteCarloEngine.Result(
-                            initialPrice * 9 / 10, initialPrice, initialPrice * 11 / 10, successProb);
+                    long price = call.getArgument(1);
+                    long budget = call.getArgument(2);
+                    double prob = budget >= price ? 0.8 : 0.2;
+                    return new MonteCarloEngine.Result(price * 9 / 10, price, price * 11 / 10, prob);
                 });
+
         market = new HashMap<>();
 
-        defaultNetWorth = AssetNetWorthBreakdown.builder()
+        zeroNetWorth = AssetNetWorthBreakdown.builder()
                 .interestBearingAssets(0L)
                 .flatRecognizedAssets(0L)
                 .build();
-        ctx = new MemberFinancialContext(defaultNetWorth, 10_000_000L, 0L);
-        when(loanPlanCalculator.calculateSavingFixed(anyLong(), anyLong(), any(AssetNetWorthBreakdown.class), anyLong()))
+        ctx = new MemberFinancialContext(zeroNetWorth, 10_000_000L, List.of());
+
+        when(loanPlanCalculator.calculateSavingFixed(
+                anyLong(), anyLong(), any(AssetNetWorthBreakdown.class), anyLong(), any()))
                 .thenReturn(LoanPlans.builder().build());
         when(rentMedianService.getBulkMedian(anyString(), anyString(), anyString()))
                 .thenAnswer(call -> toBulkMap(call.getArgument(0)));
     }
 
-    // ===== DSR 차감 관련 =====
+    // ─── soft-fail 케이스 ─────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("대출이 없으면 월저축액 전액으로 예산을 계산해 업그레이드 후보를 추천한다")
-    void noLoanUsesFullMonthlySaving() {
-        // 월저축 1천만, 대출 없음 → 2억 보증금에 ~19개월 → PATIENCE_BONUS(48) 이내 → 추천
-        // 요청: 20~25평 → 업그레이드 버킷인 26~40평(areaMin=26 > areaMax=25)만 허용
-        put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
-
-        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
+    @DisplayName("realisticItem이 null이면 soft-fail 카드를 반환한다")
+    void nullRealisticItem_returnsSoftFail() {
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, defaultRequest(), ctx, null);
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(26);
+        assertThat(result.get(0).getType()).isEqualTo(AlgorithmType.HOLD_OUT);
+        assertThat(result.get(0).getCondition()).isNull();
     }
 
     @Test
-    @DisplayName("기존 대출 월상환액을 월저축액에서 차감한 뒤 예산을 계산한다")
-    void deductsExistingLoanPaymentFromSaving() {
-        // 월저축 1천만, 대출 월상환 900만 → baseSaving 100만
-        // 2억을 100만/월로 모으면 ~169개월 걸리지만 실거래 데이터가 있으므로 추천 카드가 생성된다
-        MemberFinancialContext ctx = ctxWithLoan(9_000_000L);
-        put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
+    @DisplayName("Realistic 결과의 condition이 null이면 soft-fail 카드를 반환한다")
+    void nullCondition_returnsSoftFail() {
+        RecommendationItem noCondition = RecommendationItem.builder()
+                .type(AlgorithmType.REALISTIC).build();
 
-        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNotNull();
-    }
-
-    @Test
-    @DisplayName("월세 후보는 기존 대출 차감 후 임대료도 추가 차감한다")
-    void deductsRentOnTopOfLoanPayment() {
-        // 월저축 1천만, 대출 월상환 500만 → baseSaving 500만
-        // 월세 Q3 = 450만 → effectiveSaving 50만
-        // 1억 보증금을 50만/월로 모으면 ~180개월 걸리지만 실거래 데이터가 있으므로 추천 카드가 생성된다
-        MemberFinancialContext ctx = ctxWithLoan(5_000_000L);
-        put("11110", HousingType.APT, DealType.WOLSE, 26, 40, 1 * 억, 450 * 만);
-
-        GoalRecommendationRequest request = new GoalRecommendationRequest();
-        request.setRegionCode("11110");
-        request.setPropertyType(HousingType.APT);
-        request.setTradeType(DealType.WOLSE);
-        request.setSizeMin(20);
-        request.setSizeMax(25);
-        request.setTargetDate(NOW);
-
-        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNotNull();
-    }
-
-    @Test
-    @DisplayName("대출 월상환액이 월저축액보다 커도 저축액이 음수가 되지 않는다")
-    void clipsNegativeSavingToZero() {
-        // 대출 1500만 > 저축 1000만 → baseSaving = 0 → 현재 자산(0원)으로 2억 도달 불가 → soft-fail
-        MemberFinancialContext ctx = ctxWithLoan(15_000_000L);
-        put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
-
-        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, defaultRequest(), ctx, noCondition);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getCondition()).isNull();
@@ -163,167 +127,288 @@ class HoldOutAlgorithmTest {
 
     @Test
     @DisplayName("시장 데이터가 없으면 soft-fail 카드를 반환한다")
-    void returnsEmptyWhenNoMarketData() {
-        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNull();
-    }
-
-    // ===== 평수 업그레이드 필터 =====
-
-    @Test
-    @DisplayName("평수 지정 시 지정 areaMax 이하 버킷은 업그레이드가 아니므로 제외된다")
-    void filtersBucketsNotLargerThanSpecifiedMax() {
-        // 요청 sizeMax=25 → areaMin <= 25인 버킷(15~19, 20~25) 모두 제외 → soft-fail
-        put("11110", HousingType.APT, DealType.JEONSE, 15, 19, 2 * 억, 0);
-        put("11110", HousingType.APT, DealType.JEONSE, 20, 25, 2 * 억, 0);
-
-        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
+    void noMarketData_returnsSoftFail() {
+        // market에 아무것도 없음
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.APT, 20, 25, 50_000_000L));
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getCondition()).isNull();
     }
 
     @Test
-    @DisplayName("평수 지정 시 areaMin > base.areaMax 인 버킷만 업그레이드 후보로 허용된다")
-    void allowsOnlyBucketsLargerThanSpecifiedMax() {
-        // 요청 sizeMax=25 → 26~40(areaMin=26 > 25)만 허용
-        put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
+    @DisplayName("모든 업그레이드 변수가 이미 최고 수준이면 후보가 없어 soft-fail을 반환한다")
+    void allMaxed_noUpgradeAvailable() {
+        // APT(최고 타입) + JEONSE(최고 거래유형) + 26~40평(최고 버킷) → 업그레이드 변수 없음
+        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 80_000_000L, 0);
 
-        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(26);
-        assertThat(result.get(0).getCondition().getAreaMax()).isEqualTo(40);
-    }
-
-    @Test
-    @DisplayName("평수 미지정이면 SIZE_BUCKETS 전체를 탐색해 가장 적합한 버킷을 선택한다")
-    void exploresAllSizeBucketsWhenAreaNotSpecified() {
-        // 면적 미지정 → 필터 없이 15~19평 버킷도 탐색
-        put("11110", HousingType.APT, DealType.JEONSE, 15, 19, 2 * 억, 0);
-
-        GoalRecommendationRequest request = new GoalRecommendationRequest();
-        request.setRegionCode("11110");
-        request.setPropertyType(HousingType.APT);
-        request.setTradeType(DealType.JEONSE);
-        request.setTargetDate(NOW);
-
-        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(15);
-    }
-
-    // ===== 지역 확장 폴백 =====
-
-    @Test
-    @DisplayName("시군구 pool이 비면 상위 시도 코드로 확장해 업그레이드 후보를 탐색한다")
-    void expandsToSidoWhenSigunguPoolEmpty() {
-        // 11110(종로구)에는 데이터 없고 11(서울)에만 26~40평 데이터 있음
-        put("11", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
-
-        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition().getRegionCode()).isEqualTo("11");
-    }
-
-    @Test
-    @DisplayName("시군구에 업그레이드 후보가 있으면 시도로 확장하지 않는다")
-    void doesNotExpandToSidoWhenSigunguHasCandidates() {
-        // 11110에 데이터 있음 → 시도 11로 확장 불필요
-        put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
-        put("11",    HousingType.APT, DealType.JEONSE, 26, 40, 1 * 억, 0); // 더 저렴하지만 탐색 안 됨
-
-        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition().getRegionCode()).isEqualTo("11110");
-    }
-
-    @Test
-    @DisplayName("시도 코드(2자리)로 요청하면 지역 확장 없이 해당 시도 내에서만 탐색한다")
-    void doesNotExpandWhenAlreadySidoCode() {
-        // 시도 코드 "11" 요청 → 확장 없음, 데이터 없으면 empty
-        put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0); // 시군구에 데이터 있어도 무관
-
-        GoalRecommendationRequest request = new GoalRecommendationRequest();
-        request.setRegionCode("11");
-        request.setPropertyType(HousingType.APT);
-        request.setTradeType(DealType.JEONSE);
-        request.setSizeMin(20);
-        request.setSizeMax(25);
-        request.setTargetDate(NOW);
-
-        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.APT, 26, 40, 50_000_000L));
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getCondition()).isNull();
     }
 
-    // ===== 메시지 =====
-
     @Test
-    @DisplayName("평수 지정 + targetDate 없음: reason에 '저축하면'과 평수 범위가 포함된다")
-    void reasonIncludesSaveMonthsWhenNoTarget() {
-        put("11110", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
+    @DisplayName("업그레이드 추가 대기가 MAX_EXTRA_MONTHS(36개월) 초과하면 soft-fail을 반환한다")
+    void upgradeExceedsMaxExtraMonths_returnsSoftFail() {
+        // ctx: 저축 1천만, 대출 월 950만 → 유효 저축 50만/월
+        // baseline: 1천만 → reach 20개월 (1천만/50만)
+        // upgrade: 2.9억 median → (2.9억*0.9/0.05M) = 522개월 → extra = 502 > 36 → 거부
+        MemberFinancialContext tightCtx = ctxWithLoan(9_500_000L);
+        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 290_000_000L, 0);
 
-        GoalRecommendationRequest request = new GoalRecommendationRequest();
-        request.setRegionCode("11110");
-        request.setPropertyType(HousingType.APT);
-        request.setTradeType(DealType.JEONSE);
-        request.setSizeMin(20);
-        request.setSizeMax(25);
-
-        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), tightCtx,
+                jeonseBaseline(HousingType.APT, 20, 25, 10_000_000L));
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(26);
-        assertThat(result.get(0).getCondition().getAreaMax()).isEqualTo(40);
+        assertThat(result.get(0).getCondition()).isNull();
     }
 
-    @Test
-    @DisplayName("지역 확장으로 찾은 경우: 확장된 시도 내 후보로 조건이 채워진다")
-    void reasonMentionsOriginalRegionWhenExpanded() {
-        put("11", HousingType.APT, DealType.JEONSE, 26, 40, 2 * 억, 0);
+    // ─── 평수 업그레이드 ──────────────────────────────────────────────────────
 
-        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, aptJeonseRequest("11110"), ctx);
+    @Test
+    @DisplayName("baseline이 20~25평이면 바로 다음 버킷(26~40평)을 업그레이드 후보로 탐색한다")
+    void sizeUpgrade_findsNextBucket() {
+        // baseline 20~25평, deposit 5천만 → reach 5개월
+        // upgrade 26~40평, deposit 8천만 → median 7200만 → reach 8개월 → extra 3 → 유효
+        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 80_000_000L, 0);
+
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.APT, 20, 25, 50_000_000L));
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getCondition()).isNotNull();
+        assertThat(result.get(0).getCondition().getHousingType()).isEqualTo(HousingType.APT);
+        assertThat(result.get(0).getCondition().getDealType()).isEqualTo(DealType.JEONSE);
+        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(26);
+        assertThat(result.get(0).getCondition().getAreaMax()).isEqualTo(40);
     }
 
-    // ===== 헬퍼 =====
+    @Test
+    @DisplayName("baseline이 15~19평이면 바로 다음 버킷(20~25평)을 업그레이드 후보로 탐색한다")
+    void sizeUpgrade_15to19_findsNextBucket() {
+        // 15~19평 → 다음 버킷은 20~25평 (areaMin=20 > 19)
+        put(REGION, HousingType.APT, DealType.JEONSE, 20, 25, 60_000_000L, 0);
 
-    private MemberFinancialContext ctxWithLoan(long loanPayment) {
-        return new MemberFinancialContext(defaultNetWorth, 10_000_000L, loanPayment);
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.APT, 15, 19, 40_000_000L));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNotNull();
+        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(20);
+        assertThat(result.get(0).getCondition().getAreaMax()).isEqualTo(25);
     }
 
-    private GoalRecommendationRequest aptJeonseRequest(String regionCode) {
+    @Test
+    @DisplayName("26~40평(최고 평수 버킷) baseline에서는 평수 업그레이드 후보가 생성되지 않는다")
+    void sizeUpgrade_maxBucket_noSizeUpgradeCandidate() {
+        // 평수 업그레이드 없음 → 다른 변수(주거유형) 업그레이드로 대체
+        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 60_000_000L, 0); // 평수 업그레이드 후보 없음
+        // 주거유형 업그레이드도 APT가 최고 → 거래유형 업그레이드도 JEONSE → soft-fail
+
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.APT, 26, 40, 50_000_000L));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNull();
+    }
+
+    // ─── 주거유형 업그레이드 ──────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("baseline이 ROW_HOUSE이면 APT를 주거유형 업그레이드 후보로 탐색한다")
+    void housingTypeUpgrade_rowHouseToApt() {
+        // baseline: ROW_HOUSE, JEONSE, 20~25평, deposit 5천만
+        // upgrade: APT, JEONSE, 20~25평(areaMin=20)
+        put(REGION, HousingType.APT, DealType.JEONSE, 20, 25, 80_000_000L, 0);
+
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.ROW_HOUSE, 20, 25, 50_000_000L));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNotNull();
+        assertThat(result.get(0).getCondition().getHousingType()).isEqualTo(HousingType.APT);
+        assertThat(result.get(0).getCondition().getDealType()).isEqualTo(DealType.JEONSE);
+        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("baseline이 DETACHED이면 ROW_HOUSE를 주거유형 업그레이드 후보로 탐색한다")
+    void housingTypeUpgrade_detachedToRowHouse() {
+        put(REGION, HousingType.ROW_HOUSE, DealType.JEONSE, 20, 25, 70_000_000L, 0);
+
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.DETACHED, 20, 25, 50_000_000L));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNotNull();
+        assertThat(result.get(0).getCondition().getHousingType()).isEqualTo(HousingType.ROW_HOUSE);
+    }
+
+    @Test
+    @DisplayName("baseline이 APT(최고 주거유형)이면 주거유형 업그레이드 후보가 생성되지 않는다")
+    void housingTypeUpgrade_apt_noUpgradeCandidate() {
+        // APT → 상위 타입 없음 → 평수·거래유형만 업그레이드 후보
+        // 평수도 26~40(최고), 거래유형도 JEONSE → soft-fail
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.APT, 26, 40, 50_000_000L));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNull();
+    }
+
+    // ─── 거래유형 업그레이드 ──────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("baseline이 월세이면 전세를 거래유형 업그레이드 후보로 탐색한다")
+    void dealTypeUpgrade_wolseToJeonse() {
+        // baseline: APT, WOLSE, 20~25평, deposit=2000만, monthlyRent=30만
+        // comparable = 2000만 + 30만*12/0.05 = 9200만 → reach ~10개월
+        // upgrade: APT, JEONSE, 20~25平(areaMin=20), deposit=1억
+        // deposit.median = 1억*0.9=9000万 → reach 9개월 → extra = -1 → 유효
+        put(REGION, HousingType.APT, DealType.JEONSE, 20, 25, 100_000_000L, 0);
+
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                wolseBaseline(HousingType.APT, 20, 25, 20_000_000L, 300_000L));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNotNull();
+        assertThat(result.get(0).getCondition().getDealType()).isEqualTo(DealType.JEONSE);
+        assertThat(result.get(0).getCondition().getMonthlyRent()).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("baseline이 전세이면 거래유형 업그레이드 후보가 생성되지 않는다")
+    void dealTypeUpgrade_jeonse_noUpgradeCandidate() {
+        // JEONSE는 이미 최고 거래유형 → 업그레이드 없음
+        // APT(최고) + JEONSE(최고) + 26~40평(최고) → soft-fail
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.APT, 26, 40, 50_000_000L));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNull();
+    }
+
+    // ─── 대출 반영 ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("기존 대출 월상환액이 BudgetCalculator에 반영되어 달성 개월이 늘어난다")
+    void withExistingLoan_loanDeductedFromBudget() {
+        // 저축 1천만, 대출 500만 → 유효 저축 500만/월
+        // baseline 5천만 → reach 10개월 (5천만/500만)
+        // upgrade 8천만 → median 7200만 → reach 15개월 → extra 5 ≤ 36 → 유효
+        MemberFinancialContext loanCtx = ctxWithLoan(5_000_000L);
+        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 80_000_000L, 0);
+
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), loanCtx,
+                jeonseBaseline(HousingType.APT, 20, 25, 50_000_000L));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNotNull();
+        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(26);
+    }
+
+    // ─── 복수 후보 중 최고점 선택 ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("평수·주거유형 업그레이드 후보가 모두 있으면 점수가 높은 것을 선택한다")
+    void multipleUpgradeCandidates_bestScoreWins() {
+        // baseline: ROW_HOUSE, JEONSE, 20~25평, deposit 5천만
+        // 평수 업그레이드: APT, JEONSE, 26~40평 → deposit 8千万 → extra 3개월
+        // 주거유형 업그레이드: APT, JEONSE, 20~25평 → deposit 6千万 → extra 1개월
+        // 주거유형 업그레이드가 extra가 더 작아 horizonScore 높고, condImprovScore도 0.7 → 더 높은 점수 가능
+        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 80_000_000L, 0);  // 평수 업그레이드
+        put(REGION, HousingType.APT, DealType.JEONSE, 20, 25, 60_000_000L, 0);  // 주거유형 업그레이드
+
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.ROW_HOUSE, 20, 25, 50_000_000L));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition()).isNotNull();
+        // 두 후보 중 하나가 선택됨 — 주거유형 업그레이드(같은 평수, APT)가 더 가까워 선택될 가능성 높음
+        assertThat(result.get(0).getCondition().getHousingType()).isEqualTo(HousingType.APT);
+    }
+
+    // ─── 헬퍼 ────────────────────────────────────────────────────────────────
+
+    private RecommendationItem jeonseBaseline(HousingType ht, int areaMin, int areaMax, long deposit) {
+        return RecommendationItem.builder()
+                .type(AlgorithmType.REALISTIC)
+                .condition(GoalRecommendationResponse.Condition.builder()
+                        .regionCode(REGION)
+                        .regionName("테스트구")
+                        .housingType(ht)
+                        .dealType(DealType.JEONSE)
+                        .areaMin(areaMin)
+                        .areaMax(areaMax)
+                        .depositMin(0L)
+                        .depositMax(Long.MAX_VALUE)
+                        .monthlyRent(0L)
+                        .sampleCount(10)
+                        .marketMedianAmount(deposit)
+                        .build())
+                .build();
+    }
+
+    private RecommendationItem wolseBaseline(HousingType ht, int areaMin, int areaMax,
+                                              long deposit, long monthlyRent) {
+        return RecommendationItem.builder()
+                .type(AlgorithmType.REALISTIC)
+                .condition(GoalRecommendationResponse.Condition.builder()
+                        .regionCode(REGION)
+                        .regionName("테스트구")
+                        .housingType(ht)
+                        .dealType(DealType.WOLSE)
+                        .areaMin(areaMin)
+                        .areaMax(areaMax)
+                        .depositMin(0L)
+                        .depositMax(Long.MAX_VALUE)
+                        .monthlyRent(monthlyRent)
+                        .sampleCount(10)
+                        .marketMedianAmount(deposit)
+                        .build())
+                .build();
+    }
+
+    private MemberFinancialContext ctxWithLoan(long monthlyPayment) {
+        return new MemberFinancialContext(zeroNetWorth, 10_000_000L,
+                List.of(new LoanSchedule(monthlyPayment, 1200L)));
+    }
+
+    private GoalRecommendationRequest defaultRequest() {
         GoalRecommendationRequest request = new GoalRecommendationRequest();
-        request.setRegionCode(regionCode);
+        request.setRegionCode(REGION);
         request.setPropertyType(HousingType.APT);
         request.setTradeType(DealType.JEONSE);
         request.setSizeMin(20);
         request.setSizeMax(25);
-        request.setTargetDate(NOW);
+        request.setTargetDate(NOW.plusMonths(24));
         return request;
     }
 
-    private void put(String regionCode, HousingType housingType, DealType dealType,
-            int areaMin, int areaMax, long q3Deposit, long q3MonthlyRent) {
-        market.put(key(regionCode, housingType, dealType, areaMin), new long[]{q3Deposit, q3MonthlyRent});
-    }
-
-    private String key(String regionCode, HousingType housingType, DealType dealType, int areaMin) {
-        return regionCode + "|" + housingType + "|" + dealType + "|" + areaMin;
+    private void put(String regionCode, HousingType ht, DealType dt,
+                     int areaMin, int areaMax, long medianDeposit, long medianRent) {
+        market.put(regionCode + "|" + ht + "|" + dt + "|" + areaMin,
+                new long[]{medianDeposit, medianRent});
     }
 
     /**
-     * market에서 regionCode에 해당하는 항목만 골라 getBulkMedian 반환 형식의 맵으로 변환한다.
-     * 키: "{HousingType}|{DealType}|{areaMin평}" — HoldOutAlgorithm.buildPool과 동일한 형식.
+     * market에서 regionCode에 해당하는 항목을 HoldOutAlgorithm이 기대하는 키 형식(ht|dt|areaMin)으로 반환한다.
+     * deposit은 Q2를 medianDeposit*0.9로, Q3를 medianDeposit으로 설정해 getMedian()이 medianDeposit*0.9를 반환한다.
      */
     private Map<String, RentMedianResponse> toBulkMap(String regionCode) {
         Map<String, RentMedianResponse> bulk = new HashMap<>();
@@ -331,20 +416,20 @@ class HoldOutAlgorithmTest {
             String[] parts = entry.getKey().split("\\|");
             if (!parts[0].equals(regionCode)) continue;
             HousingType ht = HousingType.valueOf(parts[1]);
-            DealType dt = DealType.valueOf(parts[2]);
-            int areaMin = Integer.parseInt(parts[3]);
-            long[] vals = entry.getValue();
-            long q3Deposit = vals[0];
-            long q3MonthlyRent = vals[1];
+            DealType dt    = DealType.valueOf(parts[2]);
+            int areaMin    = Integer.parseInt(parts[3]);
+            long[] vals    = entry.getValue();
+            long medDeposit = vals[0];
+            long medRent    = vals[1];
             bulk.put(ht + "|" + dt + "|" + areaMin, RentMedianResponse.builder()
                     .regionCode(regionCode)
                     .regionName("테스트구")
                     .housingType(ht)
                     .dealType(dt)
                     .sampleCount(15)
-                    .deposit(Quartile.of(q3Deposit * 8 / 10, q3Deposit * 9 / 10, q3Deposit))
-                    .monthlyRent(q3MonthlyRent > 0
-                            ? Quartile.of(q3MonthlyRent * 8 / 10, q3MonthlyRent * 9 / 10, q3MonthlyRent)
+                    .deposit(Quartile.of(medDeposit * 8 / 10, medDeposit * 9 / 10, medDeposit))
+                    .monthlyRent(medRent > 0
+                            ? Quartile.of(medRent * 8 / 10, medRent * 9 / 10, medRent)
                             : Quartile.empty())
                     .build());
         }

--- a/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
@@ -18,6 +18,7 @@ import com.team.independence.goal.dto.LoanPlans;
 import com.team.independence.goal.service.MonteCarloService;
 import com.team.independence.goal.service.calculator.BudgetCalculator;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
+import com.team.independence.goal.service.calculator.LoanSchedule;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.dto.RentMedianRequest;
@@ -73,11 +74,11 @@ class PreferenceAlgorithmTest {
                 .interestBearingAssets(0L)
                 .flatRecognizedAssets(0L)
                 .build();
-        ctx = new MemberFinancialContext(defaultNetWorth, 10_000_000L, 0L);
+        ctx = new MemberFinancialContext(defaultNetWorth, 10_000_000L, List.of());
 
         when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), anyLong()))
                 .thenReturn(LoanPlans.builder().build());
-        when(loanPlanCalculator.calculateSavingFixed(anyLong(), anyLong(), any(), anyLong()))
+        when(loanPlanCalculator.calculateSavingFixed(anyLong(), anyLong(), any(), anyLong(), any()))
                 .thenReturn(LoanPlans.builder().build());
         stubMedian(2 * 억, 0, 120);
     }
@@ -166,7 +167,7 @@ class PreferenceAlgorithmTest {
 
         assertThat(item.getCondition().getMonthlyRent()).isEqualTo(40 * 만);
         // 환산값이 아니라 실제 보증금(1,000만)을 플랜 계산기로 넘긴다. targetDate가 없어 저축 고정 경로만 탄다.
-        verify(loanPlanCalculator).calculateSavingFixed(eq(MEMBER_ID), eq(1000 * 만), any(), anyLong());
+        verify(loanPlanCalculator).calculateSavingFixed(eq(MEMBER_ID), eq(1000 * 만), any(), anyLong(), any());
     }
 
     @Test

--- a/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
@@ -92,7 +92,7 @@ class RealisticAlgorithmTest {
                 .interestBearingAssets(0L)
                 .flatRecognizedAssets(0L)
                 .build();
-        ctx = new MemberFinancialContext(defaultNetWorth, MONTHLY_SAVING, 0L);
+        ctx = new MemberFinancialContext(defaultNetWorth, MONTHLY_SAVING, List.of());
 
         // MC: 가격 변화 없음으로 스텁. 선택 로직이 가려지지 않게 priceP50 = initialPrice 반환.
         when(monteCarloService.simulate(any(PriceModelRequest.class), anyLong(), anyLong(), anyInt()))
@@ -156,7 +156,7 @@ class RealisticAlgorithmTest {
         // 월 저축 2천만 → 예산 4.8억. 이제 3억짜리도 들어온다.
         RecommendationItem item = algorithm.recommend(MEMBER_ID,
                 request("11110", HousingType.APT, DealType.JEONSE),
-                new MemberFinancialContext(defaultNetWorth, 20_000_000L, 0L))
+                new MemberFinancialContext(defaultNetWorth, 20_000_000L, List.of()))
                 .get(0);
 
         assertThat(item.getCondition().getAreaMin()).isEqualTo(20);
@@ -261,7 +261,7 @@ class RealisticAlgorithmTest {
 
         RecommendationItem item = algorithm.recommend(MEMBER_ID,
                 request("11110", HousingType.APT, DealType.JEONSE),
-                new MemberFinancialContext(defaultNetWorth, 0L, 0L))
+                new MemberFinancialContext(defaultNetWorth, 0L, List.of()))
                 .get(0);
 
         // 저축 0이어도 가장 가까운 후보(가장 싼 조건) 카드는 나온다


### PR DESCRIPTION
## #️⃣연관된 이슈

- #134 
- #135

## 📝작업 내용

### 1. LoanSchedule 도입 — 대출 구간별 잔여 기간 반영

기존 `calcTotalExistingMonthlyPayment()`는 대출 월상환액을 단일 합산값으로만 다뤄
각 대출의 종료 시점이 소실됐다. 대출이 끝난 달부터 저축 여력이 늘어나는 현실을 반영하지 못하는 문제.

- `LoanSchedule(monthlyPayment, remainingMonths)` record 도입
- `BudgetCalculator.calculate / monthsToReach` — `List<LoanSchedule>` 오버로드 추가  
  매월 잔여 개월이 남은 대출 상환액만 차감, 소멸 이후 rawSaving 전액 저축
- `LoanPlanCalculator.getLoanSchedules()` 신규 — 대출 계좌별 잔여 스케줄 목록 반환
- `LoanPlanCalculator.calculateSavingFixed()` — 5번째 파라미터로 `List<LoanSchedule>` 추가  
  신규 대출 상환은 DSR 40% 한도 내 별도 소득으로 충당하므로 저축액 차감 로직 제거
- `calcShortenedMonths()` 제거 → BudgetCalculator 오버로드로 대체

### 2. 추천 서비스/알고리즘 LoanSchedule 기반 전환

- `MemberFinancialContext`: `loanPayment(long)` → `List<LoanSchedule> loanSchedules`  
  `effectiveSaving()` → `currentEffectiveSaving()` (현재 시점 스냅샷용)
- `GoalServiceImpl`: `calcEffectiveMonthlySaving()` 제거, LoanSchedule 오버로드로 교체
- `PreferenceAlgorithm`, `RealisticAlgorithm`: LoanSchedule 기반으로 전환

### 3. HoldOut 알고리즘 재설계

**기존**: MonteCarloService + PATIENCE_BONUS 기반 독립 탐색 → Realistic과 맥락 단절  
**신규**: Realistic 결과를 기준점으로 "변수 하나만 바꾼" 업그레이드 조건 탐색

| 업그레이드 변수 | 규칙 |
|---|---|
| 평수 | `nextSizeBucket(areaMax)` — 바로 다음 SIZE_BUCKET |
| 주거유형 | DETACHED→ROW_HOUSE, ROW_HOUSE·OFFICETEL→APT |
| 거래유형 | WOLSE→JEONSE (월세 baseline만) |

스코어링: `score = 0.5 × condImprovScore + 0.5 × horizonScore`  
`horizonScore = 1 / (1 + extraMonths / 24)`, `extraMonths > 36` 후보 제외

### 4. GoalRecommendationServiceImpl 2-Phase 병렬 실행

HoldOut이 Realistic 결과에 의존하므로 단순 전체 병렬 구조에서 2-Phase로 전환.

```
Phase 1 (병렬): RealisticAlgorithm + 기타(PreferenceAlgorithm)
Phase 2:        realisticFuture.thenApplyAsync → HoldOutAlgorithm
결과 순서 고정: Realistic → HoldOut → 기타
```

## 💬리뷰 요구사항(선택)