### PR TITLE
refactor: HoldOut 알고리즘 후보 탐색을 40개 조합 전체 비교 방식으로 개선

### DIFF
--- a/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalRecommendationResponse.java
@@ -98,7 +98,7 @@ public class GoalRecommendationResponse {
     }
 
     @Getter
-    @Builder
+    @Builder(toBuilder = true)
     @Jacksonized
     public static class LoanXPlan {
         private long targetAmount;

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -15,7 +15,8 @@ import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.service.RentMedianService;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -23,27 +24,28 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
- * Realistic 결과를 기준점으로 삼아 변수 하나씩 업그레이드한 조건을 추천하는 HoldOut 알고리즘.
+ * Realistic 결과를 기준점으로 삼아 "가격순 바로 위 칸"을 추천하는 HoldOut 알고리즘.
  *
  * <h3>컨셉</h3>
  * Realistic이 "지금 저축으로 목표 시점 안에 가능한 조건"을 찾아주면,
- * HoldOut은 그 결과를 기준점(baseline)으로 삼아 변수 하나만 올린 업그레이드 후보를 탐색한다.
+ * HoldOut은 그 결과를 기준점(baseline)으로 삼아 <b>조금 더 비싼 다음 등급</b>을 찾는다.
  * "조금 더 기다리면 한 단계 나은 집을 얻을 수 있다"는 메시지를 만드는 카드다.
  *
- * <h3>업그레이드 후보 (한 번에 하나씩)</h3>
- * <ul>
- *   <li><b>평수</b>: baseline의 areaMax보다 areaMin이 큰 바로 다음 SIZE_BUCKET</li>
- *   <li><b>주거유형</b>: 현재 타입 바로 상위 (DETACHED → ROW_HOUSE, ROW_HOUSE·OFFICETEL → APT)</li>
- *   <li><b>거래유형</b>: baseline이 월세인 경우에만 전세로 변경</li>
- * </ul>
+ * <h3>후보군: 40개 조합 전체</h3>
+ * 평수 하나만 키우거나 주거유형만 올리는 식으로 변수를 하나씩 바꾸면, 다른 조합이 더 싼 다음 등급인데도
+ * 못 보고 지나칠 수 있다. 그래서 주거유형(4) × 거래유형(2) × 평수 버킷(5) = 40개 조합을 모두 실거래
+ * 가격으로 평가하고, baseline보다 <b>비싼 것 중 가장 싼 것</b>을 고른다. "다음 등급이 무엇인지"는
+ * 우리가 정하지 않고 시장 가격이 정한다. baseline과 같은 조합은 자연히 후보에서 제외된다
+ * (자기 자신보다 비쌀 수 없으므로).
  *
- * <h3>스코어링</h3>
- * score = 0.5 × condImprovScore + 0.5 × horizonScore
- * <ul>
- *   <li>condImprovScore: 조건 개선 폭 (평수 면적비, 주거유형·거래유형 업그레이드 고정점수)</li>
- *   <li>horizonScore = 1 / (1 + extraMonths / 24): 추가 대기 개월이 짧을수록 높다</li>
- * </ul>
- * extraMonths가 {@link #MAX_EXTRA_MONTHS}를 초과하는 후보는 제외한다.
+ * <h3>도달 개월 상한을 두지 않는다</h3>
+ * 다음 등급이 baseline 바로 위 칸이라 가격 점프가 이미 최소이므로, 추가로 대기 개월을 잘라낼 필요가
+ * 없다. 계산된 결과가 아무리 오래 걸리더라도 그대로 보여준다.
+ *
+ * <h3>baseline이 최상위 조합일 때</h3>
+ * 40개 조합을 다 훑어도 baseline보다 비싼 것이 없으면(이미 최고가 조합이면) soft-fail 카드
+ * ({@code condition = null})를 반환한다. baseline을 그대로 복제해 보여주지 않는다 — "다음 등급"이라는
+ * 이 카드의 정체성에 맞는 답이 없다는 뜻이라, 없는 답을 지어내지 않는다.
  *
  * <h3>실행 순서 의존성</h3>
  * 이 알고리즘은 Realistic 결과에 의존한다.
@@ -58,7 +60,6 @@ import org.springframework.stereotype.Service;
 public class HoldOutAlgorithm implements RecommendationAlgorithm {
 
     private static final int    MIN_SAMPLE_COUNT   = 3;
-    private static final long   MAX_EXTRA_MONTHS   = 36L;
     private static final double ANNUAL_INTEREST_RATE = 0.05;
     private static final long   DEPOSIT_MAX_DISPLAY  = 1_000_000_000_000L;
 
@@ -94,9 +95,6 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
 
         long baselineComparable = toComparableAmount(
                 baseline.getMarketMedianAmount(), baseline.getMonthlyRent());
-        Long baselineReachMonths = budgetCalculator.monthsToReach(
-                ctx.netWorth(), ctx.rawMonthlySaving(), ctx.loanSchedules(), baselineComparable);
-        if (baselineReachMonths == null) baselineReachMonths = 0L;
 
         long desiredMonths = request.getTargetDate() != null
                 ? RecommendationAlgorithm.monthsUntil(request.getTargetDate())
@@ -108,86 +106,66 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
         Map<String, RentMedianResponse> bulkMedians =
                 rentMedianService.getBulkMedian(baseline.getRegionCode(), startYm, endYm);
 
-        List<UpgradeCandidate> candidates = buildUpgradeCandidates(baseline);
+        // 목표 시점(desiredMonths)의 예산은 후보와 무관하게 같으므로 루프 밖에서 한 번만 계산한다.
+        long budgetAtT = budgetCalculator.calculate(
+                ctx.netWorth(), ctx.rawMonthlySaving(), ctx.loanSchedules(), desiredMonths);
 
-        ScoredCandidate best = null;
-        for (UpgradeCandidate uc : candidates) {
-            ScoredCandidate scored = evaluate(uc, baseline, baselineReachMonths, bulkMedians, ctx, desiredMonths);
-            if (scored == null) continue;
-            if (best == null || scored.score() > best.score()) best = scored;
-        }
+        // 40개 조합(주거유형 × 거래유형 × 평수 버킷)을 모두 평가해 baseline보다 비싼 것 중 가장 싼 것을 고른다.
+        EvaluatedCandidate nextRung = Arrays.stream(HousingType.values())
+                .flatMap(ht -> Arrays.stream(DealType.values())
+                        .flatMap(dt -> Arrays.stream(SIZE_BUCKETS)
+                                .map(size -> evaluate(baseline.getRegionCode(), ht, dt, size, bulkMedians, budgetAtT, desiredMonths))))
+                .filter(c -> c != null && c.comparableAmount() > baselineComparable)
+                .min(Comparator.comparingLong(EvaluatedCandidate::comparableAmount))
+                .orElse(null);
 
-        if (best == null) {
+        if (nextRung == null) {
             return List.of(emptyCard());
         }
 
         LoanPlans plans = loanPlanCalculator.calculateSavingFixed(
-                memberId, best.deposit(), ctx.netWorth(), ctx.rawMonthlySaving(), ctx.loanSchedules());
+                memberId, nextRung.deposit(), ctx.netWorth(), ctx.rawMonthlySaving(), ctx.loanSchedules());
 
         return List.of(GoalRecommendationResponse.RecommendationItem.builder()
                 .type(AlgorithmType.HOLD_OUT)
                 .condition(GoalRecommendationResponse.Condition.builder()
-                        .regionCode(best.regionCode())
-                        .regionName(best.regionName())
-                        .housingType(best.housingType())
-                        .dealType(best.dealType())
-                        .areaMin(best.areaMin())
-                        .areaMax(best.areaMax())
+                        .regionCode(nextRung.regionCode())
+                        .regionName(nextRung.regionName())
+                        .housingType(nextRung.housingType())
+                        .dealType(nextRung.dealType())
+                        .areaMin(nextRung.areaMin())
+                        .areaMax(nextRung.areaMax())
                         .depositMin(0L)
                         .depositMax(DEPOSIT_MAX_DISPLAY)
-                        .monthlyRent(best.monthlyRent())
-                        .sampleCount(best.sampleCount())
-                        .marketMedianAmount(best.deposit())
+                        .monthlyRent(nextRung.monthlyRent())
+                        .sampleCount(nextRung.sampleCount())
+                        .marketMedianAmount(nextRung.deposit())
                         .build())
                 .loanX(plans.getLoanX())
                 .loanO(plans.getLoanO())
                 .build());
     }
 
-    // ─── 업그레이드 후보 생성 ─────────────────────────────────────────────────────
-
-    private List<UpgradeCandidate> buildUpgradeCandidates(GoalRecommendationResponse.Condition baseline) {
-        List<UpgradeCandidate> candidates = new ArrayList<>();
-
-        // 평수 업그레이드: baseline.areaMax보다 areaMin이 큰 바로 다음 버킷
-        int[] nextSize = nextSizeBucket(baseline.getAreaMax());
-        if (nextSize != null) {
-            candidates.add(new UpgradeCandidate(
-                    baseline.getRegionCode(), baseline.getHousingType(), baseline.getDealType(),
-                    nextSize[0], nextSize[1], UpgradeType.SIZE));
-        }
-
-        // 주거유형 업그레이드: 현재 타입의 바로 상위
-        HousingType nextType = nextHousingType(baseline.getHousingType());
-        if (nextType != null) {
-            candidates.add(new UpgradeCandidate(
-                    baseline.getRegionCode(), nextType, baseline.getDealType(),
-                    baseline.getAreaMin(), baseline.getAreaMax(), UpgradeType.HOUSING_TYPE));
-        }
-
-        // 거래유형 업그레이드: 월세 → 전세
-        if (baseline.getDealType() == DealType.WOLSE) {
-            candidates.add(new UpgradeCandidate(
-                    baseline.getRegionCode(), baseline.getHousingType(), DealType.JEONSE,
-                    baseline.getAreaMin(), baseline.getAreaMax(), UpgradeType.DEAL_TYPE));
-        }
-
-        return candidates;
-    }
-
     // ─── 후보 평가 ────────────────────────────────────────────────────────────────
 
-    private ScoredCandidate evaluate(UpgradeCandidate uc, GoalRecommendationResponse.Condition baseline,
-                                      long baselineReachMonths, Map<String, RentMedianResponse> bulkMedians,
-                                      MemberFinancialContext ctx, long desiredMonths) {
-        String key = uc.housingType() + "|" + uc.dealType() + "|" + uc.areaMin();
+    /**
+     * 조합 하나(주거유형·거래유형·평수 버킷)의 실거래 median을 조회해 목표 시점의 투영 가격까지 계산한다.
+     * 표본 부족이거나 실거래 데이터가 없으면 null.
+     */
+    private EvaluatedCandidate evaluate(
+            String regionCode, HousingType housingType, DealType dealType, int[] size,
+            Map<String, RentMedianResponse> bulkMedians, long budgetAtT, long desiredMonths) {
+
+        int areaMin = size[0];
+        int areaMax = size[1];
+        String key = housingType + "|" + dealType + "|" + areaMin;
         RentMedianResponse median = bulkMedians.get(key);
         if (median == null || median.getSampleCount() < MIN_SAMPLE_COUNT) return null;
         if (median.getDeposit() == null || median.getDeposit().getMedian() == null) return null;
 
         long deposit = median.getDeposit().getMedian();
         long monthlyRent = 0L;
-        if (uc.dealType() == DealType.WOLSE) {
+        if (dealType == DealType.WOLSE) {
             Long rentMedian = median.getMonthlyRent() != null ? median.getMonthlyRent().getMedian() : null;
             if (rentMedian == null) return null;
             monthlyRent = rentMedian;
@@ -196,71 +174,23 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
         // MC로 목표 시점의 예상 가격 투영 — Realistic과 동일한 1회 시뮬레이션
         long projectedDeposit = deposit;
         try {
-            long budgetAtT = budgetCalculator.calculate(
-                    ctx.netWorth(), ctx.rawMonthlySaving(), ctx.loanSchedules(), desiredMonths);
             MonteCarloEngine.Result mc = monteCarloService.simulate(
-                    RecommendationAlgorithm.buildPriceModelRequest(
-                            uc.regionCode(), uc.housingType(), uc.dealType(), uc.areaMin(), uc.areaMax()),
+                    RecommendationAlgorithm.buildPriceModelRequest(regionCode, housingType, dealType, areaMin, areaMax),
                     deposit, budgetAtT, (int) desiredMonths);
             projectedDeposit = mc.priceP50();
         } catch (RuntimeException e) {
-            log.debug("MC 실패, 현재 시세 사용. housingType={}, dealType={}", uc.housingType(), uc.dealType());
+            log.debug("MC 실패, 현재 시세 사용. housingType={}, dealType={}", housingType, dealType);
         }
 
         long comparableAmount = toComparableAmount(projectedDeposit, monthlyRent);
-        Long upgradeReachMonths = budgetCalculator.monthsToReach(
-                ctx.netWorth(), ctx.rawMonthlySaving(), ctx.loanSchedules(), comparableAmount);
-        if (upgradeReachMonths == null) return null;
 
-        long extraMonths = upgradeReachMonths - baselineReachMonths;
-        if (extraMonths > MAX_EXTRA_MONTHS) return null;
-
-        double condImprovScore = conditionImprovementScore(baseline, uc);
-        double horizonScore    = 1.0 / (1.0 + Math.max(0, extraMonths) / 24.0);
-        double score           = 0.5 * condImprovScore + 0.5 * horizonScore;
-
-        return new ScoredCandidate(
-                uc.regionCode(), median.getRegionName(), uc.housingType(), uc.dealType(),
-                uc.areaMin(), uc.areaMax(), projectedDeposit, monthlyRent,
-                median.getSampleCount(), extraMonths, score);
-    }
-
-    private double conditionImprovementScore(GoalRecommendationResponse.Condition baseline, UpgradeCandidate uc) {
-        return switch (uc.upgradeType()) {
-            case SIZE -> {
-                double baseMid    = (baseline.getAreaMin() + baseline.getAreaMax()) / 2.0;
-                double upgradeMid = (uc.areaMin() + uc.areaMax()) / 2.0;
-                yield Math.min(1.0, Math.max(0.0, 0.5 + (upgradeMid - baseMid) / 20.0));
-            }
-            case HOUSING_TYPE -> 0.7;
-            case DEAL_TYPE    -> 0.6;
-        };
+        return new EvaluatedCandidate(
+                regionCode, median.getRegionName(), housingType, dealType,
+                areaMin, areaMax, projectedDeposit, monthlyRent,
+                median.getSampleCount(), comparableAmount);
     }
 
     // ─── 헬퍼 ────────────────────────────────────────────────────────────────────
-
-    /**
-     * baseline.areaMax보다 areaMin이 큰 버킷 중 가장 가까운(areaMin이 가장 작은) 버킷.
-     * 이미 최대 버킷이면 null.
-     */
-    private int[] nextSizeBucket(int baselineAreaMax) {
-        int[] result = null;
-        for (int[] bucket : SIZE_BUCKETS) {
-            if (bucket[0] > baselineAreaMax && (result == null || bucket[0] < result[0])) {
-                result = bucket;
-            }
-        }
-        return result;
-    }
-
-    /** DETACHED(1) → ROW_HOUSE(2), ROW_HOUSE·OFFICETEL(2) → APT(3), APT → null */
-    private HousingType nextHousingType(HousingType current) {
-        return switch (current) {
-            case DETACHED          -> HousingType.ROW_HOUSE;
-            case ROW_HOUSE, OFFICETEL -> HousingType.APT;
-            case APT               -> null;
-        };
-    }
 
     private long toComparableAmount(long deposit, long monthlyRent) {
         if (monthlyRent <= 0) return deposit;
@@ -275,14 +205,9 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
 
     // ─── 내부 타입 ────────────────────────────────────────────────────────────────
 
-    private enum UpgradeType { SIZE, HOUSING_TYPE, DEAL_TYPE }
-
-    private record UpgradeCandidate(
-            String regionCode, HousingType housingType, DealType dealType,
-            int areaMin, int areaMax, UpgradeType upgradeType) {}
-
-    private record ScoredCandidate(
+    /** 평가가 끝난 조합 하나. {@code deposit}은 목표 시점 투영가, {@code comparableAmount}는 전세 환산 후 정렬용 값. */
+    private record EvaluatedCandidate(
             String regionCode, String regionName, HousingType housingType, DealType dealType,
             int areaMin, int areaMax, long deposit, long monthlyRent,
-            int sampleCount, long extraMonths, double score) {}
+            int sampleCount, long comparableAmount) {}
 }

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -141,9 +141,26 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
                         .sampleCount(nextRung.sampleCount())
                         .marketMedianAmount(nextRung.deposit())
                         .build())
-                .loanX(plans.getLoanX())
-                .loanO(plans.getLoanO())
+                .loanX(withMonthlyRentAdded(plans.getLoanX(), nextRung.monthlyRent()))
+                .loanO(withMonthlyRentAdded(plans.getLoanO(), nextRung.monthlyRent()))
                 .build());
+    }
+
+    /**
+     * {@code calculateSavingFixed}가 계산하는 monthlySaving은 <b>보증금을 모으는 동안</b>의 저축액이라
+     * 월세는 반영돼 있지 않다. 보증금을 다 모아 입주한 뒤부터는 매달 월세가 추가로 나가므로, 카드에
+     * 표시되는 월 부담에는 월세를 더해 보여준다. 전세(월세 0)면 원래 값 그대로 반환한다.
+     */
+    private GoalRecommendationResponse.LoanXPlan withMonthlyRentAdded(
+            GoalRecommendationResponse.LoanXPlan plan, long monthlyRent) {
+        if (plan == null || monthlyRent <= 0) return plan;
+        return plan.toBuilder().monthlySaving(plan.getMonthlySaving() + monthlyRent).build();
+    }
+
+    private GoalRecommendationResponse.LoanOPlan withMonthlyRentAdded(
+            GoalRecommendationResponse.LoanOPlan plan, long monthlyRent) {
+        if (plan == null || monthlyRent <= 0) return plan;
+        return plan.toBuilder().monthlySaving(plan.getMonthlySaving() + monthlyRent).build();
     }
 
     // ─── 후보 평가 ────────────────────────────────────────────────────────────────

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
@@ -33,22 +33,27 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 /**
- * HoldOut 추천 알고리즘 단위 테스트.
+ * HoldOut 추천 알고리즘 단위 테스트 (40개 조합 next-rung 방식).
  *
  * <p>BudgetCalculator는 실 구현체를 사용하고, 나머지 외부 의존은 목으로 대체한다.
+ * MonteCarlo 목은 P50 = 입력 가격 그대로 반환해(가격 변동 0) 후보 비교를 median 보증금으로 단순화한다.
  *
  * <h3>검증 초점</h3>
  * <ul>
- *   <li>Realistic 결과(baseline)를 기준으로 정확히 하나의 변수만 바꾼 업그레이드 후보를 탐색하는가</li>
- *   <li>realisticItem이 null이거나 condition이 null이면 soft-fail을 반환하는가</li>
- *   <li>추가 대기 개월(extraMonths)이 MAX_EXTRA_MONTHS를 초과하는 후보는 제외되는가</li>
- *   <li>기존 대출이 BudgetCalculator에 올바르게 반영되는가</li>
+ *   <li>realisticItem/condition이 없으면 soft-fail을 반환하는가</li>
+ *   <li>주거유형 × 거래유형 × 평수 버킷 40개 조합 중 baseline보다 비싼 것 중 가장 싼 것을 고르는가
+ *       (변수 하나만 바꾼 후보가 아니라 조합 전체에서)</li>
+ *   <li>baseline이 이미 최고가 조합이면(위 칸 없음) soft-fail을 반환하는가 — baseline 복제하지 않음</li>
+ *   <li>도달 개월 상한이 없어, 아무리 오래 걸려도 후보를 그대로 채택하는가</li>
+ *   <li>기존 대출(LoanSchedule)이 도달 계획에 반영되는가</li>
  * </ul>
  */
 @ExtendWith(MockitoExtension.class)
@@ -128,7 +133,7 @@ class HoldOutAlgorithmTest {
     @Test
     @DisplayName("시장 데이터가 없으면 soft-fail 카드를 반환한다")
     void noMarketData_returnsSoftFail() {
-        // market에 아무것도 없음
+        // market에 아무것도 없음 → 40개 조합 전부 median 조회 실패
         List<RecommendationItem> result = algorithm.recommend(
                 MEMBER_ID, defaultRequest(), ctx,
                 jeonseBaseline(HousingType.APT, 20, 25, 50_000_000L));
@@ -138,26 +143,89 @@ class HoldOutAlgorithmTest {
     }
 
     @Test
-    @DisplayName("모든 업그레이드 변수가 이미 최고 수준이면 후보가 없어 soft-fail을 반환한다")
-    void allMaxed_noUpgradeAvailable() {
-        // APT(최고 타입) + JEONSE(최고 거래유형) + 26~40평(최고 버킷) → 업그레이드 변수 없음
-        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 80_000_000L, 0);
+    @DisplayName("baseline이 이미 40개 조합 중 최고가면(위 칸 없음) soft-fail을 반환하고 baseline을 복제하지 않는다")
+    void baselineIsTopRung_returnsSoftFailWithoutCloning() {
+        // baseline 자체가 시장에서 가장 비싼 조합 (다른 조합은 전부 baseline보다 싸다)
+        put(REGION, HousingType.APT, DealType.JEONSE, 15, 19, 30_000_000L, 0);
+        put(REGION, HousingType.APT, DealType.JEONSE, 20, 25, 50_000_000L, 0); // baseline과 동일 조합
 
         List<RecommendationItem> result = algorithm.recommend(
                 MEMBER_ID, defaultRequest(), ctx,
-                jeonseBaseline(HousingType.APT, 26, 40, 50_000_000L));
+                jeonseBaseline(HousingType.APT, 20, 25, 50_000_000L));
 
         assertThat(result).hasSize(1);
+        assertThat(result.get(0).getType()).isEqualTo(AlgorithmType.HOLD_OUT);
         assertThat(result.get(0).getCondition()).isNull();
     }
 
+    // ─── next-rung 선택 (40개 조합 전체) ──────────────────────────────────────
+
     @Test
-    @DisplayName("업그레이드 추가 대기가 MAX_EXTRA_MONTHS(36개월) 초과하면 soft-fail을 반환한다")
-    void upgradeExceedsMaxExtraMonths_returnsSoftFail() {
-        // ctx: 저축 1천만, 대출 월 950만 → 유효 저축 50만/월
-        // baseline: 1천만 → reach 20개월 (1천만/50만)
-        // upgrade: 2.9억 median → (2.9억*0.9/0.05M) = 522개월 → extra = 502 > 36 → 거부
-        MemberFinancialContext tightCtx = ctxWithLoan(9_500_000L);
+    @DisplayName("baseline보다 비싼 조합 중 가장 싼 것을 다음 등급으로 고른다")
+    void picksCheapestCombinationAboveBaseline() {
+        // baseline: APT/JEONSE/20~25평, 5천만
+        // 후보 A: APT/JEONSE/26~40평, median 7200만(=8천만*0.9)
+        // 후보 B: ROW_HOUSE/JEONSE/26~40평, median 5400만(=6천만*0.9) — 더 싸지만 baseline보다는 비쌈
+        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 80_000_000L, 0);
+        put(REGION, HousingType.ROW_HOUSE, DealType.JEONSE, 26, 40, 60_000_000L, 0);
+
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.APT, 20, 25, 50_000_000L));
+
+        assertThat(result).hasSize(1);
+        var condition = result.get(0).getCondition();
+        assertThat(condition).isNotNull();
+        // 두 후보 모두 baseline(5천만)보다 비싸다. 그중 더 싼 ROW_HOUSE(5400만)가 다음 등급으로 선택된다.
+        assertThat(condition.getHousingType()).isEqualTo(HousingType.ROW_HOUSE);
+        assertThat(condition.getAreaMin()).isEqualTo(26);
+        assertThat(condition.getMarketMedianAmount()).isEqualTo(54_000_000L);
+    }
+
+    @Test
+    @DisplayName("baseline과 같은 조합은 자기 자신보다 비쌀 수 없어 후보에서 자연히 제외된다")
+    void baselineCombinationItselfIsExcluded() {
+        // baseline과 같은 조합(APT/JEONSE/20~25평)의 시세도 market에 넣어두지만,
+        // comparableAmount가 baseline과 같아 '더 비싼 것'에서 제외되고 26~40만 후보가 된다.
+        put(REGION, HousingType.APT, DealType.JEONSE, 20, 25, 50_000_000L, 0); // == baseline
+        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 70_000_000L, 0);
+
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.APT, 20, 25, 50_000_000L));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(26);
+    }
+
+    @Test
+    @DisplayName("거래유형이 달라도(월세 환산 포함) 가격순으로 비교해 다음 등급을 고른다")
+    void comparesAcrossDealTypesByComparableAmount() {
+        // baseline: APT/JEONSE/20~25평, 5천만
+        // 월세 후보: APT/WOLSE/20~25평, 보증금 2천만 + 월세 30만 → 환산 2천만+30만*12/0.05=9200만
+        // 전세 후보: APT/JEONSE/26~40평, median 9900만(baseline보다 비싸지만 월세 환산보다도 비쌈)
+        put(REGION, HousingType.APT, DealType.WOLSE, 20, 25, 20_000_000L, 300_000L);
+        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 110_000_000L, 0); // median = 9900만
+
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.APT, 20, 25, 50_000_000L));
+
+        assertThat(result).hasSize(1);
+        var condition = result.get(0).getCondition();
+        // 월세 환산액(9200만) < 전세 median(9900만) → 월세 후보가 다음 등급
+        // getMedian()은 Quartile.of(*0.8, *0.9, *1.0)의 가운데 값이라 300,000 * 0.9 = 270,000이 된다.
+        assertThat(condition.getDealType()).isEqualTo(DealType.WOLSE);
+        assertThat(condition.getMonthlyRent()).isEqualTo(270_000L);
+    }
+
+    // ─── 도달 개월 상한 없음 ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("도달까지 아무리 오래 걸려도 개월 상한 없이 다음 등급을 채택한다")
+    void noUpperBoundOnExtraMonths() {
+        // 저축 여력이 매우 작아 도달까지 수백 개월이 걸려도 후보를 그대로 채택해야 한다.
+        MemberFinancialContext tightCtx = ctxWithLoan(9_990_000L); // 유효 저축 1만원
         put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 290_000_000L, 0);
 
         List<RecommendationItem> result = algorithm.recommend(
@@ -165,182 +233,40 @@ class HoldOutAlgorithmTest {
                 jeonseBaseline(HousingType.APT, 20, 25, 10_000_000L));
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNull();
-    }
-
-    // ─── 평수 업그레이드 ──────────────────────────────────────────────────────
-
-    @Test
-    @DisplayName("baseline이 20~25평이면 바로 다음 버킷(26~40평)을 업그레이드 후보로 탐색한다")
-    void sizeUpgrade_findsNextBucket() {
-        // baseline 20~25평, deposit 5천만 → reach 5개월
-        // upgrade 26~40평, deposit 8천만 → median 7200만 → reach 8개월 → extra 3 → 유효
-        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 80_000_000L, 0);
-
-        List<RecommendationItem> result = algorithm.recommend(
-                MEMBER_ID, defaultRequest(), ctx,
-                jeonseBaseline(HousingType.APT, 20, 25, 50_000_000L));
-
-        assertThat(result).hasSize(1);
         assertThat(result.get(0).getCondition()).isNotNull();
