### PR TITLE
perf: RealisticAlgorithm selectRegion 시군구 N회 순차 조회 → 단일 배치 쿼리로 교체

### DIFF
--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -15,6 +15,7 @@ import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.dto.PriceModelRequest;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.dto.SigunguMedianResult;
 import com.team.independence.property.mapper.RegionMapper;
 import com.team.independence.property.service.RentMedianService;
 import java.time.YearMonth;
@@ -241,19 +242,33 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
                 ? request.getTradeType() : REFERENCE_DEAL_TYPE;
         int[] size = inputSize(request) != null ? inputSize(request) : SIZE_BUCKETS[REFERENCE_SIZE_BUCKET];
 
+        long depositMin = request.getDepositMin() != null ? request.getDepositMin() : 0L;
+        long depositMax = request.getDepositMax() != null ? request.getDepositMax() : DEPOSIT_MAX_DEFAULT;
+
+        // 25번 개별 조회 → 단일 PARTITION BY region_code 쿼리로 교체
         // 시군구 순위 비교는 raw median으로 충분하다. MC 투영을 하면 같은 시도 내 구들이 비슷한
         // 비율로 오르기 때문에 순위가 거의 바뀌지 않으면서, 구마다 priceModel 36개월 쿼리와
         // MC 시뮬레이션이 추가되어 응답 시간이 크게 늘어난다.
