### PR TITLE
[PERF] PriceModel 조합 조회 DB 왕복 최적화 (40 → 1회)

### DIFF
--- a/src/main/java/com/team/independence/goal/service/MonteCarloService.java
+++ b/src/main/java/com/team/independence/goal/service/MonteCarloService.java
@@ -2,6 +2,7 @@ package com.team.independence.goal.service;
 
 import com.team.independence.goal.dto.MonteCarloResponse;
 import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.property.dto.PriceModelResponse;
 
 public interface MonteCarloService {
 
@@ -25,4 +26,12 @@ public interface MonteCarloService {
      * @return p5 / p50 / p95 가격 분위값과 성공 확률
      */
     MonteCarloEngine.Result simulate(PriceModelRequest housing, long initialPrice, long budgetAtT, int months);
+
+    /**
+     * 이미 산출된 PriceModelResponse(μ, σ)를 그대로 받아 시뮬레이션만 실행한다.
+     *
+     * <p>Realistic·HoldOut처럼 여러 조합의 PriceModel을 배치로 미리 준비해 두는 경로에서 사용한다.
+     * 조합마다 priceModelService.estimate를 재호출하지 않아 Redis 캐시 검사·DB 왕복이 사라진다.
+     */
+    MonteCarloEngine.Result simulate(PriceModelResponse priceModel, long initialPrice, long budgetAtT, int months);
 }

--- a/src/main/java/com/team/independence/goal/service/MonteCarloServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/MonteCarloServiceImpl.java
@@ -102,6 +102,11 @@ public class MonteCarloServiceImpl implements MonteCarloService {
     @Override
     public MonteCarloEngine.Result simulate(PriceModelRequest housing, long initialPrice, long budgetAtT, int months) {
         PriceModelResponse priceModel = priceModelService.estimate(housing);
+        return simulate(priceModel, initialPrice, budgetAtT, months);
+    }
+
+    @Override
+    public MonteCarloEngine.Result simulate(PriceModelResponse priceModel, long initialPrice, long budgetAtT, int months) {
         return MonteCarloEngine.simulate(
                 priceModel.getAnnualDrift(), priceModel.getAnnualVol(),
                 initialPrice, budgetAtT,

--- a/src/main/java/com/team/independence/goal/service/RecommendationAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/RecommendationAlgorithm.java
@@ -7,9 +7,12 @@ import com.team.independence.goal.service.calculator.LoanSchedule;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
 import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.property.dto.RentMedianResponse;
 import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 추천 알고리즘 하나. 구현체 하나가 곧 추천 카드 한 장을 만든다.
@@ -63,7 +66,19 @@ public interface RecommendationAlgorithm {
     record MemberFinancialContext(
             AssetNetWorthBreakdown netWorth,
             long rawMonthlySaving,
-            List<LoanSchedule> loanSchedules) {
+            List<LoanSchedule> loanSchedules,
+            /**
+             * 요청 한 건 내에서 알고리즘들이 공유하는 bulkMedian 캐시. key는 regionCode.
+             * Realistic이 시군구를 확정한 뒤 채우면 HoldOut이 같은 지역·기간의 반복 조회를 피한다.
+             * 알고리즘들은 Phase 1 → Phase 2 순차라 락 없이 접근하지만, 방어적으로 ConcurrentHashMap을 쓴다.
+             */
+            Map<String, Map<String, RentMedianResponse>> bulkMediansCache) {
+
+        /** 기본 캐시를 자동 생성하는 3-arg 편의 생성자 — 기존 호출부(테스트 포함) 호환 유지 */
+        public MemberFinancialContext(AssetNetWorthBreakdown netWorth, long rawMonthlySaving,
+                                       List<LoanSchedule> loanSchedules) {
+            this(netWorth, rawMonthlySaving, loanSchedules, new ConcurrentHashMap<>());
+        }
 
         /** "지금 시점" 기준 실질 저축 여력 — DSR 계산 등 현재 스냅샷이 필요한 곳에서만 사용 */
         public long currentEffectiveSaving() {

--- a/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithm.java
@@ -11,14 +11,19 @@ import com.team.independence.goal.service.calculator.BudgetCalculator;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
+import com.team.independence.property.dto.PriceModelKey;
+import com.team.independence.property.dto.PriceModelResponse;
 import com.team.independence.property.dto.RentMedianResponse;
+import com.team.independence.property.service.PriceModelService;
 import com.team.independence.property.service.RentMedianService;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -70,6 +75,7 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
     private final BudgetCalculator   budgetCalculator;
     private final RentMedianService  rentMedianService;
     private final MonteCarloService  monteCarloService;
+    private final PriceModelService  priceModelService;
 
     /** Realistic 결과 없이 직접 호출되면 soft-fail을 반환한다. */
     @Override
@@ -100,11 +106,26 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
                 ? RecommendationAlgorithm.monthsUntil(request.getTargetDate())
                 : 24L;
 
+        // Realistic이 이미 채워 둔 request-scoped 캐시에서 먼저 찾는다. HoldOut은 항상 Realistic 뒤에
+        // 실행되고 baseline.regionCode == Realistic의 chosenRegion이므로, 정상 경로에서는 캐시 히트.
         YearMonth now = YearMonth.now();
         String endYm   = now.format(YM);
         String startYm = now.minusMonths(MONTHS - 1).format(YM);
-        Map<String, RentMedianResponse> bulkMedians =
-                rentMedianService.getBulkMedian(baseline.getRegionCode(), startYm, endYm);
+        Map<String, RentMedianResponse> bulkMedians = ctx.bulkMediansCache().computeIfAbsent(
+                baseline.getRegionCode(), rc -> rentMedianService.getBulkMedian(rc, startYm, endYm));
+
+        // 40조합의 PriceModel을 배치로 준비한다. Realistic이 앞선 Phase에서 같은 시군구를 이미 캐시에 채워
+        // 두었다면 대부분 Redis HIT로 흡수되고, 미스만 단일 DB 왕복으로 채워진다.
+        Set<PriceModelKey> combos = new LinkedHashSet<>();
+        for (HousingType ht : HousingType.values()) {
+            for (DealType dt : DealType.values()) {
+                for (int[] size : SIZE_BUCKETS) {
+                    combos.add(new PriceModelKey(ht, dt, size[0], size[1]));
+                }
+            }
+        }
+        Map<PriceModelKey, PriceModelResponse> priceModels =
+                priceModelService.estimateBatch(baseline.getRegionCode(), combos);
 
         // 목표 시점(desiredMonths)의 예산은 후보와 무관하게 같으므로 루프 밖에서 한 번만 계산한다.
         long budgetAtT = budgetCalculator.calculate(
@@ -114,7 +135,7 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
         EvaluatedCandidate nextRung = Arrays.stream(HousingType.values())
                 .flatMap(ht -> Arrays.stream(DealType.values())
                         .flatMap(dt -> Arrays.stream(SIZE_BUCKETS)
-                                .map(size -> evaluate(baseline.getRegionCode(), ht, dt, size, bulkMedians, budgetAtT, desiredMonths))))
+                                .map(size -> evaluate(baseline.getRegionCode(), ht, dt, size, bulkMedians, priceModels, budgetAtT, desiredMonths))))
                 .filter(c -> c != null && c.comparableAmount() > baselineComparable)
                 .min(Comparator.comparingLong(EvaluatedCandidate::comparableAmount))
                 .orElse(null);
@@ -154,7 +175,9 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
      */
     private EvaluatedCandidate evaluate(
             String regionCode, HousingType housingType, DealType dealType, int[] size,
-            Map<String, RentMedianResponse> bulkMedians, long budgetAtT, long desiredMonths) {
+            Map<String, RentMedianResponse> bulkMedians,
+            Map<PriceModelKey, PriceModelResponse> priceModels,
+            long budgetAtT, long desiredMonths) {
 
         int areaMin = size[0];
         int areaMax = size[1];
@@ -171,15 +194,19 @@ public class HoldOutAlgorithm implements RecommendationAlgorithm {
             monthlyRent = rentMedian;
         }
 
-        // MC로 목표 시점의 예상 가격 투영 — Realistic과 동일한 1회 시뮬레이션
+        // MC로 목표 시점의 예상 가격 투영 — Realistic과 동일한 1회 시뮬레이션.
+        // 배치에서 표본 부족으로 스킵된 조합은 priceModels에 없어 자동으로 현재 시세 폴백.
         long projectedDeposit = deposit;
-        try {
-            MonteCarloEngine.Result mc = monteCarloService.simulate(
-                    RecommendationAlgorithm.buildPriceModelRequest(regionCode, housingType, dealType, areaMin, areaMax),
-                    deposit, budgetAtT, (int) desiredMonths);
-            projectedDeposit = mc.priceP50();
-        } catch (RuntimeException e) {
-            log.debug("MC 실패, 현재 시세 사용. housingType={}, dealType={}", housingType, dealType);
+        PriceModelResponse priceModel = priceModels.get(
+                new PriceModelKey(housingType, dealType, areaMin, areaMax));
+        if (priceModel != null) {
+            try {
+                MonteCarloEngine.Result mc = monteCarloService.simulate(
+                        priceModel, deposit, budgetAtT, (int) desiredMonths);
+                projectedDeposit = mc.priceP50();
+            } catch (RuntimeException e) {
+                log.debug("MC 실패, 현재 시세 사용. housingType={}, dealType={}", housingType, dealType);
+            }
         }
 
         long comparableAmount = toComparableAmount(projectedDeposit, monthlyRent);

--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -13,21 +13,26 @@ import com.team.independence.goal.service.calculator.LoanPlanCalculator;
 import com.team.independence.goal.service.calculator.LoanSchedule;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
-import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.property.dto.PriceModelKey;
+import com.team.independence.property.dto.PriceModelResponse;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.dto.SigunguMedianResult;
 import com.team.independence.property.mapper.RegionMapper;
+import com.team.independence.property.service.PriceModelService;
 import com.team.independence.property.service.RentMedianService;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -144,6 +149,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
     private final LoanPlanCalculator loanPlanCalculator;
     private final BudgetCalculator budgetCalculator;
     private final MonteCarloService monteCarloService;
+    private final PriceModelService priceModelService;
 
     @Override
     public List<GoalRecommendationResponse.RecommendationItem> recommend(
@@ -165,17 +171,26 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
             return List.of(emptyCard());
         }
 
-        // 시군구 확정 후 (주거유형, 거래유형, 평수) 40개 조합을 bulk 1회 쿼리로 선조회
+        // 시군구 확정 후 (주거유형, 거래유형, 평수) 40개 조합을 bulk 1회 쿼리로 선조회.
+        // ctx의 request-scoped 캐시에 담아, 뒤이어 실행되는 HoldOut이 같은 지역을 재조회하지 않도록 공유한다.
         YearMonth now = YearMonth.now();
         String endYm   = now.format(YM);
         String startYm = now.minusMonths(MONTHS - 1).format(YM);
-        Map<String, RentMedianResponse> bulkMedians = rentMedianService.getBulkMedian(regionCode, startYm, endYm);
+        Map<String, RentMedianResponse> bulkMedians = ctx.bulkMediansCache().computeIfAbsent(
+                regionCode, rc -> rentMedianService.getBulkMedian(rc, startYm, endYm));
+
+        // 1차 + 2차에서 실제로 평가할 조합 전체를 미리 뽑아 PriceModel을 배치로 준비한다.
+        // 조합마다 개별 estimate로 돌리면 콜드 캐시 시 조합당 36개월 원본행 스캔이 왕복하지만,
+        // 배치 한 방이면 인덱스 서브레인지 스캔이 조합별로 겹치는 페이지를 재활용해 크게 절감된다.
+        Set<PriceModelKey> combos = collectCombos(request);
+        Map<PriceModelKey, PriceModelResponse> priceModels =
+                priceModelService.estimateBatch(regionCode, combos);
 
         // 2단계: 사용자가 준 조건을 지킨 채, 주지 않은 항목만 움직여 본다
         long depositMin = request.getDepositMin() != null ? request.getDepositMin() : 0L;
         long depositMax = request.getDepositMax() != null ? request.getDepositMax() : DEPOSIT_MAX_DEFAULT;
 
-        List<Candidate> asRequested = evaluateConditions(regionCode, request, search, true, bulkMedians);
+        List<Candidate> asRequested = evaluateConditions(regionCode, request, search, true, bulkMedians, priceModels);
         Optional<Candidate> keepingInput = bestWithinTarget(asRequested);
         if (keepingInput.isPresent()) {
             return List.of(assemble(memberId, keepingInput.get(), targetDate, search, depositMin, depositMax));
@@ -184,7 +199,7 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         // 3단계: 입력한 조건으로는 목표 시점을 못 지킨다. 그때만 조건을 풀고 다시 찾는다.
         // 준 조건이 하나도 없으면 1차가 이미 전 범위 탐색이라 다시 조회하지 않는다.
         List<Candidate> relaxed = hasInputCondition(request)
-                ? evaluateConditions(regionCode, request, search, false, bulkMedians)
+                ? evaluateConditions(regionCode, request, search, false, bulkMedians, priceModels)
                 : asRequested;
         if (relaxed.isEmpty()) {
             log.warn("실거래 표본이 있는 조합이 없습니다. memberId={}, regionCode={}", memberId, regionCode);
@@ -193,6 +208,32 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
 
         Candidate chosen = bestWithinTarget(relaxed).orElseGet(() -> cheapest(relaxed));
         return List.of(assemble(memberId, chosen, targetDate, search, depositMin, depositMax));
+    }
+
+    /**
+     * 1차·2차에서 평가 대상이 될 수 있는 모든 (주거유형, 거래유형, 평수) 조합을 모은다.
+     * 사용자가 준 조건은 그 값 하나로 고정, 안 준 항목은 전체 후보로 펼쳐 배치 조회 대상에 포함.
+     * 사용자 지정 area가 SIZE_BUCKETS 경계와 일치하지 않는 경우는 배치가 못 담아 자동 폴백된다.
+     */
+    private Set<PriceModelKey> collectCombos(GoalRecommendationRequest request) {
+        Set<PriceModelKey> combos = new LinkedHashSet<>();
+        List<int[]> sizes = new ArrayList<>();
+        // 1차 후보(keepInput=true)와 2차(keepInput=false)의 합집합만 있으면 되므로 항상 전체 버킷을 기본에 둔다.
+        Collections.addAll(sizes, SIZE_BUCKETS);
+        int[] userSize = inputSize(request);
+        if (userSize != null && !isBucketRange(userSize[0], userSize[1])) {
+            sizes.add(userSize);
+        }
+        List<HousingType> housingTypes = Arrays.asList(HousingType.values());
+        List<DealType> dealTypes = Arrays.asList(DealType.values());
+        for (int[] size : sizes) {
+            for (HousingType ht : housingTypes) {
+                for (DealType dt : dealTypes) {
+                    combos.add(new PriceModelKey(ht, dt, size[0], size[1]));
+                }
+            }
+        }
+        return combos;
     }
 
     /**
@@ -297,13 +338,14 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
      */
     private List<Candidate> evaluateConditions(
             String regionCode, GoalRecommendationRequest request, Search search, boolean keepInput,
-            Map<String, RentMedianResponse> bulkMedians) {
+            Map<String, RentMedianResponse> bulkMedians,
+            Map<PriceModelKey, PriceModelResponse> priceModels) {
 
         List<Candidate> candidates = new ArrayList<>();
         for (int[] size : sizeCandidates(request, keepInput)) {
             for (HousingType housingType : housingTypeCandidates(request, keepInput)) {
                 for (DealType dealType : dealTypeCandidates(request, keepInput)) {
-                    evaluate(regionCode, housingType, dealType, size[0], size[1], request, search, bulkMedians)
+                    evaluate(regionCode, housingType, dealType, size[0], size[1], request, search, bulkMedians, priceModels)
                             .ifPresent(candidates::add);
                 }
             }
@@ -383,14 +425,15 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
     private Optional<Candidate> evaluate(
             String regionCode, HousingType housingType, DealType dealType,
             int areaMin, int areaMax, GoalRecommendationRequest request, Search search,
-            Map<String, RentMedianResponse> bulkMedians) {
+            Map<String, RentMedianResponse> bulkMedians,
+            Map<PriceModelKey, PriceModelResponse> priceModels) {
 
         String key = regionCode + "|" + housingType + "|" + dealType + "|" + areaMin + "|" + areaMax;
         Optional<Candidate> cached = search.evaluated.get(key);
         if (cached != null) {
             return cached;
         }
-        Optional<Candidate> result = lookUp(regionCode, housingType, dealType, areaMin, areaMax, request, search, bulkMedians);
+        Optional<Candidate> result = lookUp(regionCode, housingType, dealType, areaMin, areaMax, request, search, bulkMedians, priceModels);
         search.evaluated.put(key, result);
         return result;
     }
@@ -398,7 +441,8 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
     private Optional<Candidate> lookUp(
             String regionCode, HousingType housingType, DealType dealType,
             int areaMin, int areaMax, GoalRecommendationRequest request, Search search,
-            Map<String, RentMedianResponse> bulkMedians) {
+            Map<String, RentMedianResponse> bulkMedians,
+            Map<PriceModelKey, PriceModelResponse> priceModels) {
 
         // SIZE_BUCKETS 범위이면 bulk 맵에서 바로 꺼낸다.
         // 사용자 지정 범위이거나 bulk 결과가 없으면 개별 쿼리로 폴백한다.
@@ -427,18 +471,21 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
 
         // MC로 목표 시점(desiredMonths)의 예상 가격을 투영한다.
         // Realistic은 시점이 고정이므로 HoldOut과 달리 수렴 루프 없이 1회 시뮬레이션으로 끝낸다.
-        // MC 실패 시 현재 시세를 그대로 사용한다.
+        // MC 실패 또는 배치 준비 실패(표본 부족)시 현재 시세를 그대로 사용한다.
         long projectedDeposit = deposit;
-        try {
-            PriceModelRequest priceReq = RecommendationAlgorithm.buildPriceModelRequest(regionCode, housingType, dealType, areaMin, areaMax);
-            long budgetAtT = budgetCalculator.calculate(
-                    search.netWorth, search.rawMonthlySaving, search.loanSchedules, search.desiredMonths);
-            MonteCarloEngine.Result mc = monteCarloService.simulate(
-                    priceReq, deposit, budgetAtT, (int) search.desiredMonths);
-            projectedDeposit = mc.priceP50();
-        } catch (RuntimeException e) {
-            log.debug("MC 실패, 현재 시세 폴백. regionCode={}, housingType={}, dealType={}",
-                    regionCode, housingType, dealType, e);
+        PriceModelResponse priceModel = priceModels.get(
+                new PriceModelKey(housingType, dealType, areaMin, areaMax));
+        if (priceModel != null) {
+            try {
+                long budgetAtT = budgetCalculator.calculate(
+                        search.netWorth, search.rawMonthlySaving, search.loanSchedules, search.desiredMonths);
+                MonteCarloEngine.Result mc = monteCarloService.simulate(
+                        priceModel, deposit, budgetAtT, (int) search.desiredMonths);
+                projectedDeposit = mc.priceP50();
+            } catch (RuntimeException e) {
+                log.debug("MC 실패, 현재 시세 폴백. regionCode={}, housingType={}, dealType={}",
+                        regionCode, housingType, dealType, e);
+            }
         }
 
         long comparableAmount = toComparableAmount(projectedDeposit, monthlyRent);

--- a/src/main/java/com/team/independence/property/dto/PriceModelBatchRow.java
+++ b/src/main/java/com/team/independence/property/dto/PriceModelBatchRow.java
@@ -1,0 +1,24 @@
+package com.team.independence.property.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * PriceModel 배치 조회의 원본 행 프로젝션.
+ * (주거유형, 거래유형)마다 배치 쿼리 한 번으로 5개 평수 버킷의 모든 원본 행을 반환하고,
+ * 서비스에서 area를 다시 버킷으로 매핑해 조합별로 그룹핑한다.
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PriceModelBatchRow {
+    private HousingType housingType;
+    private DealType dealType;
+    private String dealYm;
+    private Long deposit;
+    private BigDecimal area;
+}

--- a/src/main/java/com/team/independence/property/dto/PriceModelKey.java
+++ b/src/main/java/com/team/independence/property/dto/PriceModelKey.java
@@ -1,0 +1,11 @@
+package com.team.independence.property.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+
+/**
+ * PriceModel 배치 조회의 조합 키. 지역 코드는 배치 호출 인자로 공유되므로 여기에 두지 않는다.
+ *
+ * <p>Realistic·HoldOut이 40조합을 한 번에 준비할 때 캐시 조회·결과 매핑에 쓴다.
+ */
+public record PriceModelKey(HousingType housingType, DealType dealType, int areaMin, int areaMax) {}

--- a/src/main/java/com/team/independence/property/dto/TypeDealPair.java
+++ b/src/main/java/com/team/independence/property/dto/TypeDealPair.java
@@ -1,0 +1,10 @@
+package com.team.independence.property.dto;
+
+import com.team.independence.property.domain.DealType;
+import com.team.independence.property.domain.HousingType;
+
+/**
+ * (주거유형, 거래유형) 쌍. PriceModel 배치 쿼리에서 (housing_type, deal_type) IN 절 대용으로 쓴다.
+ * MyBatis foreach가 필드 접근으로 파라미터를 뽑을 수 있도록 record로 둔다.
+ */
+public record TypeDealPair(HousingType housingType, DealType dealType) {}

--- a/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
+++ b/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
@@ -6,8 +6,10 @@ import com.team.independence.property.domain.RentTransaction;
 import com.team.independence.property.dto.BulkMedianResult;
 import com.team.independence.property.dto.MedianAggResult;
 import com.team.independence.property.dto.MonthlyPricePoint;
+import com.team.independence.property.dto.PriceModelBatchRow;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.SigunguMedianResult;
+import com.team.independence.property.dto.TypeDealPair;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -36,15 +38,15 @@ public interface RentTransactionMapper {
                                          @Param("endYm") String endYm);
 
     /**
-     * 지역·기간·주거유형·거래유형을 받아 평수버킷별 분위값을 반환한다. 최대 5행(5버킷).
-     * getBulkMedian에서 8개 조합(4유형 × 2거래)을 순회하며 호출한다.
-     * housing_type, deal_type를 WHERE에 고정해 idx_rent_query 인덱스를 탄다.
+     * 지역·기간을 공유하는 여러 (주거유형, 거래유형) 쌍에 대해 평수버킷별 분위값을 단일 왕복으로 반환한다.
+     * (housing_type, deal_type) IN 절이 idx_rent_query 서브레인지를 조합별로 그대로 태우므로
+     * 처리 행 수는 페어별 개별 쿼리 합과 동일하고, 왕복·파서·옵티마이저 오버헤드만 사라진다.
+     * 결과 최대 8 × 5 = 40행.
      */
-    List<BulkMedianResult> findBulkMedianByType(@Param("regionCode") String regionCode,
-                                                @Param("housingType") HousingType housingType,
-                                                @Param("dealType") DealType dealType,
-                                                @Param("startYm") String startYm,
-                                                @Param("endYm") String endYm);
+    List<BulkMedianResult> findBulkMedianBatch(@Param("regionCode") String regionCode,
+                                               @Param("typePairs") List<TypeDealPair> typePairs,
+                                               @Param("startYm") String startYm,
+                                               @Param("endYm") String endYm);
 
     /**
      * 시군구 코드 목록에 대해 보증금·월세 중앙값을 단일 쿼리로 반환한다.
@@ -72,4 +74,15 @@ public interface RentTransactionMapper {
                                                      @Param("areaMaxSqm") long areaMaxSqm,
                                                      @Param("startYm") String startYm,
                                                      @Param("endYm") String endYm);
+
+    /**
+     * 배치 PriceModel 산출용. 지역·기간을 공유하는 여러 (주거유형, 거래유형) 조합을 단일 왕복으로 조회한다.
+     * area는 SIZE_BUCKETS 5개 구간의 합집합만 반환하고, 조합별 버킷 분리는 서비스에서 처리한다.
+     * 조합별로 개별 쿼리를 40회 돌리던 것을 1회 스캔으로 대체해 콜드 캐시 응답 시간을 크게 낮춘다.
+     */
+    List<PriceModelBatchRow> findAmountsForPriceModelBatch(
+            @Param("regionCode") String regionCode,
+            @Param("typePairs") List<TypeDealPair> typePairs,
+            @Param("startYm") String startYm,
+            @Param("endYm") String endYm);
 }

--- a/src/main/java/com/team/independence/property/service/PriceModelService.java
+++ b/src/main/java/com/team/independence/property/service/PriceModelService.java
@@ -1,7 +1,10 @@
 package com.team.independence.property.service;
 
+import com.team.independence.property.dto.PriceModelKey;
 import com.team.independence.property.dto.PriceModelRequest;
 import com.team.independence.property.dto.PriceModelResponse;
+import java.util.Collection;
+import java.util.Map;
 
 public interface PriceModelService {
 
@@ -9,4 +12,13 @@ public interface PriceModelService {
      * 지역 / 유형 / 면적 조건에 맞는 최근 36개월 실거래 시계열에서 연간 성장률(μ)과 연율 변동성(σ)을 추정
      */
     PriceModelResponse estimate(PriceModelRequest request);
+
+    /**
+     * 같은 지역·기간을 공유하는 여러 조합의 PriceModel을 한 번에 계산한다.
+     * Redis 캐시 히트는 그대로 재사용하고, 미스 조합만 골라 단일 DB 왕복으로 raw 행을 뽑는다.
+     * RealisticAlgorithm·HoldOutAlgorithm이 40조합을 준비할 때 콜드 캐시 왕복을 40 → 1로 접는 지점.
+     *
+     * <p>표본이 부족한 조합은 결과 맵에서 제외되므로, 호출자는 map.get(key) == null을 스킵으로 처리하면 된다.
+     */
+    Map<PriceModelKey, PriceModelResponse> estimateBatch(String regionCode, Collection<PriceModelKey> keys);
 }

--- a/src/main/java/com/team/independence/property/service/PriceModelServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/PriceModelServiceImpl.java
@@ -3,20 +3,30 @@ package com.team.independence.property.service;
 import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.property.dto.MonthlyPricePoint;
+import com.team.independence.property.dto.PriceModelBatchRow;
+import com.team.independence.property.dto.PriceModelKey;
 import com.team.independence.property.dto.PriceModelRequest;
 import com.team.independence.property.dto.PriceModelResponse;
+import com.team.independence.property.dto.TypeDealPair;
 import com.team.independence.property.mapper.RegionMapper;
 import com.team.independence.property.mapper.RentTransactionMapper;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PriceModelServiceImpl implements PriceModelService {
@@ -87,6 +97,135 @@ public class PriceModelServiceImpl implements PriceModelService {
                 .build();
         priceModelStore.save(request, response);
         return response;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<PriceModelKey, PriceModelResponse> estimateBatch(
+            String regionCode, Collection<PriceModelKey> keys) {
+
+        Map<PriceModelKey, PriceModelResponse> result = new HashMap<>();
+        if (keys == null || keys.isEmpty()) {
+            return result;
+        }
+
+        // 1) 캐시 조회 — 히트분은 즉시 결과에 담고, 미스만 다음 단계로 넘긴다.
+        List<PriceModelKey> misses = new ArrayList<>();
+        for (PriceModelKey key : keys) {
+            PriceModelRequest req = toRequest(regionCode, key);
+            Optional<PriceModelResponse> cached = priceModelStore.find(req);
+            if (cached.isPresent()) {
+                result.put(key, cached.get());
+            } else {
+                misses.add(key);
+            }
+        }
+        if (misses.isEmpty()) {
+            return result;
+        }
+
+        // 2) 미스 조합의 (housing_type, deal_type) 유니크 쌍만 뽑아 단일 배치 쿼리.
+        //    같은 (ht, dt)의 여러 area 버킷은 한 번의 인덱스 서브레인지 스캔에서 함께 딸려 나온다.
+        String regionName = regionMapper.findFullNameByCode(regionCode);
+        if (regionName == null) {
+            throw new BusinessException(ErrorCode.REGION_NOT_FOUND);
+        }
+
+        YearMonth end = YearMonth.now();
+        YearMonth start = end.minusMonths(WINDOW_MONTHS - 1);
+        String startYm = start.format(YM);
+        String endYm = end.format(YM);
+
+        Set<TypeDealPair> pairSet = new HashSet<>();
+        for (PriceModelKey k : misses) {
+            pairSet.add(new TypeDealPair(k.housingType(), k.dealType()));
+        }
+        List<TypeDealPair> typePairs = new ArrayList<>(pairSet);
+
+        List<PriceModelBatchRow> rows = rentTransactionMapper.findAmountsForPriceModelBatch(
+                regionCode, typePairs, startYm, endYm);
+
+        // 3) 조합 키(ht|dt|areaMin|areaMax)별로 행을 재그룹핑한다. area는 SIZE_BUCKETS 하드코딩 경계와 정확히 일치.
+        Map<PriceModelKey, List<MonthlyPricePoint>> perKey = new HashMap<>();
+        for (PriceModelKey miss : misses) {
+            perKey.put(miss, new ArrayList<>());
+        }
+        for (PriceModelBatchRow row : rows) {
+            PriceModelKey routingKey = routeToKey(row, misses);
+            if (routingKey == null) continue;
+            perKey.get(routingKey).add(new MonthlyPricePoint(
+                    row.getDealYm(), row.getDeposit(), row.getArea()));
+        }
+
+        // 4) 조합별로 PriceModel.estimate → 캐시 저장 → 결과 맵에 담기.
+        for (PriceModelKey miss : misses) {
+            List<MonthlyPricePoint> raw = perKey.get(miss);
+            PriceModelResponse response = buildPriceModel(regionCode, regionName, miss, raw, startYm, endYm);
+            if (response == null) {
+                // 표본 부족은 배치에서는 예외를 던지지 않고 스킵한다. 호출자는 null을 폴백 신호로 쓴다.
+                continue;
+            }
+            priceModelStore.save(toRequest(regionCode, miss), response);
+            result.put(miss, response);
+        }
+        return result;
+    }
+
+    /** 배치 행 하나를 (housingType, dealType, area 버킷) 기준으로 미스 키 중 어디에 속하는지 매핑. */
+    private PriceModelKey routeToKey(PriceModelBatchRow row, List<PriceModelKey> misses) {
+        double areaSqm = row.getArea().doubleValue();
+        for (PriceModelKey k : misses) {
+            if (k.housingType() != row.getHousingType()) continue;
+            if (k.dealType() != row.getDealType()) continue;
+            double minSqm = toSqm(k.areaMin());
+            double maxSqm = toSqm(k.areaMax());
+            if (areaSqm >= minSqm && areaSqm <= maxSqm) {
+                return k;
+            }
+        }
+        return null;
+    }
+
+    /** 배치 조합의 raw 행에서 월별 median 시계열을 만들고 PriceModel.estimate. 표본이 부족하면 null. */
+    private PriceModelResponse buildPriceModel(
+            String regionCode, String regionName, PriceModelKey key,
+            List<MonthlyPricePoint> raw, String startYm, String endYm) {
+
+        List<Double> monthlyMedians = raw.stream()
+                .collect(Collectors.groupingBy(MonthlyPricePoint::getDealYm))
+                .entrySet().stream()
+                .filter(e -> e.getValue().size() >= MIN_SAMPLES_PER_MONTH)
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> medianPerPyeong(e.getValue()))
+                .collect(Collectors.toList());
+
+        if (monthlyMedians.size() < MIN_VALID_MONTHS) {
+            return null;
+        }
+
+        PriceModel model = PriceModel.estimate(monthlyMedians);
+        return PriceModelResponse.builder()
+                .regionCode(regionCode)
+                .regionName(regionName)
+                .housingType(key.housingType())
+                .dealType(key.dealType())
+                .annualDrift(model.annualDrift())
+                .cagr(model.cagr())
+                .annualVol(model.annualVol())
+                .months(model.months())
+                .startYm(startYm)
+                .endYm(endYm)
+                .build();
+    }
+
+    private PriceModelRequest toRequest(String regionCode, PriceModelKey key) {
+        PriceModelRequest req = new PriceModelRequest();
+        req.setRegionCode(regionCode);
+        req.setHousingType(key.housingType());
+        req.setDealType(key.dealType());
+        req.setAreaMin(key.areaMin());
+        req.setAreaMax(key.areaMax());
+        return req;
     }
 
     /** 한 달치 거래 목록에서 평당 보증금(원/평)의 중앙값을 반환 */

--- a/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
@@ -10,6 +10,8 @@ import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.dto.RentMedianResponse.Quartile;
 import com.team.independence.property.dto.SigunguMedianResult;
+import com.team.independence.property.dto.TypeDealPair;
+import java.util.ArrayList;
 import com.team.independence.property.mapper.RegionMapper;
 import com.team.independence.property.mapper.RentTransactionMapper;
 import java.time.YearMonth;
@@ -83,31 +85,35 @@ public class RentMedianServiceImpl implements RentMedianService {
             throw new BusinessException(ErrorCode.REGION_NOT_FOUND);
         }
 
-        // (주거유형, 거래유형) 조합별로 개별 쿼리를 실행해 idx_rent_query 인덱스를 탄다.
-        // 단일 bulk 쿼리 대비 처리 행 수가 1/8로 줄어 윈도우 함수 비용이 크게 감소한다.
-        Map<String, RentMedianResponse> result = new HashMap<>();
-        for (HousingType housingType : HousingType.values()) {
-            for (DealType dealType : DealType.values()) {
-                List<BulkMedianResult> rows = rentTransactionMapper.findBulkMedianByType(
-                        regionCode, housingType, dealType, startYm, endYm);
-                for (BulkMedianResult r : rows) {
-                    String key = housingType + "|" + dealType + "|" + r.getAreaMin();
-                    RentMedianResponse response = RentMedianResponse.builder()
-                            .regionCode(regionCode)
-                            .regionName(regionName)
-                            .housingType(housingType)
-                            .dealType(dealType)
-                            .baseStartYm(startYm)
-                            .baseEndYm(endYm)
-                            .sampleCount(r.getSampleCount())
-                            .deposit(Quartile.of(r.getDepositQ1(), r.getDepositQ2(), r.getDepositQ3()))
-                            .monthlyRent(r.getRentQ2() != null
-                                    ? Quartile.of(r.getRentQ1(), r.getRentQ2(), r.getRentQ3())
-                                    : Quartile.empty())
-                            .build();
-                    result.put(key, response);
-                }
+        // 4 × 2 = 8개 (주거유형, 거래유형) 쌍을 한 왕복으로 조회한다.
+        // (housing_type, deal_type) IN (...)이 idx_rent_query 서브레인지 스캔을 조합별로 그대로 태우므로
+        // 처리 행 수는 8회 개별 쿼리 합과 동일하고, 왕복·파서·옵티마이저 오버헤드만 사라진다.
+        List<TypeDealPair> typePairs = new ArrayList<>(HousingType.values().length * DealType.values().length);
+        for (HousingType ht : HousingType.values()) {
+            for (DealType dt : DealType.values()) {
+                typePairs.add(new TypeDealPair(ht, dt));
             }
+        }
+        List<BulkMedianResult> rows = rentTransactionMapper.findBulkMedianBatch(
+                regionCode, typePairs, startYm, endYm);
+
+        Map<String, RentMedianResponse> result = new HashMap<>();
+        for (BulkMedianResult r : rows) {
+            String key = r.getHousingType() + "|" + r.getDealType() + "|" + r.getAreaMin();
+            RentMedianResponse response = RentMedianResponse.builder()
+                    .regionCode(regionCode)
+                    .regionName(regionName)
+                    .housingType(r.getHousingType())
+                    .dealType(r.getDealType())
+                    .baseStartYm(startYm)
+                    .baseEndYm(endYm)
+                    .sampleCount(r.getSampleCount())
+                    .deposit(Quartile.of(r.getDepositQ1(), r.getDepositQ2(), r.getDepositQ3()))
+                    .monthlyRent(r.getRentQ2() != null
+                            ? Quartile.of(r.getRentQ1(), r.getRentQ2(), r.getRentQ3())
+                            : Quartile.empty())
+                    .build();
+            result.put(key, response);
         }
         return result;
     }

--- a/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
+++ b/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
@@ -54,6 +54,28 @@
          ORDER BY deal_ym
     </select>
 
+    <!-- 배치 PriceModel 조회: (주거유형, 거래유형) 쌍 목록 + 지역·기간을 받아 5개 SIZE_BUCKETS 합집합에
+         해당하는 원본 (deal_ym, deposit, area) 행을 한 번에 반환한다. 조합별 버킷 분리·월별 중앙값 산출은
+         서비스에서 한다. RealisticAlgorithm·HoldOutAlgorithm이 40조합 × 개별 쿼리 대신 이 한 방으로 대체.
+         (housing_type, deal_type)를 IN으로 묶으면 idx_rent_query를 조합별 서브레인지로 그대로 탄다. -->
+    <select id="findAmountsForPriceModelBatch" resultType="com.team.independence.property.dto.PriceModelBatchRow">
+        SELECT housing_type, deal_type, deal_ym, deposit, area
+          FROM rent_transaction
+         WHERE region_code = #{regionCode}
+           AND (housing_type, deal_type) IN
+               <foreach collection="typePairs" item="p" open="(" separator="," close=")">
+                   (#{p.housingType}, #{p.dealType})
+               </foreach>
+           AND deal_ym BETWEEN #{startYm} AND #{endYm}
+           AND deposit &gt; 0
+           AND (   area BETWEEN 13 AND 29
+                OR area BETWEEN 33 AND 46
+                OR area BETWEEN 49 AND 62
+                OR area BETWEEN 66 AND 82
+                OR area BETWEEN 85 AND 132)
+         ORDER BY deal_ym
+    </select>
+
     <!-- MySQL 8.0 윈도우 함수로 분위값을 DB에서 직접 계산해 1행으로 반환한다.
          deposit = 0 이상치 제외. 조건에 맞는 데이터가 없으면 sampleCount=null인 1행이 반환된다. -->
     <select id="findAggregatedMedian" resultType="com.team.independence.property.dto.MedianAggResult">
@@ -129,16 +151,17 @@
          GROUP BY region_code
     </select>
 
-    <!-- bulk 쿼리. 지역·기간·주거유형·거래유형을 받아 평수버킷별 분위값을 반환.
-         housing_type, deal_type를 WHERE에 추가해 idx_rent_query 인덱스를 타도록 한다.
+    <!-- 배치 bulk median: 지역·기간을 공유하는 여러 (주거유형, 거래유형) 쌍을 한 번에 조회한다.
+         (housing_type, deal_type) IN (...)이 idx_rent_query 서브레인지를 조합별로 그대로 태우므로
+         이전 8쿼리 순차 방식과 처리 행 수는 동일하고 왕복 오버헤드만 사라진다.
          평수 버킷 경계(평 → ㎡ floor 환산): 4p=13, 9p=29 / 10p=33, 14p=46 / 15p=49, 19p=62
                                               20p=66, 25p=82 / 26p=85, 40p=132
          버킷 사이 공백(area 30-32, 47-48, 63-65, 83-84)은 WHERE 절에서 제외한다. -->
-    <select id="findBulkMedianByType" resultType="com.team.independence.property.dto.BulkMedianResult">
+    <select id="findBulkMedianBatch" resultType="com.team.independence.property.dto.BulkMedianResult">
         SELECT
-            #{housingType}  AS housing_type,
-            #{dealType}     AS deal_type,
-            bucket_min      AS area_min,
+            housing_type,
+            deal_type,
+            bucket_min AS area_min,
             CASE bucket_min
                 WHEN 4  THEN 9  WHEN 10 THEN 14 WHEN 15 THEN 19
                 WHEN 20 THEN 25 WHEN 26 THEN 40
@@ -152,7 +175,7 @@
             MAX(total) AS sample_count
         FROM (
             SELECT
-                deposit, monthly_rent,
+                housing_type, deal_type, deposit, monthly_rent,
                 CASE
                     WHEN area BETWEEN 13 AND 29  THEN 4
                     WHEN area BETWEEN 33 AND 46  THEN 10
@@ -161,7 +184,7 @@
                     WHEN area BETWEEN 85 AND 132 THEN 26
                 END AS bucket_min,
                 ROW_NUMBER() OVER (
-                    PARTITION BY
+                    PARTITION BY housing_type, deal_type,
                         CASE WHEN area BETWEEN 13 AND 29  THEN 4
                              WHEN area BETWEEN 33 AND 46  THEN 10
                              WHEN area BETWEEN 49 AND 62  THEN 15
@@ -171,7 +194,7 @@
                     ORDER BY deposit
                 ) AS dep_rn,
                 ROW_NUMBER() OVER (
-                    PARTITION BY
+                    PARTITION BY housing_type, deal_type,
                         CASE WHEN area BETWEEN 13 AND 29  THEN 4
                              WHEN area BETWEEN 33 AND 46  THEN 10
                              WHEN area BETWEEN 49 AND 62  THEN 15
@@ -181,7 +204,7 @@
                     ORDER BY monthly_rent
                 ) AS rent_rn,
                 COUNT(*) OVER (
-                    PARTITION BY
+                    PARTITION BY housing_type, deal_type,
                         CASE WHEN area BETWEEN 13 AND 29  THEN 4
                              WHEN area BETWEEN 33 AND 46  THEN 10
                              WHEN area BETWEEN 49 AND 62  THEN 15
@@ -198,8 +221,10 @@
              WHERE region_code = #{regionCode}
                 </otherwise>
             </choose>
-               AND housing_type = #{housingType}
-               AND deal_type    = #{dealType}
+               AND (housing_type, deal_type) IN
+                   <foreach collection="typePairs" item="p" open="(" separator="," close=")">
+                       (#{p.housingType}, #{p.dealType})
+                   </foreach>
                AND deposit &gt; 0
                AND deal_ym BETWEEN #{startYm} AND #{endYm}
                AND (   area BETWEEN 13 AND 29
@@ -208,7 +233,7 @@
                     OR area BETWEEN 66 AND 82
                     OR area BETWEEN 85 AND 132)
         ) t
-        GROUP BY bucket_min
+        GROUP BY housing_type, deal_type, bucket_min
     </select>
 
 </mapper>

--- a/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/HoldOutAlgorithmTest.java
@@ -21,9 +21,11 @@ import com.team.independence.goal.service.calculator.LoanPlanCalculator;
 import com.team.independence.goal.service.calculator.LoanSchedule;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
-import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.property.dto.PriceModelKey;
+import com.team.independence.property.dto.PriceModelResponse;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.dto.RentMedianResponse.Quartile;
+import com.team.independence.property.service.PriceModelService;
 import com.team.independence.property.service.RentMedianService;
 import java.time.YearMonth;
 import java.util.HashMap;
@@ -67,6 +69,7 @@ class HoldOutAlgorithmTest {
     @Mock private LoanPlanCalculator loanPlanCalculator;
     @Mock private RentMedianService rentMedianService;
     @Mock private MonteCarloService monteCarloService;
+    @Mock private PriceModelService priceModelService;
 
     private final BudgetCalculator budgetCalculator = new BudgetCalculator();
 
@@ -80,15 +83,31 @@ class HoldOutAlgorithmTest {
     @BeforeEach
     void setUp() {
         algorithm = new HoldOutAlgorithm(
-                loanPlanCalculator, budgetCalculator, rentMedianService, monteCarloService);
+                loanPlanCalculator, budgetCalculator, rentMedianService, monteCarloService, priceModelService);
 
         // MC는 P50 = 입력 가격 그대로 반환 (가격 변동 없음으로 고정)
-        when(monteCarloService.simulate(any(PriceModelRequest.class), anyLong(), anyLong(), anyInt()))
+        when(monteCarloService.simulate(any(PriceModelResponse.class), anyLong(), anyLong(), anyInt()))
                 .thenAnswer(call -> {
                     long price = call.getArgument(1);
                     long budget = call.getArgument(2);
                     double prob = budget >= price ? 0.8 : 0.2;
                     return new MonteCarloEngine.Result(price * 9 / 10, price, price * 11 / 10, prob);
+                });
+
+        // 배치 PriceModel: 모든 조합에 대해 임의의 PriceModelResponse를 반환 (MC 스텁이 이 값을 실제로 쓰지 않음)
+        when(priceModelService.estimateBatch(anyString(), any()))
+                .thenAnswer(call -> {
+                    Iterable<PriceModelKey> keys = call.getArgument(1);
+                    Map<PriceModelKey, PriceModelResponse> result = new HashMap<>();
+                    for (PriceModelKey k : keys) {
+                        result.put(k, PriceModelResponse.builder()
+                                .regionCode(call.getArgument(0))
+                                .housingType(k.housingType())
+                                .dealType(k.dealType())
+                                .annualDrift(0.0).cagr(0.0).annualVol(0.0)
+                                .months(12).build());
+                    }
+                    return result;
                 });
 
         market = new HashMap<>();

--- a/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
@@ -23,12 +23,14 @@ import com.team.independence.goal.service.calculator.LoanPlanCalculator;
 import com.team.independence.goal.service.calculator.LoanSchedule;
 import com.team.independence.property.domain.DealType;
 import com.team.independence.property.domain.HousingType;
-import com.team.independence.property.dto.PriceModelRequest;
+import com.team.independence.property.dto.PriceModelKey;
+import com.team.independence.property.dto.PriceModelResponse;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.dto.RentMedianResponse.Quartile;
 import com.team.independence.property.dto.SigunguMedianResult;
 import com.team.independence.property.mapper.RegionMapper;
+import com.team.independence.property.service.PriceModelService;
 import com.team.independence.property.service.RentMedianService;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -72,6 +74,8 @@ class RealisticAlgorithmTest {
     private BudgetCalculator budgetCalculator;
     @Mock
     private MonteCarloService monteCarloService;
+    @Mock
+    private PriceModelService priceModelService;
 
     private RealisticAlgorithm algorithm;
     private AssetNetWorthBreakdown defaultNetWorth;
@@ -87,7 +91,7 @@ class RealisticAlgorithmTest {
     void setUp() {
         algorithm = new RealisticAlgorithm(
                 rentMedianService, regionMapper, loanPlanCalculator,
-                budgetCalculator, monteCarloService);
+                budgetCalculator, monteCarloService, priceModelService);
         market = new HashMap<>();
         lookedUp = new ArrayList<>();
 
@@ -98,10 +102,27 @@ class RealisticAlgorithmTest {
         ctx = new MemberFinancialContext(defaultNetWorth, MONTHLY_SAVING, List.of());
 
         // MC: 가격 변화 없음으로 스텁. 선택 로직이 가려지지 않게 priceP50 = initialPrice 반환.
-        when(monteCarloService.simulate(any(PriceModelRequest.class), anyLong(), anyLong(), anyInt()))
+        when(monteCarloService.simulate(any(PriceModelResponse.class), anyLong(), anyLong(), anyInt()))
                 .thenAnswer(call -> {
                     long initialPrice = call.getArgument(1);
                     return new MonteCarloEngine.Result(initialPrice, initialPrice, initialPrice, 1.0);
+                });
+
+        // 배치 PriceModel: 요청 조합마다 임의의 PriceModelResponse를 반환 (MC 스텁이 이 값을 실제로 쓰지 않음)
+        when(priceModelService.estimateBatch(any(), any()))
+                .thenAnswer(call -> {
+                    String region = call.getArgument(0);
+                    Iterable<PriceModelKey> keys = call.getArgument(1);
+                    Map<PriceModelKey, PriceModelResponse> result = new HashMap<>();
+                    for (PriceModelKey k : keys) {
+                        result.put(k, PriceModelResponse.builder()
+                                .regionCode(region)
+                                .housingType(k.housingType())
+                                .dealType(k.dealType())
+                                .annualDrift(0.0).cagr(0.0).annualVol(0.0)
+                                .months(12).build());
+                    }
+                    return result;
                 });
 
         // BudgetCalculator.monthsToReach: 목표액 ÷ 월저축액 (복리 계산 대신 단순 나눗셈)


### PR DESCRIPTION
## #️⃣연관된 이슈

- #155

## 📝작업 내용

추천 알고리즘의 DB 왕복을 대폭 줄이는 배치 조회 최적화입니다.

### 문제

`RealisticAlgorithm` / `HoldOutAlgorithm`이 주거유형(4) × 거래유형(2) × 평수 버킷(5) = 최대 **40가지 조합**의 PriceModel을 조합마다 개별 `estimate()` 로 호출 → 콜드 캐시 시 **DB 40회 왕복** 발생.
`getBulkMedian`도 (주거유형, 거래유형) 쌍을 순회하며 `findBulkMedianByType` **8회 호출**.

### 해결

| 변경 전 | 변경 후 |
|---|---|
| `estimate()` 조합별 40회 호출 | `estimateBatch()` 1회 — 캐시 히트는 Redis, 미스만 단일 DB 왕복 |
| `findBulkMedianByType` 8회 순차 | `findBulkMedianBatch` 1회 — `(housing_type, deal_type) IN (...)` |

### 주요 변경 파일

**DTO (신규)**
- `PriceModelKey` — `(housingType, dealType, areaMin, areaMax)` 조합 키
- `PriceModelBatchRow` — 배치 쿼리 원본 행 프로젝션
- `TypeDealPair` — MyBatis IN 절 파라미터용 레코드

**DB 레이어**
- `RentTransactionMapper` — `findBulkMedianBatch`, `findAmountsForPriceModelBatch` 추가 / `findBulkMedianByType` 제거
- `RentTransactionMapper.xml` — 동일

**서비스 레이어**
- `PriceModelService/Impl` — `estimateBatch()` 추가 (캐시 히트 선조회 → 미스만 배치 DB 왕복 → 캐시 저장)
- `MonteCarloService/Impl` — `simulate(PriceModelResponse, ...)` 오버로드 추가 (중간 estimate 재호출 제거)
- `RentMedianServiceImpl` — `getBulkMedian` 단일 배치 쿼리로 전환

**알고리즘**
- `RealisticAlgorithm` / `HoldOutAlgorithm` — 진입 시점에 `estimateBatch()`로 전체 조합 사전 준비, 평가 루프는 맵에서 꺼내 사용
- `RecommendationAlgorithm.MemberFinancialContext` — 알고리즘 간 `bulkMediansCache` 공유 필드 추가

**테스트**
- `RealisticAlgorithmTest` / `HoldOutAlgorithmTest` — `PriceModelService` mock 추가, `estimateBatch()` 스텁 및 `simulate()` 시그니처 변경 반영

## 💬리뷰 요구사항(선택)