-        assertThat(result.get(0).getCondition().getHousingType()).isEqualTo(HousingType.APT);
-        assertThat(result.get(0).getCondition().getDealType()).isEqualTo(DealType.JEONSE);
         assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(26);
-        assertThat(result.get(0).getCondition().getAreaMax()).isEqualTo(40);
-    }
-
-    @Test
-    @DisplayName("baseline이 15~19평이면 바로 다음 버킷(20~25평)을 업그레이드 후보로 탐색한다")
-    void sizeUpgrade_15to19_findsNextBucket() {
-        // 15~19평 → 다음 버킷은 20~25평 (areaMin=20 > 19)
-        put(REGION, HousingType.APT, DealType.JEONSE, 20, 25, 60_000_000L, 0);
-
-        List<RecommendationItem> result = algorithm.recommend(
-                MEMBER_ID, defaultRequest(), ctx,
-                jeonseBaseline(HousingType.APT, 15, 19, 40_000_000L));
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNotNull();
-        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(20);
-        assertThat(result.get(0).getCondition().getAreaMax()).isEqualTo(25);
-    }
-
-    @Test
-    @DisplayName("26~40평(최고 평수 버킷) baseline에서는 평수 업그레이드 후보가 생성되지 않는다")
-    void sizeUpgrade_maxBucket_noSizeUpgradeCandidate() {
-        // 평수 업그레이드 없음 → 다른 변수(주거유형) 업그레이드로 대체
-        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 60_000_000L, 0); // 평수 업그레이드 후보 없음
-        // 주거유형 업그레이드도 APT가 최고 → 거래유형 업그레이드도 JEONSE → soft-fail
-
-        List<RecommendationItem> result = algorithm.recommend(
-                MEMBER_ID, defaultRequest(), ctx,
-                jeonseBaseline(HousingType.APT, 26, 40, 50_000_000L));
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNull();
-    }
-
-    // ─── 주거유형 업그레이드 ──────────────────────────────────────────────────
-
-    @Test
-    @DisplayName("baseline이 ROW_HOUSE이면 APT를 주거유형 업그레이드 후보로 탐색한다")
-    void housingTypeUpgrade_rowHouseToApt() {
-        // baseline: ROW_HOUSE, JEONSE, 20~25평, deposit 5천만
-        // upgrade: APT, JEONSE, 20~25평(areaMin=20)
-        put(REGION, HousingType.APT, DealType.JEONSE, 20, 25, 80_000_000L, 0);
-
-        List<RecommendationItem> result = algorithm.recommend(
-                MEMBER_ID, defaultRequest(), ctx,
-                jeonseBaseline(HousingType.ROW_HOUSE, 20, 25, 50_000_000L));
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNotNull();
-        assertThat(result.get(0).getCondition().getHousingType()).isEqualTo(HousingType.APT);
-        assertThat(result.get(0).getCondition().getDealType()).isEqualTo(DealType.JEONSE);
-        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(20);
-    }
-
-    @Test
-    @DisplayName("baseline이 DETACHED이면 ROW_HOUSE를 주거유형 업그레이드 후보로 탐색한다")
-    void housingTypeUpgrade_detachedToRowHouse() {
-        put(REGION, HousingType.ROW_HOUSE, DealType.JEONSE, 20, 25, 70_000_000L, 0);
-
-        List<RecommendationItem> result = algorithm.recommend(
-                MEMBER_ID, defaultRequest(), ctx,
-                jeonseBaseline(HousingType.DETACHED, 20, 25, 50_000_000L));
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNotNull();
-        assertThat(result.get(0).getCondition().getHousingType()).isEqualTo(HousingType.ROW_HOUSE);
-    }
-
-    @Test
-    @DisplayName("baseline이 APT(최고 주거유형)이면 주거유형 업그레이드 후보가 생성되지 않는다")
-    void housingTypeUpgrade_apt_noUpgradeCandidate() {
-        // APT → 상위 타입 없음 → 평수·거래유형만 업그레이드 후보
-        // 평수도 26~40(최고), 거래유형도 JEONSE → soft-fail
-        List<RecommendationItem> result = algorithm.recommend(
-                MEMBER_ID, defaultRequest(), ctx,
-                jeonseBaseline(HousingType.APT, 26, 40, 50_000_000L));
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNull();
-    }
-
-    // ─── 거래유형 업그레이드 ──────────────────────────────────────────────────
-
-    @Test
-    @DisplayName("baseline이 월세이면 전세를 거래유형 업그레이드 후보로 탐색한다")
-    void dealTypeUpgrade_wolseToJeonse() {
-        // baseline: APT, WOLSE, 20~25평, deposit=2000만, monthlyRent=30만
-        // comparable = 2000만 + 30만*12/0.05 = 9200만 → reach ~10개월
-        // upgrade: APT, JEONSE, 20~25平(areaMin=20), deposit=1억
-        // deposit.median = 1억*0.9=9000万 → reach 9개월 → extra = -1 → 유효
-        put(REGION, HousingType.APT, DealType.JEONSE, 20, 25, 100_000_000L, 0);
-
-        List<RecommendationItem> result = algorithm.recommend(
-                MEMBER_ID, defaultRequest(), ctx,
-                wolseBaseline(HousingType.APT, 20, 25, 20_000_000L, 300_000L));
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNotNull();
-        assertThat(result.get(0).getCondition().getDealType()).isEqualTo(DealType.JEONSE);
-        assertThat(result.get(0).getCondition().getMonthlyRent()).isEqualTo(0L);
-    }
-
-    @Test
-    @DisplayName("baseline이 전세이면 거래유형 업그레이드 후보가 생성되지 않는다")
-    void dealTypeUpgrade_jeonse_noUpgradeCandidate() {
-        // JEONSE는 이미 최고 거래유형 → 업그레이드 없음
-        // APT(최고) + JEONSE(최고) + 26~40평(최고) → soft-fail
-        List<RecommendationItem> result = algorithm.recommend(
-                MEMBER_ID, defaultRequest(), ctx,
-                jeonseBaseline(HousingType.APT, 26, 40, 50_000_000L));
-
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNull();
     }
 
     // ─── 대출 반영 ────────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("기존 대출 월상환액이 BudgetCalculator에 반영되어 달성 개월이 늘어난다")
