### PR TITLE
feat: market-trend에 목표 시점 시세 전망 추가

### DIFF
--- a/src/main/java/com/team/independence/goal/dto/GoalMarketTrendResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalMarketTrendResponse.java
@@ -22,19 +22,27 @@ public class GoalMarketTrendResponse {
     private Integer areaMin;
     private Integer areaMax;
 
-    /** 실거래 집계 기준 최신 연월 */
+    /** currentMiddleAmount 산출 기준 최신 실거래 연월 */
     private YearMonth updatedYm;
 
-    /** currentMiddleAmount - initialMiddleAmount (부호 포함) */
-    private Long changeAmount;
+    /** updatedYm 기준 최신 실거래 데이터로 predictionTargetYm 시점을 다시 예측한 몬테카를로 P50 시세.
+     *  predictionTargetYm이 이미 지났거나(months&lt;=0) 가격 모델을 만들 실거래 표본이 부족하면 null. */
+    private Long latestPredictedMarketAmount;
+
+    /** initialMiddleAmount·latestPredictedMarketAmount가 공통으로 예측하는 목표 연월(= goal.target_date).
+     *  예측 결과가 아니라 예측 대상 시점이므로 latestPredictedMarketAmount가 null이어도 항상 채워진다. */
+    private YearMonth predictionTargetYm;
+
+    /** latestPredictedMarketAmount - initialMiddleAmount (부호 포함). latestPredictedMarketAmount가 null이면 null */
+    private Long predictionChangeAmount;
 
     /** 내 목표 금액 (설정 시점에 고정, 불변) */
     private Long targetAmount;
 
-    /** 목표 설정 당시 실거래 중앙값 */
+    /** 목표 진단 당시 계산한, predictionTargetYm(목표 시점)에 대한 몬테카를로 P50 예측 시세 (설정 시점에 고정) */
     private Long initialMiddleAmount;
 
-    /** 현재 실거래 중앙값 */
+    /** updatedYm 기준 현재 실거래 중앙값 */
     private Long currentMiddleAmount;
 
     /** 목표를 유지할 때의 도달 예상 시점. 재계산하지 않고 goal.target_date를 그대로 반환한다(홈 화면에 노출되는 목표 시점과 동일 값 유지). */

--- a/src/main/java/com/team/independence/goal/service/GoalMarketTrendCacheStore.java
+++ b/src/main/java/com/team/independence/goal/service/GoalMarketTrendCacheStore.java
@@ -12,17 +12,22 @@ import org.springframework.stereotype.Component;
 
 /**
  * 홈 화면 「매물 시세 변화」 카드 데이터를 Redis에 캐싱한다.
- * Key: goal:market-trend:{goalId}  Value: GoalMarketTrendResponse의 JSON  TTL: 35일
+ * Key: goal:market-trend:v2:{goalId}  Value: GoalMarketTrendResponse의 JSON  TTL: 35일
  *
  * <p>매월 1일 배치({@link GoalMarketTrendBatchService})가 값을 덮어써 갱신하는 게 기본 흐름이고,
  * TTL은 배치가 실패했을 때 데이터가 무한정 오래된 값으로 남지 않게 하는 안전장치다.
+ *
+ * <p>v2: changeAmount(currentMiddleAmount 기준) → predictionChangeAmount(latestPredictedMarketAmount 기준)로
+ * 필드 의미가 바뀌면서 key prefix를 올렸다. 배포 전 v1 키로 저장된 캐시는 다른 의미의 changeAmount를 담고 있어
+ * 그대로 두면 배포 후에도 옛 값이 신규 필드 없이 섞여 나갈 수 있으므로, TTL 만료를 기다리지 않고 prefix를
+ * 바꿔 즉시 전부 캐시 미스로 처리한다(수동 flush 필요 없음, v1 키는 기존 TTL대로 자연 소멸).
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class GoalMarketTrendCacheStore {
 
-    private static final String KEY_PREFIX = "goal:market-trend:";
+    private static final String KEY_PREFIX = "goal:market-trend:v2:";
     private static final Duration TTL = Duration.ofDays(35); // 35일 후 자동 삭제
 
     // Redis에 문자열 형식의 Key, Value를 저장/조회할 때 사용

--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -23,12 +23,16 @@ import com.team.independence.goal.service.calculator.LoanSchedule;
 import java.util.List;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.property.dto.PriceModelResponse;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.service.PriceModelService;
 import com.team.independence.property.service.RegionQueryService;
 import com.team.independence.property.service.RentMedianService;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -69,6 +73,7 @@ public class GoalServiceImpl implements GoalService {
     private final MonteCarloSimulationStore monteCarloSimulationStore;
     private final BudgetCalculator budgetCalculator;
     private final LoanPlanCalculator loanPlanCalculator;
+    private final PriceModelService priceModelService;
 
     @Override
     public GoalDiagnosisResponse diagnose(Long memberId, GoalDiagnosisRequest request) {
@@ -433,6 +438,7 @@ public class GoalServiceImpl implements GoalService {
         }
 
         long currentMiddleAmount = currentStats.getDeposit().getMedian(); // 현재 실거래 중앙값 추출
+        YearMonth updatedYm = YearMonth.parse(currentStats.getBaseEndYm(), YM_FORMATTER); // currentMiddleAmount의 기준 연월
         long initialMiddleAmount = goal.getTargetRentMiddleAmount(); // 목표 생성 당시 중앙값 조회
 
         // 회원의 현재 자산 조회
@@ -447,20 +453,76 @@ public class GoalServiceImpl implements GoalService {
                 ? null
                 : YearMonth.now().plusMonths(monthsToReachCurrentMiddle);
 
+        // 동일 목표 시점의 몬테카를로 P50 예측을 최신 실거래 데이터로 다시 계산
+        // predictionTargetYm은 예측 결과가 아니라 예측 대상 시점(goal.target_date)이므로 예측 실패 여부와 무관하게 유지한다.
+        YearMonth predictionTargetYm = YearMonth.from(goal.getTargetDate());
+        Long latestPredictedMarketAmount = predictLatestMarketAmount(
+                goalHousing, currentMiddleAmount, updatedYm, predictionTargetYm);
+        Long predictionChangeAmount = latestPredictedMarketAmount == null
+                ? null
+                : latestPredictedMarketAmount - initialMiddleAmount;
+
         return GoalMarketTrendResponse.builder()
                 .regionName(regionName)
                 .housingType(goalHousing.getHousingType())
                 .dealType(goalHousing.getDealType())
                 .areaMin(goalHousing.getAreaMin())
                 .areaMax(goalHousing.getAreaMax())
-                .updatedYm(YearMonth.parse(currentStats.getBaseEndYm(), YM_FORMATTER))
-                .changeAmount(currentMiddleAmount - initialMiddleAmount)
+                .updatedYm(updatedYm)
+                .predictionTargetYm(predictionTargetYm)
+                .latestPredictedMarketAmount(latestPredictedMarketAmount)
+                .predictionChangeAmount(predictionChangeAmount)
                 .targetAmount(goal.getTargetAmount())
                 .initialMiddleAmount(initialMiddleAmount)
                 .currentMiddleAmount(currentMiddleAmount)
                 .maintainEta(maintainEta)
                 .reflectEta(reflectEta)
                 .build();
+    }
+
+    private PriceModelRequest buildPriceModelRequest(GoalHousing housing) {
+        PriceModelRequest req = new PriceModelRequest();
+        req.setRegionCode(housing.getRegionCode());
+        req.setHousingType(housing.getHousingType());
+        req.setDealType(housing.getDealType());
+        req.setAreaMin(housing.getAreaMin());
+        req.setAreaMax(housing.getAreaMax());
+        return req;
+    }
+
+    /**
+     * 목표 시점까지 몬테카를로 시뮬레이션을 최신 실거래 데이터 기준으로 다시 돌려 P50 가격을 예측한다.
+     * P(0)은 currentMiddleAmount(updatedYm 기준 실거래 중앙값)를 쓰고, 시뮬레이션 기간도 "today"가 아니라
+     * updatedYm → predictionTargetYm 구간으로 잡는다: currentMiddleAmount 자체가 updatedYm 시점의 값이므로
+     * 기준 가격의 시점과 성장 구간의 시작 시점을 일치시켜야 한다(today로 잡으면 최대 한 달 어긋난다).
+     *
+     * budgetAtT는 MonteCarloEngine 내부에서 successProbability 계산에만 쓰이고 priceP50에는 영향을 주지
+     * 않으므로(MonteCarloEngine.simulate 참고), 여기서는 시장 가격만 순수하게 예측하기 위해 더미값(0)을 넘긴다.
+     * 사용자 자산·저축액과 무관해야 하는 "시장 자체의 예상 시세"이기 때문이다.
+     *
+     * 목표 시점이 이미 지났거나(months<=0), PriceModel 산출에 필요한 실거래 표본이 부족하면
+     * (PROPERTY_INSUFFICIENT_DATA) null을 반환해 시세 변화 카드의 나머지 필드는 정상적으로 내려가게 한다.
+     */
+    private Long predictLatestMarketAmount(GoalHousing goalHousing, long currentMiddleAmount,
+            YearMonth updatedYm, YearMonth predictionTargetYm) {
+        long months = updatedYm.until(predictionTargetYm, ChronoUnit.MONTHS);
+        if (months <= 0) {
+            return null;
+        }
+        try {
+            PriceModelRequest priceModelRequest = buildPriceModelRequest(goalHousing);
+            PriceModelResponse priceModel = priceModelService.estimate(priceModelRequest);
+            MonteCarloEngine.Result result = MonteCarloEngine.simulate(
+                    priceModel.getAnnualDrift(), priceModel.getAnnualVol(),
+                    currentMiddleAmount, 0L,
+                    (int) months, MonteCarloEngine.DEFAULT_SIMULATIONS, MonteCarloEngine.DEFAULT_SEED);
+            return result.priceP50();
+        } catch (BusinessException e) {
+            if (e.getErrorCode() == ErrorCode.PROPERTY_INSUFFICIENT_DATA) {
+                return null;
+            }
+            throw e; // 예상 못한 다른 오류는 그대로 전파
+        }
     }
 
     /**

--- a/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
@@ -21,11 +21,10 @@ import com.team.independence.goal.dto.GoalDetailResponse;
 import com.team.independence.goal.dto.GoalForecastResponse;
 import com.team.independence.goal.mapper.GoalHousingMapper;
 import com.team.independence.goal.mapper.GoalMapper;
+import com.team.independence.goal.mapper.SavingRecordMapper;
 import com.team.independence.goal.service.calculator.BudgetCalculator;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
 import com.team.independence.goal.service.calculator.LoanSchedule;
-import com.team.independence.goal.mapper.SavingRecordMapper;
-import java.util.List;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import java.time.LocalDate;
@@ -68,18 +67,39 @@ class GoalDetailServiceImplTest {
         savingRecordMapper = new FakeSavingRecordMapper();
         assetConnectionService = new FakeAssetConnectionService();
         assetSummaryService = new FakeAssetSummaryService();
+
         // 소유권 검증과 도달 개월수 계산은 진짜 GoalServiceImpl이 담당한다.
         // 계산을 가짜로 바꾸면 forecasts 검증이 의미를 잃기 때문이다.
         // 그 외 의존성은 이 경로에서 쓰이지 않아 null로 둔다.
         service = new GoalDetailServiceImpl(
-                goalHousingMapper, savingRecordMapper, assetConnectionService, assetSummaryService,
-                new GoalServiceImpl(null, null, null, null, goalMapper, null, null, null, new BudgetCalculator(),
+                goalHousingMapper,
+                savingRecordMapper,
+                assetConnectionService,
+                assetSummaryService,
+                new GoalServiceImpl(
+                        null,
+                        null,
+                        null,
+                        null,
+                        goalMapper,
+                        null,
+                        null,
+                        null,
+                        new BudgetCalculator(),
                         new LoanPlanCalculator(null, null, null, null) {
                             @Override
-                            public long calcTotalExistingMonthlyPayment(long memberId) { return 0L; }
+                            public long calcTotalExistingMonthlyPayment(long memberId) {
+                                return 0L;
+                            }
+
                             @Override
-                            public List<LoanSchedule> getLoanSchedules(long memberId) { return List.of(); }
-                        }));
+                            public List<LoanSchedule> getLoanSchedules(long memberId) {
+                                return List.of();
+                            }
+                        },
+                        null
+                )
+        );
     }
 
     // ------------------------------------------------------------------
@@ -138,7 +158,10 @@ class GoalDetailServiceImplTest {
         assetSummaryService.growingAssets = 30_000_000L;
         assetSummaryService.fixedAssets = 20_000_000L;
 
-        assertEquals(50_000_000L, call().getProgress().getCurrentAmount().longValue());
+        assertEquals(
+                50_000_000L,
+                call().getProgress().getCurrentAmount().longValue()
+        );
     }
 
     @Test
@@ -172,9 +195,13 @@ class GoalDetailServiceImplTest {
     void 순자산이_마이너스여도_0() {
         goalMapper.goal.setTargetAmount(100_000_000L);
         assetSummaryService.growingAssets = 0L;
-        assetSummaryService.fixedAssets = -5_000_000L; // 대출이 자산보다 많은 경우
+        assetSummaryService.fixedAssets = -5_000_000L;
 
-        assertEquals(0.0, call().getProgress().getAchievementRate(), 0.0001);
+        assertEquals(
+                0.0,
+                call().getProgress().getAchievementRate(),
+                0.0001
+        );
     }
 
     @Test
@@ -184,12 +211,15 @@ class GoalDetailServiceImplTest {
         assetSummaryService.growingAssets = 100_000_000L;
         assetSummaryService.fixedAssets = 0L;
 
-        // 33.3333...% -> 33.33
-        assertEquals(33.33, call().getProgress().getAchievementRate(), 0.0001);
+        assertEquals(
+                33.33,
+                call().getProgress().getAchievementRate(),
+                0.0001
+        );
     }
 
     // ------------------------------------------------------------------
-    // 저축 현황 (명세의 저축 기록 건수별 분기)
+    // 저축 현황
     // ------------------------------------------------------------------
 
     @Test
@@ -199,21 +229,33 @@ class GoalDetailServiceImplTest {
 
         GoalDetailResponse response = call();
 
-        assertEquals(FIXED_SAVING, response.getSavingStatus().getFixedSaving());
+        assertEquals(
+                FIXED_SAVING,
+                response.getSavingStatus().getFixedSaving()
+        );
         assertNull(response.getSavingStatus().getLatestSaving());
         assertNull(response.getSavingStatus().getRecentAverageSaving());
         assertEquals(1, response.getForecasts().size());
-        assertEquals(SavingBasis.FIXED, response.getForecasts().get(0).getBasis());
+        assertEquals(
+                SavingBasis.FIXED,
+                response.getForecasts().get(0).getBasis()
+        );
     }
 
     @Test
     @DisplayName("기록이 3건 미만이면 평균은 내지 않고 RECENT_AVERAGE도 빠진다")
     void 기록_2건() {
-        savingRecordMapper.records = Arrays.asList(record("202607", 2_000_000L), record("202606", 1_800_000L));
+        savingRecordMapper.records = Arrays.asList(
+                record("202607", 2_000_000L),
+                record("202606", 1_800_000L)
+        );
 
         GoalDetailResponse response = call();
 
-        assertEquals(2_000_000L, response.getSavingStatus().getLatestSaving().longValue());
+        assertEquals(
+                2_000_000L,
+                response.getSavingStatus().getLatestSaving().longValue()
+        );
         assertNull(response.getSavingStatus().getRecentAverageSaving());
         assertFalse(hasBasis(response, SavingBasis.RECENT_AVERAGE));
         assertTrue(hasBasis(response, SavingBasis.LATEST));
@@ -225,21 +267,34 @@ class GoalDetailServiceImplTest {
         savingRecordMapper.records = Arrays.asList(
                 record("202607", 2_000_000L),
                 record("202606", 1_800_000L),
-                record("202605", 1_450_000L));
+                record("202605", 1_450_000L)
+        );
 
         GoalDetailResponse response = call();
 
-        assertEquals(2_000_000L, response.getSavingStatus().getLatestSaving().longValue());
-        assertEquals(1_750_000L, response.getSavingStatus().getRecentAverageSaving().longValue());
+        assertEquals(
+                2_000_000L,
+                response.getSavingStatus().getLatestSaving().longValue()
+        );
+        assertEquals(
+                1_750_000L,
+                response.getSavingStatus().getRecentAverageSaving().longValue()
+        );
         assertEquals(3, response.getForecasts().size());
     }
 
     @Test
     @DisplayName("가장 최근 달은 조회 결과의 첫 번째 행이다")
     void 최근달은_첫번째_행() {
-        savingRecordMapper.records = Arrays.asList(record("202607", 3_000_000L), record("202606", 1_000_000L));
+        savingRecordMapper.records = Arrays.asList(
+                record("202607", 3_000_000L),
+                record("202606", 1_000_000L)
+        );
 
-        assertEquals(3_000_000L, call().getSavingStatus().getLatestSaving().longValue());
+        assertEquals(
+                3_000_000L,
+                call().getSavingStatus().getLatestSaving().longValue()
+        );
     }
 
     // ------------------------------------------------------------------
@@ -254,7 +309,10 @@ class GoalDetailServiceImplTest {
         List<GoalForecastResponse> forecasts = call().getForecasts();
 
         assertEquals(SavingBasis.FIXED, forecasts.get(0).getBasis());
-        assertEquals(SavingBasis.RECENT_AVERAGE, forecasts.get(1).getBasis());
+        assertEquals(
+                SavingBasis.RECENT_AVERAGE,
+                forecasts.get(1).getBasis()
+        );
         assertEquals(SavingBasis.LATEST, forecasts.get(2).getBasis());
     }
 
@@ -263,20 +321,32 @@ class GoalDetailServiceImplTest {
     void 고정기준의_차이는_0() {
         savingRecordMapper.records = threeRecords();
 
-        assertEquals(0, findBasis(call(), SavingBasis.FIXED).getMonthsDiff().intValue());
+        assertEquals(
+                0,
+                findBasis(call(), SavingBasis.FIXED)
+                        .getMonthsDiff()
+                        .intValue()
+        );
     }
 
     @Test
     @DisplayName("더 많이 저축하면 예상 시점이 앞당겨지고 monthsDiff가 양수가 된다")
     void 더_저축하면_앞당겨진다() {
-        savingRecordMapper.records = threeRecords(); // 평균 175만 > 고정 150만
+        savingRecordMapper.records = threeRecords();
 
         GoalDetailResponse response = call();
-        GoalForecastResponse fixed = findBasis(response, SavingBasis.FIXED);
-        GoalForecastResponse average = findBasis(response, SavingBasis.RECENT_AVERAGE);
+        GoalForecastResponse fixed =
+                findBasis(response, SavingBasis.FIXED);
+        GoalForecastResponse average =
+                findBasis(response, SavingBasis.RECENT_AVERAGE);
 
-        assertTrue(average.getMonthsDiff() > 0, "앞당겨졌으면 양수여야 한다: " + average.getMonthsDiff());
-        assertTrue(average.getExpectedDate().isBefore(fixed.getExpectedDate()));
+        assertTrue(
+                average.getMonthsDiff() > 0,
+                "앞당겨졌으면 양수여야 한다: " + average.getMonthsDiff()
+        );
+        assertTrue(
+                average.getExpectedDate().isBefore(fixed.getExpectedDate())
+        );
     }
 
     @Test
@@ -285,9 +355,13 @@ class GoalDetailServiceImplTest {
         savingRecordMapper.records = Arrays.asList(
                 record("202607", 500_000L),
                 record("202606", 500_000L),
-                record("202605", 500_000L));
+                record("202605", 500_000L)
+        );
 
-        assertTrue(findBasis(call(), SavingBasis.RECENT_AVERAGE).getMonthsDiff() < 0);
+        assertTrue(
+                findBasis(call(), SavingBasis.RECENT_AVERAGE)
+                        .getMonthsDiff() < 0
+        );
     }
 
     @Test
@@ -299,8 +373,14 @@ class GoalDetailServiceImplTest {
         savingRecordMapper.records = threeRecords();
 
         for (GoalForecastResponse forecast : call().getForecasts()) {
-            assertNull(forecast.getExpectedDate(), forecast.getBasis() + "은 시점이 없어야 한다");
-            assertEquals(0, forecast.getMonthsDiff().intValue());
+            assertNull(
+                    forecast.getExpectedDate(),
+                    forecast.getBasis() + "은 시점이 없어야 한다"
+            );
+            assertEquals(
+                    0,
+                    forecast.getMonthsDiff().intValue()
+            );
         }
     }
 
@@ -314,9 +394,13 @@ class GoalDetailServiceImplTest {
 
         assertFalse(hasBasis(response, SavingBasis.FIXED));
         assertEquals(2, response.getForecasts().size());
+
         for (GoalForecastResponse forecast : response.getForecasts()) {
             assertNotNull(forecast.getExpectedDate());
-            assertNull(forecast.getMonthsDiff(), forecast.getBasis() + "은 비교 기준이 없다");
+            assertNull(
+                    forecast.getMonthsDiff(),
+                    forecast.getBasis() + "은 비교 기준이 없다"
+            );
         }
     }
 
@@ -324,7 +408,10 @@ class GoalDetailServiceImplTest {
     @DisplayName("실제 저축액이 0인 달만 있으면 그 기준은 목록에서 빠진다")
     void 저축액_0인_기준은_제외() {
         savingRecordMapper.records = Arrays.asList(
-                record("202607", 0L), record("202606", 0L), record("202605", 0L));
+                record("202607", 0L),
+                record("202606", 0L),
+                record("202605", 0L)
+        );
 
         GoalDetailResponse response = call();
 
@@ -338,9 +425,13 @@ class GoalDetailServiceImplTest {
     void 예상시점은_이번달_기준() {
         savingRecordMapper.records = Collections.emptyList();
 
-        YearMonth expected = findBasis(call(), SavingBasis.FIXED).getExpectedDate();
+        YearMonth expected =
+                findBasis(call(), SavingBasis.FIXED).getExpectedDate();
 
-        assertTrue(expected.isAfter(YearMonth.now()), "미래여야 한다: " + expected);
+        assertTrue(
+                expected.isAfter(YearMonth.now()),
+                "미래여야 한다: " + expected
+        );
     }
 
     // ------------------------------------------------------------------
@@ -354,7 +445,11 @@ class GoalDetailServiceImplTest {
 
         call();
 
-        assertEquals(1, assetSummaryService.netWorthCalls, "forecasts 세 개를 만들어도 자산 조회는 1회");
+        assertEquals(
+                1,
+                assetSummaryService.netWorthCalls,
+                "forecasts 세 개를 만들어도 자산 조회는 1회"
+        );
         assertEquals(1, savingRecordMapper.calls);
     }
 
@@ -366,15 +461,26 @@ class GoalDetailServiceImplTest {
         return service.getGoalDetail(MEMBER_ID, GOAL_ID);
     }
 
-    private boolean hasBasis(GoalDetailResponse response, SavingBasis basis) {
-        return response.getForecasts().stream().anyMatch(f -> f.getBasis() == basis);
+    private boolean hasBasis(
+            GoalDetailResponse response,
+            SavingBasis basis
+    ) {
+        return response.getForecasts()
+                .stream()
+                .anyMatch(f -> f.getBasis() == basis);
     }
 
-    private GoalForecastResponse findBasis(GoalDetailResponse response, SavingBasis basis) {
-        return response.getForecasts().stream()
+    private GoalForecastResponse findBasis(
+            GoalDetailResponse response,
+            SavingBasis basis
+    ) {
+        return response.getForecasts()
+                .stream()
                 .filter(f -> f.getBasis() == basis)
                 .findFirst()
-                .orElseThrow(() -> new AssertionError(basis + " 기준이 없다"));
+                .orElseThrow(
+                        () -> new AssertionError(basis + " 기준이 없다")
+                );
     }
 
     /** 평균 175만원이 되는 3개월치 기록 */
@@ -382,10 +488,14 @@ class GoalDetailServiceImplTest {
         return Arrays.asList(
                 record("202607", 2_000_000L),
                 record("202606", 1_800_000L),
-                record("202605", 1_450_000L));
+                record("202605", 1_450_000L)
+        );
     }
 
