### PR TITLE
feat: 또래 비교 집계 결과 Redis 캐시 적용

### DIFF
--- a/src/main/java/com/team/independence/compare/dto/AssetCohortStats.java
+++ b/src/main/java/com/team/independence/compare/dto/AssetCohortStats.java
@@ -1,0 +1,28 @@
+package com.team.independence.compare.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** 자산 비교 코호트 집계 결과 묶음. CompareCacheStore 직렬화 대상 */
+@Getter
+@Setter
+@NoArgsConstructor
+public class AssetCohortStats {
+
+    private int cohortSize;
+    private CohortAverages averages;
+    private SavingRangeResult savingRange;
+    private List<IncomeBracketCount> incomeBracketCounts;
+    private List<OccupationTypeCount> occupationTypeCounts;
+
+    public AssetCohortStats(int cohortSize, CohortAverages averages, SavingRangeResult savingRange,
+            List<IncomeBracketCount> incomeBracketCounts, List<OccupationTypeCount> occupationTypeCounts) {
+        this.cohortSize = cohortSize;
+        this.averages = averages;
+        this.savingRange = savingRange;
+        this.incomeBracketCounts = incomeBracketCounts;
+        this.occupationTypeCounts = occupationTypeCounts;
+    }
+}

--- a/src/main/java/com/team/independence/compare/dto/GoalCohortStats.java
+++ b/src/main/java/com/team/independence/compare/dto/GoalCohortStats.java
@@ -1,0 +1,29 @@
+package com.team.independence.compare.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** 목표 비교 코호트 집계 결과 묶음. CompareCacheStore 직렬화 대상 */
+@Getter
+@Setter
+@NoArgsConstructor
+public class GoalCohortStats {
+
+    private int cohortSize;
+    private CohortAverages averages;
+    private List<DealTypeCount> dealTypeCounts;
+    private List<RegionCount> regionCounts;
+    private List<AchievementBucketCount> achievementBucketCounts;
+
+    public GoalCohortStats(int cohortSize, CohortAverages averages,
+            List<DealTypeCount> dealTypeCounts, List<RegionCount> regionCounts,
+            List<AchievementBucketCount> achievementBucketCounts) {
+        this.cohortSize = cohortSize;
+        this.averages = averages;
+        this.dealTypeCounts = dealTypeCounts;
+        this.regionCounts = regionCounts;
+        this.achievementBucketCounts = achievementBucketCounts;
+    }
+}

