### PR TITLE
fix: Realistic·Preference 월세 monthlySaving 미반영 + Realistic 대출 상환 계산 방식

### DIFF
--- a/src/main/java/com/team/independence/goal/service/RecommendationAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/RecommendationAlgorithm.java
@@ -124,4 +124,23 @@ public interface RecommendationAlgorithm {
         req.setAreaMax(areaMax);
         return req;
     }
+
+    /**
+     * {@code LoanPlanCalculator}가 계산하는 monthlySaving은 <b>보증금을 모으는 동안</b>의 저축액이라
+     * 월세는 반영돼 있지 않다. 보증금을 다 모아 입주한 뒤부터는 매달 월세가 추가로 나가므로, 카드에
+     * 표시되는 월 부담에는 월세를 더해 보여준다. 전세(월세 0)거나 plan이 null이면 그대로 반환한다.
+     *
+     * <p>세 알고리즘이 똑같은 방식으로 이 값을 조립해야 카드끼리 비교가 가능하므로 공유 헬퍼로 둔다.
+     */
+    static GoalRecommendationResponse.LoanXPlan withMonthlyRentAdded(
+            GoalRecommendationResponse.LoanXPlan plan, long monthlyRent) {
+        if (plan == null || monthlyRent <= 0) return plan;
+        return plan.toBuilder().monthlySaving(plan.getMonthlySaving() + monthlyRent).build();
+    }
+
+    static GoalRecommendationResponse.LoanOPlan withMonthlyRentAdded(
+            GoalRecommendationResponse.LoanOPlan plan, long monthlyRent) {
+        if (plan == null || monthlyRent <= 0) return plan;
+        return plan.toBuilder().monthlySaving(plan.getMonthlySaving() + monthlyRent).build();
+    }
 }

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -141,26 +141,9 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
                         .sampleCount(nextRung.sampleCount())
                         .marketMedianAmount(nextRung.deposit())
                         .build())
-                .loanX(withMonthlyRentAdded(plans.getLoanX(), nextRung.monthlyRent()))
-                .loanO(withMonthlyRentAdded(plans.getLoanO(), nextRung.monthlyRent()))
+                .loanX(RecommendationAlgorithm.withMonthlyRentAdded(plans.getLoanX(), nextRung.monthlyRent()))
+                .loanO(RecommendationAlgorithm.withMonthlyRentAdded(plans.getLoanO(), nextRung.monthlyRent()))
                 .build());
-    }
-
-    /**
-     * {@code calculateSavingFixed}가 계산하는 monthlySaving은 <b>보증금을 모으는 동안</b>의 저축액이라
-     * 월세는 반영돼 있지 않다. 보증금을 다 모아 입주한 뒤부터는 매달 월세가 추가로 나가므로, 카드에
-     * 표시되는 월 부담에는 월세를 더해 보여준다. 전세(월세 0)면 원래 값 그대로 반환한다.
-     */
-    private GoalRecommendationResponse.LoanXPlan withMonthlyRentAdded(
-            GoalRecommendationResponse.LoanXPlan plan, long monthlyRent) {
-        if (plan == null || monthlyRent <= 0) return plan;
-        return plan.toBuilder().monthlySaving(plan.getMonthlySaving() + monthlyRent).build();
-    }
-
-    private GoalRecommendationResponse.LoanOPlan withMonthlyRentAdded(
-            GoalRecommendationResponse.LoanOPlan plan, long monthlyRent) {
-        if (plan == null || monthlyRent <= 0) return plan;
-        return plan.toBuilder().monthlySaving(plan.getMonthlySaving() + monthlyRent).build();
     }
 
     // ─── 후보 평가 ────────────────────────────────────────────────────────────────

--- a/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
@@ -154,14 +154,15 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
                 .build();
 
         // ① 저축 고정 — 사용자의 월 저축액을 그대로 두고 도달 시점을 계산