-    private SavingRecord record(String recordYm, long actualSaving) {
+    private SavingRecord record(
+            String recordYm,
+            long actualSaving
+    ) {
         return SavingRecord.builder()
                 .goalId(GOAL_ID)
                 .recordYm(recordYm)
@@ -452,7 +562,8 @@ class GoalDetailServiceImplTest {
         }
     }
 
-    private static class FakeGoalHousingMapper implements GoalHousingMapper {
+    private static class FakeGoalHousingMapper
+            implements GoalHousingMapper {
 
         private GoalHousing housing = GoalHousing.builder()
                 .goalId(GOAL_ID)
@@ -483,34 +594,49 @@ class GoalDetailServiceImplTest {
         }
     }
 
-    private static class FakeSavingRecordMapper implements SavingRecordMapper {
+    private static class FakeSavingRecordMapper
+            implements SavingRecordMapper {
 
         private List<SavingRecord> records = new ArrayList<>();
         private int calls = 0;
 
         @Override
-        public List<SavingRecord> findRecentByGoalId(Long goalId, int limit) {
+        public List<SavingRecord> findRecentByGoalId(
+                Long goalId,
+                int limit
+        ) {
             calls++;
-            return records.size() > limit ? records.subList(0, limit) : records;
+
+            return records.size() > limit
+                    ? records.subList(0, limit)
+                    : records;
         }
     }
 
-    private static class FakeAssetConnectionService implements AssetConnectionService {
+    private static class FakeAssetConnectionService
+            implements AssetConnectionService {
 
         @Override
-        public com.team.independence.asset.dto.connection.AssetLinkResponse linkAccount(
-                Long memberId, com.team.independence.asset.dto.connection.AssetLinkRequest request) {
+        public com.team.independence.asset.dto.connection.AssetLinkResponse
+        linkAccount(
+                Long memberId,
+                com.team.independence.asset.dto.connection.AssetLinkRequest request
+        ) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public List<com.team.independence.asset.dto.connection.LinkedOrganizationResponse> getConnections(Long memberId) {
+        public List<com.team.independence.asset.dto.connection.LinkedOrganizationResponse>
+        getConnections(Long memberId) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public com.team.independence.asset.dto.connection.UnlinkOrganizationResponse unlinkOrganization(
-                Long memberId, String organizationCode) {
+        public com.team.independence.asset.dto.connection.UnlinkOrganizationResponse
+        unlinkOrganization(
+                Long memberId,
+                String organizationCode
+        ) {
             throw new UnsupportedOperationException();
         }
 
@@ -520,15 +646,19 @@ class GoalDetailServiceImplTest {
         }
     }
 
-    private static class FakeAssetSummaryService implements AssetSummaryService {
+    private static class FakeAssetSummaryService
+            implements AssetSummaryService {
 
         private long growingAssets = 100_000_000L;
         private long fixedAssets = 20_000_000L;
         private int netWorthCalls = 0;
 
         @Override
-        public AssetNetWorthBreakdown getNetWorthBreakdown(Long memberId) {
+        public AssetNetWorthBreakdown getNetWorthBreakdown(
+                Long memberId
+        ) {
             netWorthCalls++;
+
             return AssetNetWorthBreakdown.builder()
                     .interestBearingAssets(growingAssets)
                     .flatRecognizedAssets(fixedAssets)
@@ -546,7 +676,10 @@ class GoalDetailServiceImplTest {
         }
 
         @Override
-        public void updateMonthlySavings(Long memberId, Long monthlySavings) {
+        public void updateMonthlySavings(
+                Long memberId,
+                Long monthlySavings
+        ) {
             throw new UnsupportedOperationException();
         }
     }

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplMarketTrendTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplMarketTrendTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,12 +23,14 @@ import com.team.independence.goal.service.calculator.BudgetCalculator;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.PriceModelResponse;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.dto.RentMedianResponse.Quartile;
+import com.team.independence.property.service.PriceModelService;
 import com.team.independence.property.service.RegionQueryService;
 import com.team.independence.property.service.RentMedianService;
-import com.team.independence.goal.service.calculator.LoanSchedule;
+import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
@@ -43,14 +44,32 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class GoalServiceImplMarketTrendTest {
 
-    @Mock RegionQueryService regionQueryService;
-    @Mock AssetConnectionService assetConnectionService;
-    @Mock AssetSummaryService assetSummaryService;
-    @Mock RentMedianService rentMedianService;
-    @Mock GoalMapper goalMapper;
-    @Mock GoalHousingMapper goalHousingMapper;
-    @Mock GoalMarketTrendCacheStore goalMarketTrendCacheStore;
-    @Mock LoanPlanCalculator loanPlanCalculator;
+    @Mock
+    RegionQueryService regionQueryService;
+
+    @Mock
+    AssetConnectionService assetConnectionService;
+
+    @Mock
+    AssetSummaryService assetSummaryService;
+
+    @Mock
+    RentMedianService rentMedianService;
+
+    @Mock
+    GoalMapper goalMapper;
+
+    @Mock
+    GoalHousingMapper goalHousingMapper;
+
+    @Mock
+    GoalMarketTrendCacheStore goalMarketTrendCacheStore;
+
+    @Mock
+    LoanPlanCalculator loanPlanCalculator;
+
+    @Mock
+    PriceModelService priceModelService;
 
     GoalServiceImpl service;
 
@@ -60,18 +79,60 @@ class GoalServiceImplMarketTrendTest {
     @BeforeEach
     void setUp() {
         service = new GoalServiceImpl(
-                regionQueryService, assetConnectionService, assetSummaryService, rentMedianService,
-                goalMapper, goalHousingMapper, goalMarketTrendCacheStore, null, new BudgetCalculator(), loanPlanCalculator);
+                regionQueryService,
+                assetConnectionService,
+                assetSummaryService,
+                rentMedianService,
+                goalMapper,
+                goalHousingMapper,
+                goalMarketTrendCacheStore,
+                null,
+                new BudgetCalculator(),
+                loanPlanCalculator,
+                priceModelService
+        );
     }
 
-    private Goal goal(long targetAmount, long targetRentMiddleAmount, long monthlySaving) {
+    /**
+     * 몬테카를로 예측을 드리프트·변동성 0으로 고정해
+     * priceP50이 항상 P0(currentMiddleAmount)와 같게 만든다.
+     */
+    private void stubFlatPricePrediction() {
+        when(priceModelService.estimate(any()))
+                .thenReturn(
+                        PriceModelResponse.builder()
+                                .annualDrift(0.0)
+                                .annualVol(0.0)
+                                .build()
+                );
+    }
+
+    private Goal goal(
+            long targetAmount,
+            long targetRentMiddleAmount,
+            long monthlySaving
+    ) {
+        return goal(
+                targetAmount,
+                targetRentMiddleAmount,
+                monthlySaving,
+                LocalDate.now().plusYears(1)
+        );
+    }
+
+    private Goal goal(
+            long targetAmount,
+            long targetRentMiddleAmount,
+            long monthlySaving,
+            LocalDate targetDate
+    ) {
         return Goal.builder()
                 .id(GOAL_ID)
                 .memberId(MEMBER_ID)
                 .goalType("HOUSING")
                 .targetAmount(targetAmount)
                 .targetRentMiddleAmount(targetRentMiddleAmount)
-                .targetDate(java.time.LocalDate.now().plusYears(1))
+                .targetDate(targetDate)
                 .monthlySaving(monthlySaving)
                 .status("ACTIVE")
                 .build();
@@ -92,7 +153,11 @@ class GoalServiceImplMarketTrendTest {
                 .build();
     }
 
-    private RentMedianResponse rentStats(int sampleCount, Long median, String baseEndYm) {
+    private RentMedianResponse rentStats(
+            int sampleCount,
+            Long median,
+            String baseEndYm
+    ) {
         return RentMedianResponse.builder()
                 .regionCode("11680")
                 .regionName("서울 강남구")
@@ -101,7 +166,15 @@ class GoalServiceImplMarketTrendTest {
                 .baseStartYm("202509")
                 .baseEndYm(baseEndYm)
                 .sampleCount(sampleCount)
-                .deposit(sampleCount == 0 ? Quartile.empty() : Quartile.of(median - 1000, median, median + 1000))
+                .deposit(
+                        sampleCount == 0
+                                ? Quartile.empty()
+                                : Quartile.of(
+                                median - 1000,
+                                median,
+                                median + 1000
+                        )
+                )
                 .monthlyRent(Quartile.empty())
                 .build();
     }
@@ -109,158 +182,507 @@ class GoalServiceImplMarketTrendTest {
     @Test
     @DisplayName("getMarketTrend - 캐시 히트면 재계산 없이 캐시 값을 그대로 반환한다")
     void getMarketTrend_cacheHit_returnsWithoutRecompute() {
-        when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(goal(100_000_000L, 90_000_000L, 1_000_000L));
-        GoalMarketTrendResponse cached = GoalMarketTrendResponse.builder().targetAmount(100_000_000L).build();
-        when(goalMarketTrendCacheStore.find(GOAL_ID)).thenReturn(Optional.of(cached));
+        when(goalMapper.findActiveByMemberId(MEMBER_ID))
+                .thenReturn(
+                        goal(
+                                100_000_000L,
+                                90_000_000L,
+                                1_000_000L
+                        )
+                );
 
-        GoalMarketTrendResponse result = service.getMarketTrend(MEMBER_ID);
+        GoalMarketTrendResponse cached =
+                GoalMarketTrendResponse.builder()
+                        .targetAmount(100_000_000L)
+                        .build();
+
+        when(goalMarketTrendCacheStore.find(GOAL_ID))
+                .thenReturn(Optional.of(cached));
+
+        GoalMarketTrendResponse result =
+                service.getMarketTrend(MEMBER_ID);
 
         assertThat(result).isSameAs(cached);
-        verify(rentMedianService, never()).getMedian(any());
-        verify(assetSummaryService, never()).getNetWorthBreakdown(anyLong());
-        verify(goalMarketTrendCacheStore, never()).save(any(), any());
+
+        verify(rentMedianService, never())
+                .getMedian(any());
+
+        verify(assetSummaryService, never())
+                .getNetWorthBreakdown(anyLong());
+
+        verify(goalMarketTrendCacheStore, never())
+                .save(any(), any());
     }
 
     @Test
     @DisplayName("getMarketTrend - ACTIVE 목표가 없으면 GOAL_NOT_FOUND")
     void getMarketTrend_noActiveGoal_throws() {
-        when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(null);
+        when(goalMapper.findActiveByMemberId(MEMBER_ID))
+                .thenReturn(null);
 
-        assertThatThrownBy(() -> service.getMarketTrend(MEMBER_ID))
+        assertThatThrownBy(
+                () -> service.getMarketTrend(MEMBER_ID)
+        )
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GOAL_NOT_FOUND);
+                .hasFieldOrPropertyWithValue(
+                        "errorCode",
+                        ErrorCode.GOAL_NOT_FOUND
+                );
     }
 
     @Test
     @DisplayName("getMarketTrend - 캐시 미스면 refreshMarketTrend로 계산 후 캐시에 저장한다")
     void getMarketTrend_cacheMiss_computesAndCaches() {
-        Goal goal = goal(100_000_000L, 90_000_000L, 1_000_000L);
-        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID)).thenReturn(List.of());
-        when(goalMapper.findActiveByMemberId(MEMBER_ID)).thenReturn(goal);
-        when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
-        when(goalMarketTrendCacheStore.find(GOAL_ID)).thenReturn(Optional.empty());
-        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
-        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
+        Goal goal = goal(
+                100_000_000L,
+                90_000_000L,
+                1_000_000L
+        );
+
+        stubFlatPricePrediction();
+
+        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID))
+                .thenReturn(List.of());
+
+        when(goalMapper.findActiveByMemberId(MEMBER_ID))
+                .thenReturn(goal);
+
+        when(goalMapper.findById(GOAL_ID))
+                .thenReturn(goal);
+
+        when(goalMarketTrendCacheStore.find(GOAL_ID))
+                .thenReturn(Optional.empty());
+
+        when(goalHousingMapper.findByGoalId(GOAL_ID))
+                .thenReturn(goalHousing());
+
+        when(regionQueryService.resolveRegionName("11680"))
+                .thenReturn("서울 강남구");
+
         when(rentMedianService.getMedian(any(RentMedianRequest.class)))
-                .thenReturn(rentStats(5, 95_000_000L, "202607"));
+                .thenReturn(
+                        rentStats(
+                                5,
+                                95_000_000L,
+                                "202607"
+                        )
+                );
+
         when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID))
-                .thenReturn(AssetNetWorthBreakdown.builder()
-                        .interestBearingAssets(0L)
-                        .flatRecognizedAssets(200_000_000L)
-                        .build());
+                .thenReturn(
+                        AssetNetWorthBreakdown.builder()
+                                .interestBearingAssets(0L)
+                                .flatRecognizedAssets(200_000_000L)
+                                .build()
+                );
 
-        GoalMarketTrendResponse result = service.getMarketTrend(MEMBER_ID);
+        GoalMarketTrendResponse result =
+                service.getMarketTrend(MEMBER_ID);
 
-        assertThat(result.getCurrentMiddleAmount()).isEqualTo(95_000_000L);
-        assertThat(result.getChangeAmount()).isEqualTo(5_000_000L); // 95M - 90M
-        assertThat(result.getUpdatedYm()).isEqualTo(YearMonth.of(2026, 7));
-        verify(goalMarketTrendCacheStore).save(eq(GOAL_ID), any(GoalMarketTrendResponse.class));
+        assertThat(result.getCurrentMiddleAmount())
+                .isEqualTo(95_000_000L);
+
+        assertThat(result.getUpdatedYm())
+                .isEqualTo(YearMonth.of(2026, 7));
+
+        // 드리프트·변동성 0이므로
+        // latestPredictedMarketAmount는 P0(currentMiddleAmount)와 같다
+        assertThat(result.getLatestPredictedMarketAmount())
+                .isEqualTo(95_000_000L);
+
+        assertThat(result.getPredictionTargetYm())
+                .isEqualTo(
+                        YearMonth.from(goal.getTargetDate())
+                );
+
+        assertThat(result.getPredictionChangeAmount())
+                .isEqualTo(5_000_000L);
+
+        verify(goalMarketTrendCacheStore)
+                .save(
+                        eq(GOAL_ID),
+                        any(GoalMarketTrendResponse.class)
+                );
+    }
+
+    @Test
+    @DisplayName("getMarketTrend - 가격 모델 표본이 부족하면 예측값만 null이고 predictionTargetYm은 target_date로 유지된다")
+    void getMarketTrend_priceModelInsufficientData_predictionFieldsAreNull() {
+        Goal goal = goal(
+                100_000_000L,
+                90_000_000L,
+                1_000_000L
+        );
+
+        when(priceModelService.estimate(any()))
+                .thenThrow(
+                        new BusinessException(
+                                ErrorCode.PROPERTY_INSUFFICIENT_DATA
+                        )
+                );
+
+        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID))
+                .thenReturn(List.of());
+
+        when(goalMapper.findActiveByMemberId(MEMBER_ID))
+                .thenReturn(goal);
+
+        when(goalMapper.findById(GOAL_ID))
+                .thenReturn(goal);
+
+        when(goalMarketTrendCacheStore.find(GOAL_ID))
+                .thenReturn(Optional.empty());
+
+        when(goalHousingMapper.findByGoalId(GOAL_ID))
+                .thenReturn(goalHousing());
+
+        when(regionQueryService.resolveRegionName("11680"))
+                .thenReturn("서울 강남구");
+
+        when(rentMedianService.getMedian(any(RentMedianRequest.class)))
+                .thenReturn(
+                        rentStats(
+                                5,
+                                95_000_000L,
+                                "202607"
+                        )
+                );
+
+        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID))
+                .thenReturn(
+                        AssetNetWorthBreakdown.builder()
+                                .interestBearingAssets(0L)
+                                .flatRecognizedAssets(200_000_000L)
+                                .build()
+                );
+
+        GoalMarketTrendResponse result =
+                service.getMarketTrend(MEMBER_ID);
+
+        assertThat(result.getLatestPredictedMarketAmount())
+                .isNull();
+
+        assertThat(result.getPredictionTargetYm())
+                .isEqualTo(
+                        YearMonth.from(goal.getTargetDate())
+                );
+
+        assertThat(result.getPredictionChangeAmount())
+                .isNull();
+
+        assertThat(result.getCurrentMiddleAmount())
+                .isEqualTo(95_000_000L);
+
+        assertThat(result.getMaintainEta())
+                .isEqualTo(
+                        YearMonth.from(goal.getTargetDate())
+                );
+    }
+
+    @Test
+    @DisplayName("getMarketTrend - 목표 시점이 실거래 기준 연월보다 과거면 예측을 아예 시도하지 않지만 predictionTargetYm은 target_date로 유지된다")
+    void getMarketTrend_predictionTargetBeforeUpdatedYm_skipsPrediction() {
+        // updatedYm(202607)보다 이전인 targetDate
+        // → months <= 0 guard로 걸러져야 한다.
+        Goal goal = goal(
+                100_000_000L,
+                90_000_000L,
+                1_000_000L,
+                LocalDate.of(2026, 6, 1)
+        );
+
+        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID))
+                .thenReturn(List.of());
+
+        when(goalMapper.findActiveByMemberId(MEMBER_ID))
+                .thenReturn(goal);
+
+        when(goalMapper.findById(GOAL_ID))
+                .thenReturn(goal);
+
+        when(goalMarketTrendCacheStore.find(GOAL_ID))
+                .thenReturn(Optional.empty());
+
+        when(goalHousingMapper.findByGoalId(GOAL_ID))
+                .thenReturn(goalHousing());
+
+        when(regionQueryService.resolveRegionName("11680"))
+                .thenReturn("서울 강남구");
+
+        when(rentMedianService.getMedian(any(RentMedianRequest.class)))
+                .thenReturn(
+                        rentStats(
+                                5,
+                                95_000_000L,
+                                "202607"
+                        )
+                );
+
+        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID))
+                .thenReturn(
+                        AssetNetWorthBreakdown.builder()
+                                .interestBearingAssets(0L)
+                                .flatRecognizedAssets(200_000_000L)
+                                .build()
+                );
+
+        GoalMarketTrendResponse result =
+                service.getMarketTrend(MEMBER_ID);
+
+        assertThat(result.getLatestPredictedMarketAmount())
+                .isNull();
+
+        assertThat(result.getPredictionTargetYm())
+                .isEqualTo(
+                        YearMonth.from(goal.getTargetDate())
+                );
+
+        assertThat(result.getPredictionChangeAmount())
+                .isNull();
+
+        verify(priceModelService, never())
+                .estimate(any());
     }
 
     @Test
     @DisplayName("refreshMarketTrend - 조건에 맞는 실거래가 없으면 GOAL_NO_MARKET_DATA")
     void refreshMarketTrend_noMarketData_throws() {
-        Goal goal = goal(100_000_000L, 90_000_000L, 1_000_000L);
-        when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
-        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
-        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
-        when(rentMedianService.getMedian(any(RentMedianRequest.class))).thenReturn(rentStats(0, null, "202607"));
+        Goal goal = goal(
+                100_000_000L,
+                90_000_000L,
+                1_000_000L
+        );
 
-        assertThatThrownBy(() -> service.refreshMarketTrend(GOAL_ID))
+        when(goalMapper.findById(GOAL_ID))
+                .thenReturn(goal);
+
+        when(goalHousingMapper.findByGoalId(GOAL_ID))
+                .thenReturn(goalHousing());
+
+        when(regionQueryService.resolveRegionName("11680"))
+                .thenReturn("서울 강남구");
+
+        when(rentMedianService.getMedian(any(RentMedianRequest.class)))
+                .thenReturn(
+                        rentStats(
+                                0,
+                                null,
+                                "202607"
+                        )
+                );
+
+        assertThatThrownBy(
+                () -> service.refreshMarketTrend(GOAL_ID)
+        )
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GOAL_NO_MARKET_DATA);
+                .hasFieldOrPropertyWithValue(
+                        "errorCode",
+                        ErrorCode.GOAL_NO_MARKET_DATA
+                );
 
-        verify(goalMarketTrendCacheStore, never()).save(any(), any());
+        verify(goalMarketTrendCacheStore, never())
+                .save(any(), any());
     }
 
     @Test
     @DisplayName("refreshMarketTrend - 목표가 없으면 GOAL_NOT_FOUND")
     void refreshMarketTrend_goalNotFound_throws() {
-        when(goalMapper.findById(GOAL_ID)).thenReturn(null);
+        when(goalMapper.findById(GOAL_ID))
+                .thenReturn(null);
 
-        assertThatThrownBy(() -> service.refreshMarketTrend(GOAL_ID))
+        assertThatThrownBy(
+                () -> service.refreshMarketTrend(GOAL_ID)
+        )
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GOAL_NOT_FOUND);
+                .hasFieldOrPropertyWithValue(
+                        "errorCode",
+                        ErrorCode.GOAL_NOT_FOUND
+                );
     }
 
     @Test
     @DisplayName("refreshMarketTrend - 희망 주거 조건이 없으면 GOAL_NOT_FOUND")
     void refreshMarketTrend_goalHousingNotFound_throws() {
-        Goal goal = goal(100_000_000L, 90_000_000L, 1_000_000L);
-        when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
-        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(null);
+        Goal goal = goal(
+                100_000_000L,
+                90_000_000L,
+                1_000_000L
+        );
 
-        assertThatThrownBy(() -> service.refreshMarketTrend(GOAL_ID))
+        when(goalMapper.findById(GOAL_ID))
+                .thenReturn(goal);
+
+        when(goalHousingMapper.findByGoalId(GOAL_ID))
+                .thenReturn(null);
+
+        assertThatThrownBy(
+                () -> service.refreshMarketTrend(GOAL_ID)
+        )
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GOAL_NOT_FOUND);
+                .hasFieldOrPropertyWithValue(
+                        "errorCode",
+                        ErrorCode.GOAL_NOT_FOUND
+                );
     }
 
     @Test
     @DisplayName("refreshMarketTrend - maintainEta는 재계산하지 않고 goal.target_date를 그대로 반환한다")
     void refreshMarketTrend_maintainEta_usesStoredTargetDateAsIs() {
-        Goal goal = goal(1L, 90_000_000L, 1_000_000L); // targetAmount=1원, 사실상 이미 달성
-        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID)).thenReturn(List.of());
-        when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
-        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
-        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
+        Goal goal = goal(
+                1L,
+                90_000_000L,
+                1_000_000L
+        );
+
+        stubFlatPricePrediction();
+
+        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID))
+                .thenReturn(List.of());
+
+        when(goalMapper.findById(GOAL_ID))
+                .thenReturn(goal);
+
+        when(goalHousingMapper.findByGoalId(GOAL_ID))
+                .thenReturn(goalHousing());
+
+        when(regionQueryService.resolveRegionName("11680"))
+                .thenReturn("서울 강남구");
+
         when(rentMedianService.getMedian(any(RentMedianRequest.class)))