--- a/src/main/java/com/team/independence/compare/service/CompareCacheStore.java
+++ b/src/main/java/com/team/independence/compare/service/CompareCacheStore.java
@@ -1,0 +1,106 @@
+package com.team.independence.compare.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.independence.compare.dto.AssetCohortStats;
+import com.team.independence.compare.dto.CohortCondition;
+import com.team.independence.compare.dto.GoalCohortStats;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 또래 비교 코호트 집계 결과를 Redis에 캐싱한다.
+ *
+ * Key 구조: compare:{type}:v1:{snapshotYm}:{netAssetsMin}:{netAssetsMax}:{ageMin}:{ageMax}:{incomeMin}:{incomeMax}:{occ}
+ * TTL: 24시간. goal_snapshot은 매월 1일 배치로 갱신되므로 하루면 충분하다.
+ *
+ * 배치 완료 시 {@link #evictAll()}로 compare:* 전체를 무효화한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CompareCacheStore {
+
+    private static final String ASSETS_PREFIX = "compare:assets:v1:";
+    private static final String GOALS_PREFIX = "compare:goals:v1:";
+    private static final String EVICT_PATTERN = "compare:*";
+    private static final Duration TTL = Duration.ofHours(24);
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public Optional<AssetCohortStats> findAssetStats(CohortCondition condition) {
+        String json = redisTemplate.opsForValue().get(assetKey(condition));
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(json, AssetCohortStats.class));
+        } catch (JsonProcessingException e) {
+            log.warn("[비교 캐시] 자산 역직렬화 실패, 캐시 미스로 처리: key={}", assetKey(condition), e);
+            return Optional.empty();
+        }
+    }
+
+    public void saveAssetStats(CohortCondition condition, AssetCohortStats stats) {
+        try {
+            redisTemplate.opsForValue().set(assetKey(condition), objectMapper.writeValueAsString(stats), TTL);
+        } catch (JsonProcessingException e) {
+            log.warn("[비교 캐시] 자산 직렬화 실패, 캐싱 건너뜀: key={}", assetKey(condition), e);
+        }
+    }
+
+    public Optional<GoalCohortStats> findGoalStats(CohortCondition condition) {
+        String json = redisTemplate.opsForValue().get(goalKey(condition));
+        if (json == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(json, GoalCohortStats.class));
+        } catch (JsonProcessingException e) {
+            log.warn("[비교 캐시] 목표 역직렬화 실패, 캐시 미스로 처리: key={}", goalKey(condition), e);
+            return Optional.empty();
+        }
+    }
+
+    public void saveGoalStats(CohortCondition condition, GoalCohortStats stats) {
+        try {
+            redisTemplate.opsForValue().set(goalKey(condition), objectMapper.writeValueAsString(stats), TTL);
+        } catch (JsonProcessingException e) {
+            log.warn("[비교 캐시] 목표 직렬화 실패, 캐싱 건너뜀: key={}", goalKey(condition), e);
+        }
+    }
+
+    /** goal_snapshot 배치 완료 후 호출. 스냅샷이 교체됐으므로 compare 캐시 전체를 무효화한다. */
+    public void evictAll() {
+        Set<String> keys = redisTemplate.keys(EVICT_PATTERN);
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+            log.info("[비교 캐시] 배치 완료 후 캐시 전체 삭제. {}건", keys.size());
+        }
+    }
+
+    private String assetKey(CohortCondition c) {
+        return ASSETS_PREFIX + conditionSuffix(c);
+    }
+
+    private String goalKey(CohortCondition c) {
+        return GOALS_PREFIX + conditionSuffix(c);
+    }
+
+    private String conditionSuffix(CohortCondition c) {
+        return c.getSnapshotYm()
+                + ":" + c.getNetAssetsMin()
+                + ":" + c.getNetAssetsMax()
+                + ":" + c.getAgeMin()
+                + ":" + c.getAgeMax()
+                + ":" + c.getMonthlyIncomeMin()
+                + ":" + c.getMonthlyIncomeMax()
+                + ":" + c.getOccupationType();
+    }
+}

--- a/src/main/java/com/team/independence/compare/service/CompareServiceImpl.java
+++ b/src/main/java/com/team/independence/compare/service/CompareServiceImpl.java
@@ -16,12 +16,14 @@ import com.team.independence.compare.domain.CohortType;
 import com.team.independence.compare.domain.GoalSnapshot;
 import com.team.independence.compare.domain.MonthlyIncomeBracket;
 import com.team.independence.compare.dto.AchievementBucketCount;
+import com.team.independence.compare.dto.AssetCohortStats;
 import com.team.independence.compare.dto.AssetCompareResponse;
 import com.team.independence.compare.dto.CompareRequest;
 import com.team.independence.compare.dto.CohortAverages;
 import com.team.independence.compare.dto.CohortCondition;
 import com.team.independence.compare.dto.CompareCohort;
 import com.team.independence.compare.dto.CompareResponse;
+import com.team.independence.compare.dto.GoalCohortStats;
 import com.team.independence.compare.dto.CompareResponse.AchievementBucket;
 import com.team.independence.compare.dto.CompareResponse.AchievementDistribution;
 import com.team.independence.compare.dto.CompareResponse.Cohort;