-    void withExistingLoan_loanDeductedFromBudget() {
-        // 저축 1천만, 대출 500만 → 유효 저축 500만/월
-        // baseline 5천만 → reach 10개월 (5천만/500만)
-        // upgrade 8천만 → median 7200만 → reach 15개월 → extra 5 ≤ 36 → 유효
+    @DisplayName("기존 대출(LoanSchedule)이 도달 계획 계산에 그대로 전달된다")
+    void existingLoanPassedToLoanPlanCalculator() {
         MemberFinancialContext loanCtx = ctxWithLoan(5_000_000L);
         put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 80_000_000L, 0);
 
-        List<RecommendationItem> result = algorithm.recommend(
+        algorithm.recommend(
                 MEMBER_ID, defaultRequest(), loanCtx,
                 jeonseBaseline(HousingType.APT, 20, 25, 50_000_000L));
 
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNotNull();
-        assertThat(result.get(0).getCondition().getAreaMin()).isEqualTo(26);
+        Mockito.verify(loanPlanCalculator).calculateSavingFixed(
+                Mockito.eq(MEMBER_ID), anyLong(), any(AssetNetWorthBreakdown.class),
+                Mockito.eq(10_000_000L), Mockito.eq(loanCtx.loanSchedules()));
     }
 
-    // ─── 복수 후보 중 최고점 선택 ─────────────────────────────────────────────
-
     @Test
-    @DisplayName("평수·주거유형 업그레이드 후보가 모두 있으면 점수가 높은 것을 선택한다")
-    void multipleUpgradeCandidates_bestScoreWins() {
-        // baseline: ROW_HOUSE, JEONSE, 20~25평, deposit 5천만
-        // 평수 업그레이드: APT, JEONSE, 26~40평 → deposit 8千万 → extra 3개월
-        // 주거유형 업그레이드: APT, JEONSE, 20~25평 → deposit 6千万 → extra 1개월
-        // 주거유형 업그레이드가 extra가 더 작아 horizonScore 높고, condImprovScore도 0.7 → 더 높은 점수 가능
-        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 80_000_000L, 0);  // 평수 업그레이드
-        put(REGION, HousingType.APT, DealType.JEONSE, 20, 25, 60_000_000L, 0);  // 주거유형 업그레이드
+    @DisplayName("다음 등급의 투영 보증금으로 calculateSavingFixed를 호출한다")
+    void reachesNextRungBySavingFixed() {
+        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 80_000_000L, 0); // median = 72,000,000
 
-        List<RecommendationItem> result = algorithm.recommend(
+        algorithm.recommend(
                 MEMBER_ID, defaultRequest(), ctx,
-                jeonseBaseline(HousingType.ROW_HOUSE, 20, 25, 50_000_000L));
+                jeonseBaseline(HousingType.APT, 20, 25, 50_000_000L));
 
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCondition()).isNotNull();
-        // 두 후보 중 하나가 선택됨 — 주거유형 업그레이드(같은 평수, APT)가 더 가까워 선택될 가능성 높음
-        assertThat(result.get(0).getCondition().getHousingType()).isEqualTo(HousingType.APT);
+        ArgumentCaptor<Long> amount = ArgumentCaptor.forClass(Long.class);
+        Mockito.verify(loanPlanCalculator).calculateSavingFixed(
+                anyLong(), amount.capture(), any(AssetNetWorthBreakdown.class), anyLong(), any());
+        assertThat(amount.getValue()).isEqualTo(72_000_000L);
     }
 
     // ─── 헬퍼 ────────────────────────────────────────────────────────────────