-                .thenReturn(rentStats(5, 1L, "202607"));
+                .thenReturn(
+                        rentStats(
+                                5,
+                                1L,
+                                "202607"
+                        )
+                );
+
         when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID))
-                .thenReturn(AssetNetWorthBreakdown.builder()
-                        .interestBearingAssets(0L)
-                        .flatRecognizedAssets(1_000_000_000L)
-                        .build());
+                .thenReturn(
+                        AssetNetWorthBreakdown.builder()
+                                .interestBearingAssets(0L)
+                                .flatRecognizedAssets(1_000_000_000L)
+                                .build()
+                );
 
-        GoalMarketTrendResponse result = service.refreshMarketTrend(GOAL_ID);
+        GoalMarketTrendResponse result =
+                service.refreshMarketTrend(GOAL_ID);
 
-        // 자산이 충분해 이미 달성 가능한 상황이어도 maintainEta는 재계산되지 않고 저장된 target_date 그대로다
-        assertThat(result.getMaintainEta()).isEqualTo(YearMonth.from(goal.getTargetDate()));
-        assertThat(result.getReflectEta()).isEqualTo(YearMonth.now());
+        // 자산이 충분해 이미 달성 가능한 상황이어도
+        // maintainEta는 재계산되지 않고 저장된 target_date 그대로다.
+        assertThat(result.getMaintainEta())
+                .isEqualTo(
+                        YearMonth.from(goal.getTargetDate())
+                );
+
+        assertThat(result.getReflectEta())
+                .isEqualTo(YearMonth.now());
     }
 
     @Test
     @DisplayName("refreshMarketTrend - reflectEta는 상한(240개월) 내 도달 불가능하면 null, maintainEta는 그대로 target_date")
     void refreshMarketTrend_unreachable_reflectEtaIsNull() {
-        Goal goal = goal(9_999_999_999L, 90_000_000L, 0L); // 저축 0, 목표는 사실상 도달 불가
-        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID)).thenReturn(List.of());
-        when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
-        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
-        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
+        Goal goal = goal(
+                9_999_999_999L,
+                90_000_000L,
+                0L
+        );
+
+        stubFlatPricePrediction();
+
+        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID))
+                .thenReturn(List.of());
+
+        when(goalMapper.findById(GOAL_ID))
+                .thenReturn(goal);
+
+        when(goalHousingMapper.findByGoalId(GOAL_ID))
+                .thenReturn(goalHousing());
+
+        when(regionQueryService.resolveRegionName("11680"))
+                .thenReturn("서울 강남구");
+
         when(rentMedianService.getMedian(any(RentMedianRequest.class)))