+        // monthlySaving은 보증금을 모으는 동안의 저축액이라 월세가 빠져 있다. 월세 조건이면 더해서 보여준다.
         LoanPlans savingFixedPlans = loanPlanCalculator.calculateSavingFixed(
                 memberId, projectedDeposit, netWorth, rawMonthlySaving, ctx.loanSchedules());
         GoalRecommendationResponse.RecommendationItem savingFixedCard =
                 GoalRecommendationResponse.RecommendationItem.builder()
                         .type(AlgorithmType.PREFERENCE_SAVING_FIXED)
                         .condition(condition)
-                        .loanX(savingFixedPlans.getLoanX())
-                        .loanO(savingFixedPlans.getLoanO())
+                        .loanX(RecommendationAlgorithm.withMonthlyRentAdded(savingFixedPlans.getLoanX(), monthlyRent))
+                        .loanO(RecommendationAlgorithm.withMonthlyRentAdded(savingFixedPlans.getLoanO(), monthlyRent))
                         .build();
 
         // ② 시점 고정 — 목표 시점을 고정하고 필요한 월 저축액을 역산.
@@ -169,7 +170,10 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
         GoalRecommendationResponse.RecommendationItem dateFixedCard;
         if (request.getTargetDate() != null) {
             LoanPlans dateFixedPlans = loanPlanCalculator.calculate(memberId, projectedDeposit, targetDate, ctx.currentEffectiveSaving());
-            GoalRecommendationResponse.LoanOPlan dateFixedLoanO = dateFixedPlans.getLoanO();
+            GoalRecommendationResponse.LoanXPlan dateFixedLoanX =
+                    RecommendationAlgorithm.withMonthlyRentAdded(dateFixedPlans.getLoanX(), monthlyRent);
+            GoalRecommendationResponse.LoanOPlan dateFixedLoanO =
+                    RecommendationAlgorithm.withMonthlyRentAdded(dateFixedPlans.getLoanO(), monthlyRent);
             if (dateFixedLoanO != null) {
                 // 시점을 고정한 카드라 대출은 개월을 줄이는 게 아니라 필요 저축액을 낮춘다 → 단축 개월은 0
                 dateFixedLoanO = dateFixedLoanO.toBuilder().shortenedMonths(0L).build();
@@ -177,7 +181,7 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
             dateFixedCard = GoalRecommendationResponse.RecommendationItem.builder()
                     .type(AlgorithmType.PREFERENCE_DATE_FIXED)
                     .condition(condition)
-                    .loanX(dateFixedPlans.getLoanX())
+                    .loanX(dateFixedLoanX)
                     .loanO(dateFixedLoanO)
                     .build();
         } else {

--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -10,6 +10,7 @@ import com.team.independence.goal.service.MonteCarloService;
 import com.team.independence.goal.service.RecommendationAlgorithm;
 import com.team.independence.goal.service.calculator.BudgetCalculator;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
+import com.team.independence.goal.service.calculator.LoanSchedule;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.dto.PriceModelRequest;
@@ -152,9 +153,9 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         long desiredMonths = RecommendationAlgorithm.monthsUntil(targetDate);
 
         AssetNetWorthBreakdown netWorth = ctx.netWorth();
-        long effectiveSaving  = ctx.currentEffectiveSaving();
 
-        Search search = new Search(memberId, netWorth, effectiveSaving, desiredMonths);
+        Search search = new Search(memberId, netWorth, ctx.rawMonthlySaving(), ctx.loanSchedules(),
+                ctx.currentEffectiveSaving(), desiredMonths);
 
         // 1단계: 시군구 확정
         String regionCode = selectRegion(request, search);
@@ -273,7 +274,8 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
                 cheapestCode = code;
                 cheapestAmount = amount;
             }
-            Long reachMonths = budgetCalculator.monthsToReach(search.netWorth, search.effectiveSaving, amount);
+            Long reachMonths = budgetCalculator.monthsToReach(
+                    search.netWorth, search.rawMonthlySaving, search.loanSchedules, amount);
             boolean withinTarget = reachMonths != null
                     && (double) reachMonths / search.desiredMonths <= MAX_REACH_RATIO;
             if (withinTarget && amount > bestAmount) {
@@ -429,7 +431,8 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         long projectedDeposit = deposit;
         try {
             PriceModelRequest priceReq = RecommendationAlgorithm.buildPriceModelRequest(regionCode, housingType, dealType, areaMin, areaMax);
-            long budgetAtT = budgetCalculator.calculate(search.netWorth, search.effectiveSaving, search.desiredMonths);
+            long budgetAtT = budgetCalculator.calculate(
+                    search.netWorth, search.rawMonthlySaving, search.loanSchedules, search.desiredMonths);
             MonteCarloEngine.Result mc = monteCarloService.simulate(
                     priceReq, deposit, budgetAtT, (int) search.desiredMonths);
             projectedDeposit = mc.priceP50();
@@ -440,7 +443,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
 
         long comparableAmount = toComparableAmount(projectedDeposit, monthlyRent);
         Long reachMonths = budgetCalculator.monthsToReach(
-                search.netWorth, search.effectiveSaving, comparableAmount);
+                search.netWorth, search.rawMonthlySaving, search.loanSchedules, comparableAmount);
 
         return Optional.of(new Candidate(
                 regionCode, median.getRegionName(), housingType, dealType,
@@ -486,10 +489,16 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
             long depositMin, long depositMax) {
 
         // 화면에 나가는 목표 금액은 환산값이 아니라 실제로 모아야 하는 보증금이다.
-        LoanPlans plans = loanPlanCalculator.calculate(memberId, chosen.deposit(), targetDate, search.effectiveSaving);
+        // loanO 달성 가능 여부 판정은 "지금 시점" 스냅샷이면 충분하므로 currentEffectiveSaving을 쓴다.
+        LoanPlans plans = loanPlanCalculator.calculate(
+                memberId, chosen.deposit(), targetDate, search.currentEffectiveSaving);
 
         // 날짜 고정 카드라 대출은 시점을 앞당기는 게 아니라 필요 저축액을 낮춘다 → 단축 개월은 0
-        GoalRecommendationResponse.LoanOPlan loanO = plans.getLoanO();
+        // monthlySaving은 보증금을 모으는 동안의 저축액이라 월세가 빠져 있다. 월세 후보면 더해서 보여준다.
+        GoalRecommendationResponse.LoanXPlan loanX =
+                RecommendationAlgorithm.withMonthlyRentAdded(plans.getLoanX(), chosen.monthlyRent());
+        GoalRecommendationResponse.LoanOPlan loanO =
+                RecommendationAlgorithm.withMonthlyRentAdded(plans.getLoanO(), chosen.monthlyRent());
         if (loanO != null) {
             loanO = loanO.toBuilder().shortenedMonths(0L).build();
         }
@@ -511,7 +520,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         return GoalRecommendationResponse.RecommendationItem.builder()
                 .type(AlgorithmType.REALISTIC)
                 .condition(condition)
-                .loanX(plans.getLoanX())
+                .loanX(loanX)
                 .loanO(loanO)
                 .build();
     }
@@ -533,16 +542,23 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
     private static class Search {
         private final long memberId;
         private final AssetNetWorthBreakdown netWorth;
-        /** 기존 대출 월상환액 차감 후 순저축액 */
-        private final long effectiveSaving;
+        /** 사용자 입력 월 저축액(원). 예산 계산에는 이 값과 loanSchedules를 함께 넘긴다. */
+        private final long rawMonthlySaving;
+        /** 기존 대출 스케줄 — 구간별로 대출이 끝나는 시점을 반영해 예산을 계산할 때 쓴다. */
+        private final List<LoanSchedule> loanSchedules;
+        /** "지금 시점" 스냅샷 순저축액. loanO 달성 가능 여부(capacity) 판정 등 현재 스냅샷이 필요한 곳에서만 쓴다. */
+        private final long currentEffectiveSaving;
         private final long desiredMonths;
         /** 조합 키 → 평가 결과. 표본이 없어 후보가 되지 못한 조합도 담아 재조회를 막는다. */
         private final Map<String, Optional<Candidate>> evaluated = new HashMap<>();
 
-        private Search(long memberId, AssetNetWorthBreakdown netWorth, long effectiveSaving, long desiredMonths) {
+        private Search(long memberId, AssetNetWorthBreakdown netWorth, long rawMonthlySaving,
+                       List<LoanSchedule> loanSchedules, long currentEffectiveSaving, long desiredMonths) {
             this.memberId = memberId;
             this.netWorth = netWorth;
-            this.effectiveSaving = effectiveSaving;
+            this.rawMonthlySaving = rawMonthlySaving;
+            this.loanSchedules = loanSchedules;
+            this.currentEffectiveSaving = currentEffectiveSaving;
             this.desiredMonths = desiredMonths;
         }
     }

--- a/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
@@ -13,6 +13,7 @@ import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
 import com.team.independence.goal.dto.AlgorithmType;
 import com.team.independence.goal.service.RecommendationAlgorithm.MemberFinancialContext;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
+import com.team.independence.goal.dto.GoalRecommendationResponse;
 import com.team.independence.goal.dto.GoalRecommendationResponse.RecommendationItem;
 import com.team.independence.goal.dto.LoanPlans;
 import com.team.independence.goal.service.MonteCarloService;
@@ -168,6 +169,47 @@ class PreferenceAlgorithmTest {
         assertThat(item.getCondition().getMonthlyRent()).isEqualTo(40 * 만);
         // 환산값이 아니라 실제 보증금(1,000만)을 플랜 계산기로 넘긴다. targetDate가 없어 저축 고정 경로만 탄다.
         verify(loanPlanCalculator).calculateSavingFixed(eq(MEMBER_ID), eq(1000 * 만), any(), anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("월세면 저축 고정·시점 고정 두 카드 모두 monthlySaving에 월세를 더한다")
+    void addsMonthlyRentToBothCardsWhenWolse() {
+        stubMedian(1000 * 만, 40 * 만, 60);
+        when(loanPlanCalculator.calculateSavingFixed(anyLong(), anyLong(), any(), anyLong(), any()))
+                .thenReturn(LoanPlans.builder()
+                        .loanX(GoalRecommendationResponse.LoanXPlan.builder()
+                                .targetAmount(1000 * 만).monthlySaving(1_000_000L).build())
+                        .build());
+        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), anyLong()))
+                .thenReturn(LoanPlans.builder()
+                        .loanX(GoalRecommendationResponse.LoanXPlan.builder()
+                                .targetAmount(1000 * 만).monthlySaving(500_000L).build())
+                        .build());
+
+        GoalRecommendationRequest request = request("11110");
+        request.setTradeType(DealType.WOLSE);
+        request.setTargetDate(java.time.YearMonth.now().plusMonths(24));
+
+        List<RecommendationItem> result = algorithm.recommend(MEMBER_ID, request, ctx);
+
+        // 저축 고정: 목(100만) + 월세(40만) = 140만
+        assertThat(result.get(0).getLoanX().getMonthlySaving()).isEqualTo(1_400_000L);
+        // 시점 고정: 목(50만) + 월세(40만) = 90만
+        assertThat(result.get(1).getLoanX().getMonthlySaving()).isEqualTo(900_000L);
+    }
+
+    @Test
+    @DisplayName("전세면 monthlySaving을 그대로 둔다")
+    void keepsMonthlySavingUnchangedWhenJeonse() {
+        when(loanPlanCalculator.calculateSavingFixed(anyLong(), anyLong(), any(), anyLong(), any()))
+                .thenReturn(LoanPlans.builder()
+                        .loanX(GoalRecommendationResponse.LoanXPlan.builder()
+                                .targetAmount(2 * 억).monthlySaving(1_000_000L).build())
+                        .build());
+
+        RecommendationItem item = recommend(request("11110"));
+
+        assertThat(item.getLoanX().getMonthlySaving()).isEqualTo(1_000_000L);
     }
 
     @Test

--- a/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
@@ -13,12 +13,14 @@ import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
 import com.team.independence.goal.dto.AlgorithmType;
 import com.team.independence.goal.service.RecommendationAlgorithm.MemberFinancialContext;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
+import com.team.independence.goal.dto.GoalRecommendationResponse;
 import com.team.independence.goal.dto.GoalRecommendationResponse.RecommendationItem;
 import com.team.independence.goal.dto.LoanPlans;
 import com.team.independence.goal.service.MonteCarloEngine;
 import com.team.independence.goal.service.MonteCarloService;
 import com.team.independence.goal.service.calculator.BudgetCalculator;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
+import com.team.independence.goal.service.calculator.LoanSchedule;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.dto.PriceModelRequest;
@@ -103,17 +105,18 @@ class RealisticAlgorithmTest {
                 });
 
         // BudgetCalculator.monthsToReach: 목표액 ÷ 월저축액 (복리 계산 대신 단순 나눗셈)
-        when(budgetCalculator.monthsToReach(any(), anyLong(), anyLong())).thenAnswer(call -> {
+        // loanSchedules 인자는 이 테스트들에서 항상 빈 리스트라 무시하고 rawMonthlySaving만 쓴다.
+        when(budgetCalculator.monthsToReach(any(), anyLong(), any(), anyLong())).thenAnswer(call -> {
             long monthlySaving = call.getArgument(1);
-            long targetAmount = call.getArgument(2);
+            long targetAmount = call.getArgument(3);
             if (monthlySaving <= 0) return null;
             return (long) Math.ceil((double) targetAmount / monthlySaving);
         });
 
         // BudgetCalculator.calculate: MC에 넘기는 budgetAtT 용도라 값 자체는 중요하지 않음
-        when(budgetCalculator.calculate(any(), anyLong(), anyLong())).thenAnswer(call -> {
+        when(budgetCalculator.calculate(any(), anyLong(), any(), anyLong())).thenAnswer(call -> {
             long monthlySaving = call.getArgument(1);
-            long months = call.getArgument(2);
+            long months = call.getArgument(3);
             return monthlySaving * months;
         });
 
@@ -223,6 +226,32 @@ class RealisticAlgorithmTest {
     }
 
     @Test
+    @DisplayName("월세 후보를 고르면 loanX·loanO monthlySaving에 월세를 더해 보여준다")
+    void addsMonthlyRentToLoanXAndLoanOWhenWolseChosen() {
+        put("11110", HousingType.APT, DealType.WOLSE, 15, 1000 * 만, 40 * 만);
+
+        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), anyLong()))
+                .thenReturn(LoanPlans.builder()
+                        .loanX(GoalRecommendationResponse.LoanXPlan.builder()
+                                .targetAmount(1000 * 만).monthlySaving(1_000_000L).build())
+                        .loanO(GoalRecommendationResponse.LoanOPlan.builder()
+                                .loanAmount(500 * 만).targetAmount(500 * 만).monthlySaving(1_000_000L).build())
+                        .build());
+
+        GoalRecommendationRequest request = request("11110", HousingType.APT, null);
+        request.setSizeMin(15);
+        request.setSizeMax(19);
+
+        RecommendationItem item = recommend(request);
+
+        // 목(100만) + 월세(40만) = 140만
+        assertThat(item.getLoanX().getMonthlySaving()).isEqualTo(1_400_000L);
+        assertThat(item.getLoanO().getMonthlySaving()).isEqualTo(1_400_000L);
+        // 월세와 무관한 필드는 유지된다
+        assertThat(item.getLoanO().getShortenedMonths()).isEqualTo(0L);
+    }
+
+    @Test
     @DisplayName("환산했을 때 월세가 더 비싸면 전세를 고른다")
     void prefersJeonseWhenWolseIsPricierAfterConversion() {
         put("11110", HousingType.APT, DealType.JEONSE, 15, 2 * 억, 0);
@@ -237,6 +266,22 @@ class RealisticAlgorithmTest {
 
         assertThat(item.getCondition().getDealType()).isEqualTo(DealType.JEONSE);
         assertThat(item.getCondition().getMonthlyRent()).isZero();
+    }
+
+    @Test
+    @DisplayName("예산 계산에 loanSchedules를 그대로 넘긴다 — 대출이 끝나는 시점을 구간별로 반영하기 위함")
+    void passesLoanSchedulesThroughToBudgetCalculator() {
+        put("11110", HousingType.APT, DealType.JEONSE, 15, 2 * 억, 0);
+
+        List<LoanSchedule> schedules = List.of(new LoanSchedule(1_000_000L, 12L));
+        MemberFinancialContext ctxWithLoan = new MemberFinancialContext(defaultNetWorth, MONTHLY_SAVING, schedules);
+
+        algorithm.recommend(MEMBER_ID, request("11110", HousingType.APT, DealType.JEONSE), ctxWithLoan);
+
+        org.mockito.ArgumentCaptor<List<LoanSchedule>> captor = org.mockito.ArgumentCaptor.forClass(List.class);
+        verify(budgetCalculator, org.mockito.Mockito.atLeastOnce())
+                .monthsToReach(any(), anyLong(), captor.capture(), anyLong());
+        assertThat(captor.getValue()).isEqualTo(schedules);
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

- #145 

close #145

## 📝작업 내용

> 이번 PR에서 작업한 내용을 상세하게 설명해주세요(이미지 첨부 가능)

두 가지를 고쳤습니다.

### 1. Realistic·Preference 월세 monthlySaving 미반영

`HOLD_OUT` 카드(#140)에는 이미 적용한 "다음 등급이 월세면 `monthlySaving`에 월세를 더한다" 로직을 `REALISTIC`·`PREFERENCE`는 갖고 있지 않았습니다. `condition.monthlyRent`에는 월세가 담기지만 `loanX`·`loanO`의 `monthlySaving`(카드 표시값)에는 반영되지 않아, 월세 조건을 고르면 실제보다 월 부담이 적어 보였습니다.

- `withMonthlyRentAdded`를 `RecommendationAlgorithm` 인터페이스의 공유 static 헬퍼로 옮겨 세 알고리즘(`HoldOut`·`Realistic`·`Preference`)이 모두 재사용하도록 했습니다.
- 저축 기간 동안(입주 전)은 월세를 안 내는 게 맞으므로 도달 시점 계산 자체는 건드리지 않고, 화면에 보여지는 `monthlySaving`에만 월세를 더했습니다.

### 2. Realistic의 낡은 대출 상환 계산 방식

`RealisticAlgorithm`이 조건 탐색(`selectRegion`·`lookUp`) 중 `ctx.currentEffectiveSaving()`(지금 이 순간의 저축 여력 스냅샷)을 미래 전체 기간에 고정값으로 사용하고 있었습니다. 기존 대출이 미래 어느 시점에 끝나도 반영되지 않아, 저축 여력이 영원히 줄어든 채로 계산됐습니다.

- `Preference`·`HoldOut`처럼 `rawMonthlySaving` + `loanSchedules`를 `BudgetCalculator`의 구간별(대출 잔여 기간을 반영하는) 오버로드에 그대로 넘기도록 바꿨습니다.
- `LoanPlanCalculator.calculate()`(시점 고정 카드가 쓰는 필요저축액 역산)에 넘기는 `effectiveSaving`은 그대로 뒀습니다. 이 값은 "지금 이 순간 감당 가능한가"를 묻는 capacity 판정용이라 스냅샷이 맞는 도구이기 때문입니다.