### PR TITLE
[REFACTOR] 달성률 구간 마지막 칸 분리: 80~100% → 80~90%, 90~100%

### DIFF
--- a/src/main/java/com/team/independence/compare/dto/AchievementBucketCount.java
+++ b/src/main/java/com/team/independence/compare/dto/AchievementBucketCount.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Setter
 public class AchievementBucketCount {
 
-    /** 0=0~10%, 1=10~20% ... 8=80~100% */
+    /** 0=0~10%, 1=10~20% ... 9=90~100% */
     private int bucketIndex;
 
     private int count;

--- a/src/main/java/com/team/independence/compare/dto/GoalCompareResponse.java
+++ b/src/main/java/com/team/independence/compare/dto/GoalCompareResponse.java
@@ -39,8 +39,7 @@ public class GoalCompareResponse {
     }
 
     /**
-     * 달성률 10% 단위 구간.
-     * 마지막 구간(80~100%)만 폭이 20이다.
+     * 달성률 10% 단위 구간. 마지막 구간은 90~100%이다.
      * isMine은 primitive boolean이 아닌 Boolean — Jackson이 "isMine"으로 직렬화하려면 래퍼 타입이어야 한다.
      */
     @Getter

--- a/src/main/java/com/team/independence/compare/mapper/GoalSnapshotMapper.java
+++ b/src/main/java/com/team/independence/compare/mapper/GoalSnapshotMapper.java
@@ -69,7 +69,7 @@ public interface GoalSnapshotMapper {
     List<RegionCount> countTopRegions(CohortCondition condition);
 
     /**
-     * 달성률 10% 구간별 인원 수. 마지막 구간(80~100%)만 폭이 20이다.
+     * 달성률 10% 구간별 인원 수. 마지막 구간은 90~100%이다.
      *
      * <p>인원이 0인 구간은 결과에 없다. 빈 구간 채우기는 서비스 계층에서 한다.
      */

--- a/src/main/java/com/team/independence/compare/service/CompareServiceImpl.java
+++ b/src/main/java/com/team/independence/compare/service/CompareServiceImpl.java
@@ -63,8 +63,8 @@ public class CompareServiceImpl implements CompareService {
     private static final int MIN_AGE_RANGE = 1;
     private static final int MAX_AGE_RANGE = 5;
 
-    /** 달성률 구간 개수. 0~10 … 70~80 여덟 칸에 마지막 80~100 한 칸 */
-    private static final int BUCKET_SIZE = 9;
+    /** 달성률 구간 개수. 0~10 … 80~90 아홉 칸에 마지막 90~100 한 칸 */
+    private static final int BUCKET_SIZE = 10;
 
     /** 집계 기준월 형식 YYYYMM */
     private static final DateTimeFormatter YM = DateTimeFormatter.ofPattern("yyyyMM");
@@ -328,7 +328,7 @@ public class CompareServiceImpl implements CompareService {
         for (int i = 0; i < BUCKET_SIZE; i++) {
             buckets.add(GoalCompareResponse.Bucket.builder()
                     .rangeMin(i * 10)
-                    .rangeMax(i == BUCKET_SIZE - 1 ? 100 : (i + 1) * 10)
+                    .rangeMax((i + 1) * 10)
                     .count(bucketCounts[i])
                     .ratio(percentage(bucketCounts[i], cohortSize))
                     .isMine(myIndex >= 0 && i == myIndex)
@@ -471,7 +471,7 @@ public class CompareServiceImpl implements CompareService {
         for (int i = 0; i < BUCKET_SIZE; i++) {
             buckets.add(AchievementBucket.builder()
                     .rangeMin(i * 10)
-                    .rangeMax(i == BUCKET_SIZE - 1 ? 100 : (i + 1) * 10)
+                    .rangeMax((i + 1) * 10)
                     .count(counts[i])
                     .ratio(percentage(counts[i], cohortSize))
                     .isMine(myIndex >= 0 && i == myIndex)

--- a/src/main/resources/mybatis/mapper/compare/GoalSnapshotMapper.xml
+++ b/src/main/resources/mybatis/mapper/compare/GoalSnapshotMapper.xml
@@ -199,15 +199,15 @@
 
     <!--
       달성률을 10 단위로 나눈 구간 번호로 묶는다.
-      LEAST(..., 8) 로 80% 이상은 모두 마지막 구간(80~100%)에 넣는다.
+      LEAST(..., 9) 로 90% 이상은 모두 마지막 구간(90~100%)에 넣는다.
     -->
     <select id="countByAchievementBucket"
             resultType="com.team.independence.compare.dto.AchievementBucketCount">
-        SELECT LEAST(FLOOR(achievement_rate / 10), 8) AS bucketIndex,
+        SELECT LEAST(FLOOR(achievement_rate / 10), 9) AS bucketIndex,
                COUNT(*)                               AS `count`
         FROM goal_snapshot
         <include refid="cohortWhere"/>
-        GROUP BY LEAST(FLOOR(achievement_rate / 10), 8)
+        GROUP BY LEAST(FLOOR(achievement_rate / 10), 9)
         ORDER BY bucketIndex
     </select>
 

--- a/src/test/java/com/team/independence/compare/service/CompareServiceImplTest.java
+++ b/src/test/java/com/team/independence/compare/service/CompareServiceImplTest.java
@@ -101,29 +101,29 @@ class CompareServiceImplTest {
 
     @Test
     @DisplayName("인원이 0인 구간도 자리를 지킨다")
-    void 빈_구간도_9칸에_포함된다() {
+    void 빈_구간도_10칸에_포함된다() {
         mapper.cohortCount = 10;
         // 쿼리는 인원이 있는 구간만 돌려준다. 0~10과 10~20은 아예 없다.
         mapper.buckets = Arrays.asList(bucket(2, 4), bucket(6, 6));
 
         List<AchievementBucket> buckets = call().getAchievementDistribution().getBuckets();
 
-        assertEquals(9, buckets.size());
+        assertEquals(10, buckets.size());
         assertEquals(0, buckets.get(0).getCount().intValue());
         assertEquals(0.0, buckets.get(0).getRatio(), 0.0001);
         assertEquals(4, buckets.get(2).getCount().intValue());
     }
 
     @Test
-    @DisplayName("마지막 구간만 80~100으로 폭이 두 배다")
-    void 마지막_구간은_80에서_100이다() {
+    @DisplayName("모든 구간이 10% 폭이고 마지막은 90~100이다")
+    void 마지막_구간은_90에서_100이다() {
         mapper.cohortCount = 10;
         List<AchievementBucket> buckets = call().getAchievementDistribution().getBuckets();
 
         assertEquals(0, buckets.get(0).getRangeMin().intValue());
         assertEquals(10, buckets.get(0).getRangeMax().intValue());
-        assertEquals(80, buckets.get(8).getRangeMin().intValue());
-        assertEquals(100, buckets.get(8).getRangeMax().intValue());
+        assertEquals(90, buckets.get(9).getRangeMin().intValue());
+        assertEquals(100, buckets.get(9).getRangeMax().intValue());
     }
 
     @Test
@@ -139,7 +139,7 @@ class CompareServiceImplTest {
     }
 
     @Test
-    @DisplayName("달성률 80 이상은 모두 마지막 구간에 들어간다")
+    @DisplayName("달성률 90 이상은 모두 마지막 구간에 들어간다")
     void 달성률_100도_마지막_구간이다() {
         mapper.cohortCount = 10;
         mapper.me.setAchievementRate(100.0);
@@ -147,7 +147,7 @@ class CompareServiceImplTest {
         List<AchievementBucket> buckets = call().getAchievementDistribution().getBuckets();
 
         // (int)(100 / 10) = 10. 방어하지 않으면 배열 밖을 가리킨다.
-        assertTrue(buckets.get(8).getIsMine());
+        assertTrue(buckets.get(9).getIsMine());
     }
 
     // ------------------------------------------------------------------

--- a/src/test/java/com/team/independence/compare/service/CompareServiceIntegrationTest.java
+++ b/src/test/java/com/team/independence/compare/service/CompareServiceIntegrationTest.java
@@ -185,18 +185,18 @@ class CompareServiceIntegrationTest {
     // ------------------------------------------------------------------
 
     @Test
-    @DisplayName("달성률 구간은 항상 9칸이고 내 구간에만 표시가 붙는다")
-    void 달성률_구간이_9칸이다() {
+    @DisplayName("달성률 구간은 항상 10칸이고 내 구간에만 표시가 붙는다")
+    void 달성률_구간이_10칸이다() {
         CompareResponse response = callOrSkip();
         assumeTrue(response.getAchievementDistribution() != null, "코호트 인원 미달이라 건너뜁니다");
 
         List<AchievementBucket> buckets = response.getAchievementDistribution().getBuckets();
-        assertEquals(9, buckets.size());
+        assertEquals(10, buckets.size());
 
-        // 마지막 칸만 폭이 두 배(80~100)다.
+        // 모든 칸이 10% 폭이고 마지막은 90~100이다.
         assertEquals(0, buckets.get(0).getRangeMin().intValue());
-        assertEquals(80, buckets.get(8).getRangeMin().intValue());
-        assertEquals(100, buckets.get(8).getRangeMax().intValue());
+        assertEquals(90, buckets.get(9).getRangeMin().intValue());
+        assertEquals(100, buckets.get(9).getRangeMax().intValue());
 
         assertEquals(1, buckets.stream().filter(AchievementBucket::getIsMine).count(),
                 "내 구간 표시는 정확히 하나여야 한다");


### PR DESCRIPTION
## #️⃣연관된 이슈

- #137

## 📝작업 내용

달성률 분포 차트의 마지막 구간이 `80~100%(폭 20%)`로 다른 구간(10%)보다 두 배 넓게 묶여 있던 문제를 수정합니다.
90% 이상 고달성 구간의 분포를 세밀하게 표현할 수 있도록 `80~90%`, `90~100%` 두 칸으로 분리했습니다.

**변경 범위**

| 파일 | 변경 내용 |
|------|-----------|
| `CompareServiceImpl.java` | `BUCKET_SIZE` 9 → 10, `bucketIndexOf` 상한 자동 반영 |
| `GoalSnapshotMapper.xml` | `LEAST(FLOOR(achievement_rate / 10), 8)` → `LEAST(..., 9)` |
| `GoalSnapshotMapper.java` | Javadoc 주석 업데이트 |
| `AchievementBucketCount.java` | 인덱스 설명 `8=80~100%` → `9=90~100%` |
| `GoalCompareResponse.java` | Bucket 주석 업데이트 |
| `CompareServiceImplTest.java` | 9칸→10칸, `get(8)`→`get(9)`, 범위 기댓값 수정 |
| `CompareServiceIntegrationTest.java` | 동일 |

DB 마이그레이션은 불필요합니다. SQL `FLOOR` 로직의 상한값만 변경되므로 기존 스냅샷 데이터는 다음 배치 집계 시 새 구간에 자동으로 반영됩니다.