@@ -79,6 +81,7 @@ public class CompareServiceImpl implements CompareService {
 
     private final GoalSnapshotMapper goalSnapshotMapper;
     private final AgreementService agreementService;
+    private final CompareCacheStore compareCacheStore;
 
     /** 자산 비교 */
     @Override
@@ -95,31 +98,41 @@ public class CompareServiceImpl implements CompareService {
 
         List<CohortType> applied = resolveApplied(request.getCohortTypes());
         CohortCondition condition = buildCondition(snapshotYm, me, request.getAssetRange(), request.getAgeRange(), applied);
-        int cohortSize = goalSnapshotMapper.countCohort(condition);
-        if (cohortSize < MINIMUM_COHORT_SIZE) {
+
+        AssetCohortStats stats = compareCacheStore.findAssetStats(condition).orElseGet(() -> {
+            int size = goalSnapshotMapper.countCohort(condition);
+            if (size < MINIMUM_COHORT_SIZE) {
+                return new AssetCohortStats(size, null, null, null, null);
+            }
+            AssetCohortStats fresh = new AssetCohortStats(
+                    size,
+                    goalSnapshotMapper.findAverages(condition),
+                    goalSnapshotMapper.findSavingRange(condition),
+                    goalSnapshotMapper.countByIncomeBracket(condition),
+                    goalSnapshotMapper.countByOccupationType(condition));
+            compareCacheStore.saveAssetStats(condition, fresh);
+            return fresh;
+        });
+
+        if (stats.getCohortSize() < MINIMUM_COHORT_SIZE) {
             return AssetCompareResponse.builder()
                     .snapshotYm(snapshotYm)
-                    .cohort(buildCohort(request.getAssetRange(), request.getAgeRange(), cohortSize, applied, false))
+                    .cohort(buildCohort(request.getAssetRange(), request.getAgeRange(), stats.getCohortSize(), applied, false))
                     .build();
         }
 
-        CohortAverages averages = goalSnapshotMapper.findAverages(condition);
-        SavingRangeResult savingRange = goalSnapshotMapper.findSavingRange(condition);
-        List<IncomeBracketCount> incomeCounts = goalSnapshotMapper.countByIncomeBracket(condition);
-        List<OccupationTypeCount> occupationCounts = goalSnapshotMapper.countByOccupationType(condition);
-
         return AssetCompareResponse.builder()
                 .snapshotYm(snapshotYm)
-                .cohort(buildCohort(request.getAssetRange(), request.getAgeRange(), cohortSize, applied, true))
+                .cohort(buildCohort(request.getAssetRange(), request.getAgeRange(), stats.getCohortSize(), applied, true))
                 .myMonthlyIncome(me.getMonthlyIncome())
-                .cohortAverageNetAssets(averages.getAverageNetAssets())
+                .cohortAverageNetAssets(stats.getAverages().getAverageNetAssets())
                 .saving(AssetCompareResponse.Saving.builder()
                         .mine(me.getMonthlySaving())
-                        .cohortMin(savingRange.getCohortRangeMin())
-                        .cohortMax(savingRange.getCohortRangeMax())
+                        .cohortMin(stats.getSavingRange().getCohortRangeMin())
+                        .cohortMax(stats.getSavingRange().getCohortRangeMax())
                         .build())
-                .incomeBracketDistribution(toIncomeBracketItems(incomeCounts, cohortSize))
-                .occupationDistribution(toOccupationItems(occupationCounts, cohortSize))
+                .incomeBracketDistribution(toIncomeBracketItems(stats.getIncomeBracketCounts(), stats.getCohortSize()))
+                .occupationDistribution(toOccupationItems(stats.getOccupationTypeCounts(), stats.getCohortSize()))
                 .build();
     }
 
@@ -140,33 +153,43 @@ public class CompareServiceImpl implements CompareService {
 
         List<CohortType> applied = resolveApplied(request.getCohortTypes());
         CohortCondition condition = buildCondition(snapshotYm, me, request.getAssetRange(), request.getAgeRange(), applied);
-        int cohortSize = goalSnapshotMapper.countCohort(condition);
-        if (cohortSize < MINIMUM_COHORT_SIZE) {
+
+        GoalCohortStats stats = compareCacheStore.findGoalStats(condition).orElseGet(() -> {
+            int size = goalSnapshotMapper.countCohort(condition);
+            if (size < MINIMUM_COHORT_SIZE) {
+                return new GoalCohortStats(size, null, null, null, null);
+            }
+            GoalCohortStats fresh = new GoalCohortStats(
+                    size,
+                    goalSnapshotMapper.findAverages(condition),
+                    goalSnapshotMapper.countByDealType(condition),
+                    goalSnapshotMapper.countTopRegions(condition),
+                    goalSnapshotMapper.countByAchievementBucket(condition));
+            compareCacheStore.saveGoalStats(condition, fresh);
+            return fresh;
+        });
+
+        if (stats.getCohortSize() < MINIMUM_COHORT_SIZE) {
             return GoalCompareResponse.builder()
                     .snapshotYm(snapshotYm)
-                    .cohort(buildCohort(request.getAssetRange(), request.getAgeRange(), cohortSize, applied, false))
+                    .cohort(buildCohort(request.getAssetRange(), request.getAgeRange(), stats.getCohortSize(), applied, false))
                     .build();
         }
 
-        CohortAverages averages = goalSnapshotMapper.findAverages(condition);
-        List<DealTypeCount> dealTypeCounts = goalSnapshotMapper.countByDealType(condition);
-        List<RegionCount> regionCounts = goalSnapshotMapper.countTopRegions(condition);
-        List<AchievementBucketCount> bucketCounts = goalSnapshotMapper.countByAchievementBucket(condition);
-
         return GoalCompareResponse.builder()
                 .snapshotYm(snapshotYm)
-                .cohort(buildCohort(request.getAssetRange(), request.getAgeRange(), cohortSize, applied, true))
+                .cohort(buildCohort(request.getAssetRange(), request.getAgeRange(), stats.getCohortSize(), applied, true))
                 .myMonthlyIncome(me.getMonthlyIncome())
-                .cohortAverageNetAssets(averages.getAverageNetAssets())
+                .cohortAverageNetAssets(stats.getAverages().getAverageNetAssets())
                 .achievement(GoalCompareResponse.Achievement.builder()
                         .mine(me.getAchievementRate())
-                        .cohortAverage(averages.getCohortAverageRate())
-                        .buckets(toAchievementBuckets(bucketCounts, cohortSize, me.getAchievementRate()))
+                        .cohortAverage(stats.getAverages().getCohortAverageRate())
+                        .buckets(toAchievementBuckets(stats.getAchievementBucketCounts(), stats.getCohortSize(), me.getAchievementRate()))
                         .build())
-                .dealTypeDistribution(toDealTypeItems(dealTypeCounts, cohortSize))
-                .averageTargetAmount(averages.getAverageTargetAmount())
-                .averagePrepMonths(averages.getAveragePrepMonths())
-                .popularRegions(toRegionItems(regionCounts, cohortSize))
+                .dealTypeDistribution(toDealTypeItems(stats.getDealTypeCounts(), stats.getCohortSize()))
+                .averageTargetAmount(stats.getAverages().getAverageTargetAmount())
+                .averagePrepMonths(stats.getAverages().getAveragePrepMonths())
+                .popularRegions(toRegionItems(stats.getRegionCounts(), stats.getCohortSize()))
                 .build();
     }
 

--- a/src/main/java/com/team/independence/compare/service/GoalSnapshotBatchServiceImpl.java
+++ b/src/main/java/com/team/independence/compare/service/GoalSnapshotBatchServiceImpl.java
@@ -10,6 +10,7 @@ import com.team.independence.compare.mapper.GoalSnapshotMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import com.team.independence.compare.service.CompareCacheStore;
 
 /**
  * 목표 스냅샷 생성 배치 구현.
@@ -25,6 +26,7 @@ public class GoalSnapshotBatchServiceImpl implements GoalSnapshotBatchService {
     private static final DateTimeFormatter YM = DateTimeFormatter.ofPattern("yyyyMM");
 
     private final GoalSnapshotMapper goalSnapshotMapper;
+    private final CompareCacheStore compareCacheStore;
 
     @Override
     @Transactional
@@ -35,6 +37,7 @@ public class GoalSnapshotBatchServiceImpl implements GoalSnapshotBatchService {
 
         int affected = goalSnapshotMapper.insertSnapshots(snapshotYm, baseDate);
         log.info("[배치] 목표 스냅샷 생성 완료. snapshotYm={}, 처리 {}건", snapshotYm, affected);
+        compareCacheStore.evictAll();
         return affected;
     }
 

--- a/src/test/java/com/team/independence/compare/service/CompareServiceImplTest.java
+++ b/src/test/java/com/team/independence/compare/service/CompareServiceImplTest.java
@@ -19,17 +19,20 @@ import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.compare.domain.GoalSnapshot;
 import com.team.independence.compare.dto.AchievementBucketCount;
+import com.team.independence.compare.dto.AssetCohortStats;
 import com.team.independence.compare.dto.CohortAverages;
 import com.team.independence.compare.dto.CohortCondition;
 import com.team.independence.compare.dto.CompareResponse;
 import com.team.independence.compare.dto.CompareResponse.AchievementBucket;
 import com.team.independence.compare.dto.CompareResponse.DealTypeItem;
 import com.team.independence.compare.dto.DealTypeCount;
+import com.team.independence.compare.dto.GoalCohortStats;
 import com.team.independence.compare.dto.IncomeBracketCount;
 import com.team.independence.compare.dto.OccupationTypeCount;
 import com.team.independence.compare.dto.RegionCount;
 import com.team.independence.compare.dto.SavingRangeResult;
 import com.team.independence.compare.mapper.GoalSnapshotMapper;
+import java.util.Optional;
 import com.team.independence.member.domain.Agreement;
 import com.team.independence.member.domain.Agreement.AgreementType;
 import com.team.independence.member.service.AgreementService;
@@ -55,7 +58,7 @@ class CompareServiceImplTest {
     void setUp() {
         mapper = new FakeMapper();
         agreementService = new FakeAgreementService();
-        service = new CompareServiceImpl(mapper, agreementService);
+        service = new CompareServiceImpl(mapper, agreementService, new FakeCompareCacheStore());
     }
 
     // ------------------------------------------------------------------
@@ -556,5 +559,30 @@ class CompareServiceImplTest {
             aggregateCalls++;
             return new ArrayList<>();
         }
+    }
+
+    static class FakeCompareCacheStore extends CompareCacheStore {
+        FakeCompareCacheStore() {
+            super(null, null);
+        }
+
+        @Override
+        public Optional<AssetCohortStats> findAssetStats(CohortCondition condition) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void saveAssetStats(CohortCondition condition, AssetCohortStats stats) {}
+
+        @Override
+        public Optional<GoalCohortStats> findGoalStats(CohortCondition condition) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void saveGoalStats(CohortCondition condition, GoalCohortStats stats) {}
+
+        @Override
+        public void evictAll() {}
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

Related to #157
Related to #154

## 📝작업 내용

또래 비교(compare) 자산/목표 집계 결과를 Redis read-aside 방식으로 캐싱합니다.

- `CompareCacheStore`: 코호트 집계 결과를 Redis에 저장/조회
  - Key: `compare:{type}:v1:{snapshotYm}:{netAssetsMin}:{netAssetsMax}:{ageMin}:{ageMax}:{incomeMin}:{incomeMax}:{occ}`
  - TTL 24h (`goal_snapshot`이 매월 1일 배치로 갱신되므로 하루면 충분)
- `CompareServiceImpl`: `getAssetComparison`/`getGoalComparison`에서 캐시 조회 후 미스일 때만 집계 쿼리 실행 및 저장
- `GoalSnapshotBatchServiceImpl`: 스냅샷 배치 완료 시 `evictAll()`로 `compare:*` 전체 무효화 (스냅샷 교체 반영)
- DTO `AssetCohortStats` / `GoalCohortStats` 추가: 캐시 직렬화용 집계 결과 묶음
- 캐시 HIT/MISS, evict 동작 테스트 보강

### 성능 (20k 코호트, 200 VU / 60s - 상세 #157)

| 지표 | Before (no-cache) | After (cache) | 개선 |
|---|---|---|---|
| p95 | 2824 ms | 194 ms | 14.5배 ↓ |
| 평균 | 1831 ms | 69 ms | 26배 ↓ |
| 완전한 비교 처리량 | 99.2 건/s | ~1309 건/s | 약 13배 ↑ |

### 스크린샷

Response Time Graph(Before/After)는 #157 에 첨부

## 💬리뷰 요구사항(선택)
- `CompareCacheStore`가 현재 `JsonProcessingException`만 처리합니다. Redis 연결 장애 시 예외가 그대로 전파되어 500이 날 수 있는데, DB 폴백(캐시 실패 시 집계 쿼리로 우회)을 이 PR에 포함할지 / 후속 이슈로 분리할지 의견 부탁드립니다.