@@ -358,26 +284,6 @@ class HoldOutAlgorithmTest {
                         .depositMin(0L)
                         .depositMax(Long.MAX_VALUE)
                         .monthlyRent(0L)
-                        .sampleCount(10)
-                        .marketMedianAmount(deposit)
-                        .build())
-                .build();
-    }
-
-    private RecommendationItem wolseBaseline(HousingType ht, int areaMin, int areaMax,
-                                              long deposit, long monthlyRent) {
-        return RecommendationItem.builder()
-                .type(AlgorithmType.REALISTIC)
-                .condition(GoalRecommendationResponse.Condition.builder()
-                        .regionCode(REGION)
-                        .regionName("테스트구")
-                        .housingType(ht)
-                        .dealType(DealType.WOLSE)
-                        .areaMin(areaMin)
-                        .areaMax(areaMax)
-                        .depositMin(0L)
-                        .depositMax(Long.MAX_VALUE)
-                        .monthlyRent(monthlyRent)
                         .sampleCount(10)
                         .marketMedianAmount(deposit)
                         .build())

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
@@ -219,6 +219,62 @@ class HoldOutAlgorithmTest {
         assertThat(condition.getMonthlyRent()).isEqualTo(270_000L);
     }
 
+    @Test
+    @DisplayName("다음 등급이 월세면 loanX·loanO의 monthlySaving에 월세를 더해 보여준다")
+    void addsMonthlyRentToLoanXAndLoanOWhenNextRungIsWolse() {
+        // baseline: APT/JEONSE/20~25평, 5천만
+        // 다음 등급: APT/WOLSE/26~40평, 보증금 5천만 + 월세 30만 → comparable = 5천만+30만*12/0.05=1억1800만 > baseline
+        put(REGION, HousingType.APT, DealType.WOLSE, 26, 40, 50_000_000L, 300_000L);
+
+        when(loanPlanCalculator.calculateSavingFixed(
+                anyLong(), anyLong(), any(AssetNetWorthBreakdown.class), anyLong(), any()))
+                .thenReturn(LoanPlans.builder()
+                        .loanX(GoalRecommendationResponse.LoanXPlan.builder()
+                                .targetAmount(45_000_000L).targetDate(NOW.plusMonths(10)).monthlySaving(1_000_000L)
+                                .build())
+                        .loanO(GoalRecommendationResponse.LoanOPlan.builder()
+                                .loanAmount(10_000_000L).targetAmount(35_000_000L).targetDate(NOW.plusMonths(7))
+                                .monthlySaving(1_000_000L).shortenedMonths(3L)
+                                .build())
+                        .build());
+
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.APT, 20, 25, 50_000_000L));
+
+        assertThat(result).hasSize(1);
+        var item = result.get(0);
+        assertThat(item.getCondition().getDealType()).isEqualTo(DealType.WOLSE);
+        // getMedian() = 30만 * 0.9 = 27만
+        assertThat(item.getCondition().getMonthlyRent()).isEqualTo(270_000L);
+        // 목의 monthlySaving(100만) + 월세(27만) = 127만
+        assertThat(item.getLoanX().getMonthlySaving()).isEqualTo(1_270_000L);
+        assertThat(item.getLoanO().getMonthlySaving()).isEqualTo(1_270_000L);
+        // 월세와 무관한 필드는 그대로 유지된다
+        assertThat(item.getLoanO().getShortenedMonths()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("다음 등급이 전세면 monthlySaving을 그대로 둔다")
+    void keepsMonthlySavingUnchangedWhenNextRungIsJeonse() {
+        put(REGION, HousingType.APT, DealType.JEONSE, 26, 40, 80_000_000L, 0);
+
+        when(loanPlanCalculator.calculateSavingFixed(
+                anyLong(), anyLong(), any(AssetNetWorthBreakdown.class), anyLong(), any()))
+                .thenReturn(LoanPlans.builder()
+                        .loanX(GoalRecommendationResponse.LoanXPlan.builder()
+                                .targetAmount(72_000_000L).targetDate(NOW.plusMonths(20)).monthlySaving(1_000_000L)
+                                .build())
+                        .build());
+
+        List<RecommendationItem> result = algorithm.recommend(
+                MEMBER_ID, defaultRequest(), ctx,
+                jeonseBaseline(HousingType.APT, 20, 25, 50_000_000L));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getLoanX().getMonthlySaving()).isEqualTo(1_000_000L);
+    }
+
     // ─── 도달 개월 상한 없음 ─────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