-                .thenReturn(rentStats(5, 9_999_999_999L, "202607"));
+                .thenReturn(
+                        rentStats(
+                                5,
+                                9_999_999_999L,
+                                "202607"
+                        )
+                );
+
         when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID))
-                .thenReturn(AssetNetWorthBreakdown.builder()
-                        .interestBearingAssets(0L)
-                        .flatRecognizedAssets(0L)
-                        .build());
+                .thenReturn(
+                        AssetNetWorthBreakdown.builder()
+                                .interestBearingAssets(0L)
+                                .flatRecognizedAssets(0L)
+                                .build()
+                );
 
-        GoalMarketTrendResponse result = service.refreshMarketTrend(GOAL_ID);
+        GoalMarketTrendResponse result =
+                service.refreshMarketTrend(GOAL_ID);
 
-        assertThat(result.getMaintainEta()).isEqualTo(YearMonth.from(goal.getTargetDate()));
-        assertThat(result.getReflectEta()).isNull();
+        assertThat(result.getMaintainEta())
+                .isEqualTo(
+                        YearMonth.from(goal.getTargetDate())
+                );
+
+        assertThat(result.getReflectEta())
+                .isNull();
     }
 
     @Test
     @DisplayName("refreshMarketTrend - maintainEta(목표 유지)와 reflectEta(시세 반영)는 금액이 다르면 다른 시점으로 계산된다")
     void refreshMarketTrend_maintainAndReflect_diverge() {
-        // targetAmount(100M)가 currentMiddleAmount(10M)보다 훨씬 커서, 반영(reflect) 쪽이 훨씬 빨리 도달해야 한다
-        Goal goal = goal(100_000_000L, 90_000_000L, 1_000_000L);
-        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID)).thenReturn(List.of());
-        when(goalMapper.findById(GOAL_ID)).thenReturn(goal);
-        when(goalHousingMapper.findByGoalId(GOAL_ID)).thenReturn(goalHousing());
-        when(regionQueryService.resolveRegionName("11680")).thenReturn("서울 강남구");
+        // targetAmount(100M)가 currentMiddleAmount(10M)보다 훨씬 크므로
+        // 반영(reflect) 쪽이 훨씬 빨리 도달해야 한다.
+        Goal goal = goal(
+                100_000_000L,
+                90_000_000L,
+                1_000_000L
+        );
+
+        stubFlatPricePrediction();
+
+        when(loanPlanCalculator.getLoanSchedules(MEMBER_ID))
+                .thenReturn(List.of());
+
+        when(goalMapper.findById(GOAL_ID))
+                .thenReturn(goal);
+
+        when(goalHousingMapper.findByGoalId(GOAL_ID))
+                .thenReturn(goalHousing());
+
+        when(regionQueryService.resolveRegionName("11680"))
+                .thenReturn("서울 강남구");
+
         when(rentMedianService.getMedian(any(RentMedianRequest.class)))