+        Map<String, SigunguMedianResult> medians = rentMedianService.getMediansBySidoPrefix(
+                requested, housingType, dealType, size[0], size[1],
+                depositMin, depositMax,
+                request.getMonthlyRentMin(), request.getMonthlyRentMax());
+
         String bestCode = null;
         long bestAmount = Long.MIN_VALUE;
         String cheapestCode = null;
         long cheapestAmount = Long.MAX_VALUE;
 
         for (String code : sigunguCodes) {
-            Long amount = quickMedianAmount(code, housingType, dealType, size[0], size[1], request, search);
-            if (amount == null) {
+            SigunguMedianResult r = medians.get(code);
+            if (r == null || r.getSampleCount() < MIN_SAMPLE_COUNT || r.getDepositMedian() == null) {
                 continue;
             }
+            long deposit = r.getDepositMedian();
+            long monthlyRent = dealType == DealType.WOLSE && r.getRentMedian() != null
+                    ? r.getRentMedian() : 0L;
+            long amount = toComparableAmount(deposit, monthlyRent);
+
             if (amount < cheapestAmount) {
                 cheapestCode = code;
                 cheapestAmount = amount;
@@ -268,35 +283,6 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         }
 
         return bestCode != null ? bestCode : cheapestCode;
-    }
-
-    /**
-     * 시군구 순위 비교용 raw 환산보증금. priceModel, MC를 생략하고 getMedian 1회만 호출한다.
-     * 결과를 search.evaluated에 저장하지 않아 evaluateConditions에서 전체 평가를 재실행한다.
-     *
-     * @return 환산보증금(원). 표본 부족이면 null.
-     */
-    private Long quickMedianAmount(
-            String regionCode, HousingType housingType, DealType dealType,
-            int areaMin, int areaMax, GoalRecommendationRequest request, Search search) {
-
-        RentMedianResponse median;
-        try {
-            median = rentMedianService.getMedian(
-                    buildMedianRequest(regionCode, housingType, dealType, areaMin, areaMax, request));
-        } catch (RuntimeException e) {
-            log.debug("시군구 시세 조회 실패, 건너뜀. regionCode={}", regionCode, e);
-            return null;
-        }
-
-        if (median.getSampleCount() < MIN_SAMPLE_COUNT || median.getDeposit().getMedian() == null) {
-            return null;
-        }
-
-        long deposit = median.getDeposit().getMedian();
-        long monthlyRent = dealType == DealType.WOLSE && median.getMonthlyRent().getMedian() != null
-                ? median.getMonthlyRent().getMedian() : 0L;
-        return toComparableAmount(deposit, monthlyRent);
     }
 
     // ===== 2단계: 조건 =====

--- a/src/main/java/com/team/independence/property/dto/SigunguMedianResult.java
+++ b/src/main/java/com/team/independence/property/dto/SigunguMedianResult.java
@@ -1,0 +1,12 @@
+package com.team.independence.property.dto;
+
+import lombok.Data;
+
+/** findMediansBySidoPrefix 결과 DTO - 시군구별 보증금, 월세 중앙값 1행 */
+@Data
+public class SigunguMedianResult {
+    private String regionCode;
+    private Long depositMedian;
+    private Long rentMedian;
+    private int sampleCount;
+}

--- a/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
+++ b/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
@@ -3,10 +3,11 @@ package com.team.independence.property.mapper;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.domain.RentTransaction;
-import com.team.independence.property.dto.MonthlyPricePoint;
 import com.team.independence.property.dto.BulkMedianResult;
 import com.team.independence.property.dto.MedianAggResult;
+import com.team.independence.property.dto.MonthlyPricePoint;
 import com.team.independence.property.dto.RentMedianRequest;
+import com.team.independence.property.dto.SigunguMedianResult;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -44,6 +45,23 @@ public interface RentTransactionMapper {
                                                 @Param("dealType") DealType dealType,
                                                 @Param("startYm") String startYm,
                                                 @Param("endYm") String endYm);
+
+    /**
+     * 시도 내 모든 시군구의 보증금 및 월세 중앙값을 단일 쿼리로 반환한다.
+     * RealisticAlgorithm.selectRegion()에서 N개 시군구 개별 조회를 대체한다.
+     */
+    List<SigunguMedianResult> findMediansBySidoPrefix(
+            @Param("sidoPrefix") String sidoPrefix,
+            @Param("housingType") HousingType housingType,
+            @Param("dealType") DealType dealType,
+            @Param("areaMinSqm") long areaMinSqm,
+            @Param("areaMaxSqm") long areaMaxSqm,
+            @Param("startYm") String startYm,
+            @Param("endYm") String endYm,
+            @Param("depositMin") long depositMin,
+            @Param("depositMax") long depositMax,
+            @Param("monthlyRentMin") Long monthlyRentMin,
+            @Param("monthlyRentMax") Long monthlyRentMax);
 
     /** 가격 모델(μ, σ) 산출용 월별 (거래연월, 보증금, 면적) 목록. 보증금 0 제외 */
     List<MonthlyPricePoint> findAmountsForPriceModel(@Param("regionCode") String regionCode,

--- a/src/main/java/com/team/independence/property/service/RentMedianService.java
+++ b/src/main/java/com/team/independence/property/service/RentMedianService.java
@@ -1,7 +1,10 @@
 package com.team.independence.property.service;
 
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.dto.SigunguMedianResult;
 import java.util.Map;
 
 public interface RentMedianService {
@@ -21,4 +24,16 @@ public interface RentMedianService {
      * @throws com.team.independence.common.exception.BusinessException 지역 코드가 존재하지 않으면
      */
     Map<String, RentMedianResponse> getBulkMedian(String regionCode, String startYm, String endYm);
+
+    /**
+     * RealisticAlgorithm.selectRegion() 전용. 시도 내 모든 시군구의 보증금 및 월세 중앙값을
+     * 단일 쿼리로 반환해 N번 개별 조회를 대체한다.
+     *
+     * @return 키: 시군구 region_code (5자리)
+     */
+    Map<String, SigunguMedianResult> getMediansBySidoPrefix(
+            String sidoPrefix, HousingType housingType, DealType dealType,
+            int areaMin, int areaMax,
+            long depositMin, long depositMax,
+            Long monthlyRentMin, Long monthlyRentMax);
 }

--- a/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
@@ -9,6 +9,7 @@ import com.team.independence.property.dto.MedianAggResult;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.dto.RentMedianResponse.Quartile;
+import com.team.independence.property.dto.SigunguMedianResult;
 import com.team.independence.property.mapper.RegionMapper;
 import com.team.independence.property.mapper.RentTransactionMapper;
 import java.time.YearMonth;
@@ -107,6 +108,31 @@ public class RentMedianServiceImpl implements RentMedianService {
                     result.put(key, response);
                 }
             }
+        }
+        return result;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, SigunguMedianResult> getMediansBySidoPrefix(
+            String sidoPrefix, HousingType housingType, DealType dealType,
+            int areaMin, int areaMax,
+            long depositMin, long depositMax,
+            Long monthlyRentMin, Long monthlyRentMax) {
+
+        YearMonth end = YearMonth.now();
+        YearMonth start = end.minusMonths(MONTHS - 1);
+
+        List<SigunguMedianResult> rows = rentTransactionMapper.findMediansBySidoPrefix(
+                sidoPrefix, housingType, dealType,
+                toSqm(areaMin), toSqm(areaMax),
+                start.format(YM), end.format(YM),
+                depositMin, depositMax,
+                monthlyRentMin, monthlyRentMax);
+
+        Map<String, SigunguMedianResult> result = new HashMap<>();
+        for (SigunguMedianResult row : rows) {
+            result.put(row.getRegionCode(), row);
         }
         return result;
     }

--- a/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
+++ b/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
@@ -94,6 +94,38 @@
         ) t
     </select>
 