closes #139

## 📝작업 내용

> 이번 PR에서 작업한 내용을 상세하게 설명해주세요(이미지 첨부 가능)

`HoldOutAlgorithm`의 후보 탐색 방식을 "변수 하나만 업그레이드"에서 "주거유형 × 거래유형 × 평수 버킷 40개 조합 전체 비교"로 바꿨습니다.

- 주거유형(4) × 거래유형(2) × 평수 버킷(5) = 40개 조합을 모두 실거래 median으로 평가합니다.
- baseline(Realistic이 고른 조건)보다 비싼 조합 중 **가장 싼 것**을 다음 등급으로 선택합니다. "다음 등급이 무엇인지"를 변수 하나가 아니라 실거래 가격이 정하게 됩니다.
- 추가 대기 개월 상한(36개월) 컷과 스코어링(조건개선·대기기간 가중합) 로직을 제거했습니다. 계산된 도달 개월이 얼마든 그대로 보여줍니다.
- baseline이 이미 40개 조합 중 최고가면(더 비싼 후보가 없으면) soft-fail(condition=null)을 반환합니다. baseline을 복제해서 보여주지 않습니다.
- 2-Phase 실행 구조(Realistic 완료 후 결과를 HoldOut에 전달)와 LoanSchedule 기반 예산 계산은 그대로 유지했습니다.

