### PR TITLE
feat: 활성 목표 조회 API 추가

### DIFF
--- a/src/main/java/com/team/independence/goal/controller/GoalController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalController.java
@@ -49,6 +49,11 @@ public class GoalController {
         return ApiResponse.ok(goalService.createGoal(memberId, request));
     }
 
+    @GetMapping("/active")
+    public ApiResponse<GoalResponse> getActiveGoal(@LoginMember Long memberId) {
+        return ApiResponse.ok(goalService.getActiveGoal(memberId));
+    }
+
     @GetMapping("/{goalId}")
     public ApiResponse<GoalResponse> getGoal(
             @LoginMember Long memberId,

--- a/src/main/java/com/team/independence/goal/service/GoalService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalService.java
@@ -74,6 +74,11 @@ public interface GoalService {
     GoalMarketTrendResponse refreshMarketTrend(Long goalId);
 
     /**
+     * 회원의 활성(ACTIVE) 목표를 조회한다. 활성 목표가 없으면 null을 반환한다(예외 아님).
+     */
+    GoalResponse getActiveGoal(Long memberId);
+
+    /**
      * 홈 화면 「목표 달성 요약」 카드 데이터. 목표 조건, 목표 금액/시점, 현재 진행 상황(현재 자금/잔여 금액/
      * 달성률/예상 잔여 개월)을 한 번에 조회한다. 회원의 활성 목표가 없으면 GOAL_NOT_FOUND.
      */

--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -497,6 +497,16 @@ public class GoalServiceImpl implements GoalService {
         return calculateEffectiveMonthToReach(memberId, netWorth, fixedSaving, targetAmount);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public GoalResponse getActiveGoal(Long memberId) {
+        Goal goal = goalMapper.findActiveByMemberId(memberId);
+        if (goal == null) {
+            return null;
+        }
+        return toGoalResponse(goal, goalHousingMapper.findByGoalId(goal.getId()));
+    }
+
     // 홈 화면 「목표 달성 요약」 카드 데이터 조회
     @Override
     @Transactional(readOnly = true)


### PR DESCRIPTION
## #️⃣연관된 이슈

- #150

## 📝작업 내용

`GET /goals/active` 엔드포인트를 추가하여, 로그인한 회원의 현재 활성(ACTIVE) 상태 목표를 단건 조회할 수 있도록 합니다.

활성 목표가 없는 경우 예외를 던지지 않고 `null`을 반환하여, 클라이언트가 목표 미설정 상태를 구분해 처리할 수 있게 합니다.

**변경 파일**
- `GoalController` — `GET /goals/active` 엔드포인트 추가
- `GoalService` — `getActiveGoal(Long memberId)` 메서드 인터페이스 정의
- `GoalServiceImpl` — `getActiveGoal` 구현 (활성 목표 없으면 `null` 반환)