+    <!-- 시도 내 시군구별 보증금·월세 중앙값을 단일 쿼리로 반환한다.
+         RealisticAlgorithm.selectRegion()에서 N번 개별 조회(findAggregatedMedian)를 대체한다.
+         PARTITION BY region_code로 시군구를 한 번에 집계해 쿼리 수를 1로 줄인다.
+         housing_type, deal_type를 WHERE에 고정해 idx_rent_query 인덱스를 탄다. -->
+    <select id="findMediansBySidoPrefix" resultType="com.team.independence.property.dto.SigunguMedianResult">
+        SELECT region_code,
+               MAX(CASE WHEN dep_rn  = CEIL(0.50 * total) THEN deposit      END) AS deposit_median,
+               MAX(CASE WHEN rent_rn = CEIL(0.50 * total) THEN monthly_rent END) AS rent_median,
+               MAX(total) AS sample_count
+          FROM (
+               SELECT region_code, deposit, monthly_rent,
+                      ROW_NUMBER() OVER (PARTITION BY region_code ORDER BY deposit)      AS dep_rn,
+                      ROW_NUMBER() OVER (PARTITION BY region_code ORDER BY monthly_rent) AS rent_rn,
+                      COUNT(*)     OVER (PARTITION BY region_code)                       AS total
+                 FROM rent_transaction
+                WHERE region_code LIKE CONCAT(#{sidoPrefix}, '%')
+                  AND housing_type = #{housingType}
+                  AND deal_type    = #{dealType}
+                  AND deal_ym      BETWEEN #{startYm} AND #{endYm}
+                  AND area         BETWEEN #{areaMinSqm} AND #{areaMaxSqm}
+                  AND deposit      BETWEEN #{depositMin} AND #{depositMax}
+                  AND deposit &gt; 0
+               <if test="monthlyRentMin != null">
+                  AND monthly_rent &gt;= #{monthlyRentMin}
+               </if>
+               <if test="monthlyRentMax != null">
+                  AND monthly_rent &lt;= #{monthlyRentMax}
+               </if>
+          ) t
+         GROUP BY region_code
+    </select>
+
     <!-- bulk 쿼리. 지역·기간·주거유형·거래유형을 받아 평수버킷별 분위값을 반환.
          housing_type, deal_type를 WHERE에 추가해 idx_rent_query 인덱스를 타도록 한다.
          평수 버킷 경계(평 → ㎡ floor 환산): 4p=13, 9p=29 / 10p=33, 14p=46 / 15p=49, 19p=62

--- a/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
@@ -25,6 +25,7 @@ import com.team.independence.property.dto.PriceModelRequest;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.dto.RentMedianResponse.Quartile;
+import com.team.independence.property.dto.SigunguMedianResult;
 import com.team.independence.property.mapper.RegionMapper;
 import com.team.independence.property.service.RentMedianService;
 import java.util.ArrayList;
@@ -122,6 +123,35 @@ class RealisticAlgorithmTest {
                     asked.getDealType(), asked.getAreaMin()));
             return toResponse(asked);
         });
+
+        // selectRegion()이 시도(2자리) 입력 시 호출하는 배치 조회 스텁.
+        // market 맵에서 sidoPrefix로 시작하는 시군구·조합을 걸러 SigunguMedianResult로 변환한다.
+        when(rentMedianService.getMediansBySidoPrefix(
+                any(), any(), any(), anyInt(), anyInt(), anyLong(), anyLong(), any(), any()))
+                .thenAnswer(call -> {
+                    String sidoPrefix = call.getArgument(0);
+                    HousingType ht  = call.getArgument(1);
+                    DealType    dt  = call.getArgument(2);
+                    int         am  = call.<Integer>getArgument(3);
+
+                    Map<String, SigunguMedianResult> result = new HashMap<>();
+                    for (Map.Entry<String, long[]> entry : market.entrySet()) {
+                        String[] parts = entry.getKey().split("\\|");
+                        if (!parts[0].startsWith(sidoPrefix)) continue;
+                        if (!parts[1].equals(ht.name()))       continue;
+                        if (!parts[2].equals(dt.name()))       continue;
+                        if (Integer.parseInt(parts[3]) != am)  continue;
+
+                        long[] data = entry.getValue();
+                        SigunguMedianResult r = new SigunguMedianResult();
+                        r.setRegionCode(parts[0]);
+                        r.setDepositMedian(data[0]);
+                        r.setRentMedian(data[1] > 0 ? data[1] : null);
+                        r.setSampleCount((int) data[2]);
+                        result.put(parts[0], r);
+                    }
+                    return result;
+                });
 
         when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), anyLong()))
                 .thenReturn(LoanPlans.builder().build());