### 다음 등급이 월세일 때 monthlySaving에 월세를 더해 보여줌 (실사용 중 발견한 버그 수정)

`calculateSavingFixed`가 계산하는 `monthlySaving`은 **보증금을 모으는 동안**의 저축액입니다. 다음 등급이 월세 매물이면 보증금을 다 모아 입주한 뒤부터 매달 월세가 추가로 나가는데, 이 부담이 카드 어디에도 드러나지 않는 문제가 있었습니다.

- 후보 정렬(어떤 게 baseline보다 "비싼 다음 등급"인지 판단)에는 그대로 전세환산 보증금(`comparableAmount` = 보증금 + 월세×12÷5%)을 씁니다. 저축 기간 동안은 아직 입주 전이라 월세를 안 내는 게 맞으므로, 도달 시점(targetDate) 계산 로직 자체는 건드리지 않았습니다.
- 다음 등급이 월세일 때만 `loanX.monthlySaving`·`loanO.monthlySaving`에 실거래 median 월세를 더해서 반환합니다. 전세면 그대로 둡니다.
- `LoanXPlan`에 `toBuilder=true`를 추가해 계산된 플랜 위에 월세만 얹을 수 있게 했습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 도달 개월 상한을 없앤 것이 맞는 방향인지 검토 부탁드립니다. 다음 등급이 baseline 바로 위 칸이라 가격 점프 자체는 최소이지만, 사용자 저축 여력에 따라 도달 개월이 매우 길게 나올 수 있습니다.
- baseline이 최상위 조합일 때 soft-fail로 처리하는 것과, baseline을 그대로 복제해 보여주는 것 중 어느 쪽이 더 나은 UX인지 의견 부탁드립니다.
- 월세 반영은 이번엔 HoldOut에만 적용했습니다. `calculateSavingFixed`/`calculate`는 Realistic·Preference도 함께 쓰는 공용 계산기라, 그 두 알고리즘이 월세 매물을 고르는 경우에도 같은 문제(monthlySaving에 월세 미반영)가 있을 수 있습니다. 범위를 넓혀 공용 계산기 단에서 처리할지는 별도 논의가 필요해 보입니다.