-                .thenReturn(rentStats(5, 10_000_000L, "202607"));
+                .thenReturn(
+                        rentStats(
+                                5,
+                                10_000_000L,
+                                "202607"
+                        )
+                );
+
         when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID))
-                .thenReturn(AssetNetWorthBreakdown.builder()
-                        .interestBearingAssets(0L)
-                        .flatRecognizedAssets(0L)
-                        .build());
+                .thenReturn(
+                        AssetNetWorthBreakdown.builder()
+                                .interestBearingAssets(0L)
+                                .flatRecognizedAssets(0L)
+                                .build()
+                );
 
-        GoalMarketTrendResponse result = service.refreshMarketTrend(GOAL_ID);
+        GoalMarketTrendResponse result =
+                service.refreshMarketTrend(GOAL_ID);
 
-        assertThat(result.getMaintainEta()).isNotNull();
-        assertThat(result.getReflectEta()).isNotNull();
-        assertThat(result.getReflectEta()).isLessThan(result.getMaintainEta());
+        assertThat(result.getMaintainEta())
+                .isNotNull();
+
+        assertThat(result.getReflectEta())
+                .isNotNull();
+
+        assertThat(result.getReflectEta())
+                .isLessThan(result.getMaintainEta());
     }
 }

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplSummaryTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplSummaryTest.java
@@ -48,7 +48,7 @@ class GoalServiceImplSummaryTest {
     void setUp() {
         service = new GoalServiceImpl(
                 regionQueryService, assetConnectionService, assetSummaryService, rentMedianService,
-                goalMapper, goalHousingMapper, goalMarketTrendCacheStore, null, new BudgetCalculator(), null);
+                goalMapper, goalHousingMapper, goalMarketTrendCacheStore, null, new BudgetCalculator(), null, null);
     }
 
     private Goal goal(long targetAmount, long monthlySaving) {

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplTest.java
@@ -26,7 +26,7 @@ class GoalServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        service = new GoalServiceImpl(null, null, null, null, null, null, null, null, new BudgetCalculator(), null);
+        service = new GoalServiceImpl(null, null, null, null, null, null, null, null, new BudgetCalculator(), null, null);
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## #️⃣연관된 이슈

- #147 

## 📝작업 내용

기존 market-trend는 initialMiddleAmount와 currentMiddleAmount를 비교해 시세 변화량을 제공했지만, 진단 시점의 initialMiddleAmount가 몬테카를로 기반의 목표 시점 예측 시세로 사용되면서 현재 실거래 시세와 직접 비교하기 어려워졌습니다.

이에 따라 최신 실거래 데이터를 기준으로 목표 시점의 시세를 다시 예측하고, 진단 당시 전망과 최신 전망을 비교할 수 있도록 API를 확장했습니다.

### 1. 목표 시점 최신 예측 시세 추가
- GoalMarketTrendResponse에 아래 필드 추가
    - latestPredictedMarketAmount: 최신 실거래 데이터를 기준으로 다시 계산한 목표 시점 P50 예측 시세
    - predictionTargetYm: 예측 대상 목표 연월
- 기존 changeAmount는 predictionChangeAmount로 변경
    - latestPredictedMarketAmount - initialMiddleAmount
    - 기존 실제 시세 변화량이 아니라 진단 당시 전망 대비 최신 전망 변화량을 의미하도록 수정

### 2. 최신 실거래 기준 몬테카를로 재예측
-  GoalServiceImpl.computeMarketTrend에서 PriceModelService와 MonteCarloEngine을 이용해 목표 시점의 P50 시세를 재계산
- 예측 기준
    - 시작 시점: updatedYm
    - 시작 가격(P0): currentMiddleAmount
    - 종료 시점: predictionTargetYm
- currentMiddleAmount가 updatedYm 기준 실거래 중앙값이므로 YearMonth.now()가 아닌 updatedYm부터 목표 시점까지의 기간을 사용해 기준 시점 불일치를 방지

### 3. 사용자 자산과 독립된 시장 시세 전망으로 처리
- 이번 latestPredictedMarketAmount는 사용자의 자산이나 월 저축액이 아닌 시장 자체의 미래 시세 전망값으로 사용
- MonteCarloEngine의 budgetAtT는 성공 확률 계산에만 사용되고 priceP50에는 영향을 주지 않으므로, 별도의 자산 조회 없이 시세 P50을 계산하도록 처리

### 4. 예측 실패 시 graceful degradation

다음 상황에서는 전체 market-trend API를 실패시키지 않고 최신 전망 관련 값만 null로 반환

- 목표 시점이 이미 지난 경우
- 가격 모델 생성에 필요한 실거래 표본이 부족한 경우 (PROPERTY_INSUFFICIENT_DATA)

예측 실패 시:

- latestPredictedMarketAmount: null
- predictionChangeAmount: null
- predictionTargetYm: 목표 시점이므로 그대로 유지

즉 predictionTargetYm은 예측 결과가 아니라 예측 대상 시점이기 때문에 성공 여부와 관계없이 항상 반환되도록 처리했습니다.

### 5. 순환 참조 방지
- 기존 MonteCarloServiceImpl이 이미 GoalService에 의존하고 있어 GoalServiceImpl → MonteCarloService 의존성을 추가할 경우 순환 참조가 발생할 수 있음
- 이를 피하기 위해 GoalServiceImpl에서는 MonteCarloService를 거치지 않고 PriceModelService + MonteCarloEngine을 직접 사용
- 기존 목표 상세 /simulation 엔드포인트 및 MonteCarloServiceImpl 로직은 변경하지 않음

### 6. Redis 캐시 버전업
- changeAmount의 의미와 응답 구조가 변경되어 기존 캐시와 새 응답이 섞이지 않도록 캐시 키 버전업
    - 기존: goal:market-trend:{goalId}
    - 변경: goal:market-trend:v2:{goalId}
- 기존 v1 캐시는 TTL에 따라 자연 만료되며 별도 flush는 필요하지 않음

### 기타
- DB 스키마 및 마이그레이션 변경 없음
- 관련 market-trend 테스트 수정 및 예측 실패 케이스 반영

## 스크린샷 (선택)
### 현재 예측 시세 계산 완료 
<img width="419" height="348" alt="스크린샷 2026-08-21 오후 3 30 25" src="https://github.com/user-attachments/assets/f714f032-45e5-4231-a87a-48f48934c91b" />

### 계산 불가 시
<img width="341" height="323" alt="스크린샷 2026-08-21 오후 2 46 50" src="https://github.com/user-attachments/assets/f7a9094b-3f9f-4d0b-a40d-bea739926947" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?