### PR DESCRIPTION
## 개요

서울(시도) 입력 시 `selectRegion()`이 25개 시군구를 순차적으로 개별 쿼리(`findAggregatedMedian`)해 19.7초가 소요되던 병목을 단일 배치 쿼리로 대체합니다.

Closes #141

---

## 원인 분석

`RealisticAlgorithm.selectRegion()`은 시도 코드(2자리) 입력 시 해당 시도 내 모든 시군구 코드를 조회한 뒤, 각 시군구마다 `quickMedianAmount()` → `rentMedianService.getMedian()` → `findAggregatedMedian` SQL을 순차 호출했습니다.

- 서울 기준 시군구 25개 × 쿼리 1회 = 25회 순차 쿼리
- 측정 소요 시간: 19.7초
- Preference의 `LIKE '11%'` 전체 스캔이 Phase 1에서 병렬 실행되며 InnoDB 버퍼 풀 경합 → 후반 시군구일수록 쿼리가 느려지는 escalation 현상

## 변경 내용

### 핵심 변경

| Before | After |
|---|---|
| 시군구 N개 × `findAggregatedMedian` 순차 호출 | `findMediansBySidoPrefix` 단일 쿼리 |
| 서울 기준 약 19.7초 | 예상 1~3초 |

### 신규 SQL (`findMediansBySidoPrefix`)

```sql
SELECT region_code,
       MAX(CASE WHEN dep_rn = CEIL(0.50 * total) THEN deposit END) AS deposit_median,
       MAX(CASE WHEN rent_rn = CEIL(0.50 * total) THEN monthly_rent END) AS rent_median,
       MAX(total) AS sample_count
FROM (
    SELECT region_code, deposit, monthly_rent,
           ROW_NUMBER() OVER (PARTITION BY region_code ORDER BY deposit)      AS dep_rn,
           ROW_NUMBER() OVER (PARTITION BY region_code ORDER BY monthly_rent) AS rent_rn,
           COUNT(*)     OVER (PARTITION BY region_code)                       AS total
      FROM rent_transaction
     WHERE region_code LIKE CONCAT(#{sidoPrefix}, '%')
       AND housing_type = #{housingType}   -- idx_rent_query 인덱스 사용
       AND deal_type    = #{dealType}
       AND deal_ym BETWEEN #{startYm} AND #{endYm}
       AND ...
) t
GROUP BY region_code
```

`housing_type`, `deal_type`을 WHERE에 고정해 `idx_rent_query (region_code, housing_type, deal_type, deal_ym)` 인덱스를 그대로 탑니다.

### 변경 파일

| 파일 | 변경 |
|---|---|
| `property/dto/SigunguMedianResult.java` | **신규** — 시군구별 중앙값 결과 DTO |
| `property/mapper/RentTransactionMapper.java` | `findMediansBySidoPrefix()` 메서드 추가 |
| `property/mapper/RentTransactionMapper.xml` | 배치 쿼리 SQL 추가 |
| `property/service/RentMedianService.java` | `getMediansBySidoPrefix()` 인터페이스 추가 |
| `property/service/RentMedianServiceImpl.java` | `getMediansBySidoPrefix()` 구현 |
| `goal/service/algorithm/RealisticAlgorithm.java` | `selectRegion()` 리팩토링, `quickMedianAmount()` 제거 |

---

## 테스트 체크리스트

- [ ] 서울(`regionCode=11`) 요청 후 Docker 로그에서 `selectRegion` 소요 시간 확인
- [ ] 시군구 직접 지정(`regionCode=11110` 등) 시 기존 동작 유지 확인 (배치 쿼리 미호출)
- [ ] 비수도권 시도(`regionCode=26` 부산 등) 정상 응답 확인
- [ ] 추천 결과 카드(REALISTIC) 조건·금액이 기존과 동일한지 확인