### PR TITLE
feat: 이번 달 저축 기록 조회/입력 API 구현

### DIFF
--- a/src/main/java/com/team/independence/goal/controller/GoalController.java
+++ b/src/main/java/com/team/independence/goal/controller/GoalController.java
@@ -9,6 +9,8 @@ import com.team.independence.goal.dto.GoalMarketTrendResponse;
 import com.team.independence.goal.dto.GoalForecastResponse;
 import com.team.independence.goal.dto.GoalResponse;
 import com.team.independence.goal.dto.GoalSaveRequest;
+import com.team.independence.goal.dto.GoalSavingCurrentResponse;
+import com.team.independence.goal.dto.GoalSavingCurrentUpdateRequest;
 import com.team.independence.goal.dto.GoalSummaryResponse;
 import com.team.independence.goal.dto.MonteCarloResponse;
 import com.team.independence.goal.service.GoalDetailService;
@@ -107,5 +109,17 @@ public class GoalController {
     @GetMapping("/summary")
     public ApiResponse<GoalSummaryResponse> getSummary(@LoginMember Long memberId) {
         return ApiResponse.ok(goalService.getSummary(memberId));
+    }
+
+    @GetMapping("/savings/current")
+    public ApiResponse<GoalSavingCurrentResponse> getCurrentSaving(@LoginMember Long memberId) {
+        return ApiResponse.ok(goalService.getCurrentSaving(memberId));
+    }
+
+    @PutMapping("/savings/current")
+    public ApiResponse<GoalSavingCurrentResponse> updateCurrentSaving(
+            @LoginMember Long memberId,
+            @Valid @RequestBody GoalSavingCurrentUpdateRequest request) {
+        return ApiResponse.ok(goalService.updateCurrentSaving(memberId, request));
     }
 }

--- a/src/main/java/com/team/independence/goal/dto/GoalSavingCurrentResponse.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalSavingCurrentResponse.java
@@ -1,0 +1,24 @@
+package com.team.independence.goal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 홈 화면 「이번 달 저축 기록」 카드 응답.
+ * 아직 입력하지 않은 달은 actualSaving=null, recorded=false, differenceAmount=null로 내려간다(오류 아님).
+ */
+@Getter
+@Builder
+public class GoalSavingCurrentResponse {
+
+    /** 기록 연월 YYYYMM */
+    private String recordYm;
+    /** 그 달 목표 저축액(goal.monthly_saving) */
+    private Long targetSaving;
+    /** 사용자가 입력한 실제 저축액. 미입력이면 null */
+    private Long actualSaving;
+    /** 이번 달 실제 저축액 입력 여부 */
+    private boolean recorded;
+    /** actualSaving - targetSaving. 미입력이면 null */
+    private Long differenceAmount;
+}

--- a/src/main/java/com/team/independence/goal/dto/GoalSavingCurrentUpdateRequest.java
+++ b/src/main/java/com/team/independence/goal/dto/GoalSavingCurrentUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.team.independence.goal.dto;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 이번 달 실제 저축액 입력/수정 공통 요청. 0원도 유효한 기록으로 허용한다. */
+@Getter
+@NoArgsConstructor
+public class GoalSavingCurrentUpdateRequest {
+
+    @NotNull
+    @PositiveOrZero
+    private Long actualSaving;
+}

--- a/src/main/java/com/team/independence/goal/mapper/SavingRecordMapper.java
+++ b/src/main/java/com/team/independence/goal/mapper/SavingRecordMapper.java
@@ -13,4 +13,14 @@ public interface SavingRecordMapper {
      * 최근 3개월 평균·가장 최근 달 저축액 산출에 쓴다.
      */
     List<SavingRecord> findRecentByGoalId(@Param("goalId") Long goalId, @Param("limit") int limit);
+
+    /** 특정 목표의 특정 연월 저축 기록을 조회한다. 없으면 null(아직 입력하지 않은 달, 오류 아님). */
+    SavingRecord findByGoalIdAndRecordYm(@Param("goalId") Long goalId, @Param("recordYm") String recordYm);
+
+    /**
+     * 이번 달 실제 저축액을 입력/수정한다(uk_saving_goal_ym 기준 upsert).
+     * targetSaving은 최초 입력 시에만 고정되고, 이후 수정에서는 갱신하지 않는다(그 시점 monthly_saving 스냅샷 유지).
+     */
+    void upsertActualSaving(@Param("goalId") Long goalId, @Param("recordYm") String recordYm,
+            @Param("targetSaving") Long targetSaving, @Param("actualSaving") Long actualSaving);
 }

--- a/src/main/java/com/team/independence/goal/service/GoalService.java
+++ b/src/main/java/com/team/independence/goal/service/GoalService.java
@@ -8,6 +8,8 @@ import com.team.independence.goal.dto.GoalMarketTrendResponse;
 import com.team.independence.goal.dto.GoalForecastResponse;
 import com.team.independence.goal.dto.GoalResponse;
 import com.team.independence.goal.dto.GoalSaveRequest;
+import com.team.independence.goal.dto.GoalSavingCurrentResponse;
+import com.team.independence.goal.dto.GoalSavingCurrentUpdateRequest;
 import com.team.independence.goal.dto.GoalSummaryResponse;
 
 public interface GoalService {
@@ -83,4 +85,15 @@ public interface GoalService {
      * 달성률/예상 잔여 개월)을 한 번에 조회한다. 회원의 활성 목표가 없으면 GOAL_NOT_FOUND.
      */
     GoalSummaryResponse getSummary(Long memberId);
+
+    /**
+     * 홈 화면 「이번 달 저축 기록」 카드 데이터. 이번 달 saving_record가 없으면 오류가 아니라
+     * actualSaving=null, recorded=false로 응답한다. 활성 목표가 없으면 GOAL_NOT_FOUND.
+     */
+    GoalSavingCurrentResponse getCurrentSaving(Long memberId);
+
+    /**
+     * 이번 달 실제 저축액을 입력하거나 수정한다(같은 API로 upsert). 활성 목표가 없으면 GOAL_NOT_FOUND.
+     */
+    GoalSavingCurrentResponse updateCurrentSaving(Long memberId, GoalSavingCurrentUpdateRequest request);
 }

--- a/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalServiceImpl.java
@@ -8,15 +8,19 @@ import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.goal.domain.Goal;
 import com.team.independence.goal.domain.GoalHousing;
 import com.team.independence.goal.domain.SavingBasis;
+import com.team.independence.goal.domain.SavingRecord;
 import com.team.independence.goal.dto.GoalDiagnosisRequest;
 import com.team.independence.goal.dto.GoalDiagnosisResponse;
 import com.team.independence.goal.dto.GoalForecastResponse;
 import com.team.independence.goal.dto.GoalMarketTrendResponse;
 import com.team.independence.goal.dto.GoalResponse;
 import com.team.independence.goal.dto.GoalSaveRequest;
+import com.team.independence.goal.dto.GoalSavingCurrentResponse;
+import com.team.independence.goal.dto.GoalSavingCurrentUpdateRequest;
 import com.team.independence.goal.dto.GoalSummaryResponse;
 import com.team.independence.goal.mapper.GoalHousingMapper;
 import com.team.independence.goal.mapper.GoalMapper;
+import com.team.independence.goal.mapper.SavingRecordMapper;
 import com.team.independence.goal.service.calculator.BudgetCalculator;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
 import com.team.independence.goal.service.calculator.LoanSchedule;
@@ -69,6 +73,7 @@ public class GoalServiceImpl implements GoalService {
     private final RentMedianService rentMedianService; // 조건에 맞는 실거래 4분위값 조회
     private final GoalMapper goalMapper;
     private final GoalHousingMapper goalHousingMapper;
+    private final SavingRecordMapper savingRecordMapper;
     private final GoalMarketTrendCacheStore goalMarketTrendCacheStore;
     private final MonteCarloSimulationStore monteCarloSimulationStore;
     private final BudgetCalculator budgetCalculator;
@@ -615,6 +620,55 @@ public class GoalServiceImpl implements GoalService {
                         .achievementRate(achievementRate)
                         .remainingMonths(remainingMonths)
                         .build())
+                .build();
+    }
+
+    // 홈 화면 「이번 달 저축 기록」 카드 데이터 조회. 아직 입력하지 않은 달은 오류가 아니라 recorded=false로 응답한다.
+    @Override
+    @Transactional(readOnly = true)
+    public GoalSavingCurrentResponse getCurrentSaving(Long memberId) {
+        Goal goal = goalMapper.findActiveByMemberId(memberId);
+        if (goal == null) {
+            throw new BusinessException(ErrorCode.GOAL_NOT_FOUND);
+        }
+
+        String recordYm = YearMonth.now().format(YM_FORMATTER);
+        SavingRecord record = savingRecordMapper.findByGoalIdAndRecordYm(goal.getId(), recordYm);
+        if (record == null) {
+            return GoalSavingCurrentResponse.builder()
+                    .recordYm(recordYm)
+                    .targetSaving(goal.getMonthlySaving())
+                    .actualSaving(null)
+                    .recorded(false)
+                    .differenceAmount(null)
+                    .build();
+        }
+        return toSavingCurrentResponse(record);
+    }
+
+    // 이번 달 실제 저축액 입력/수정(같은 API로 upsert). target_saving은 최초 입력 시점 monthly_saving으로 고정한다.
+    @Override
+    @Transactional
+    public GoalSavingCurrentResponse updateCurrentSaving(Long memberId, GoalSavingCurrentUpdateRequest request) {
+        Goal goal = goalMapper.findActiveByMemberId(memberId);
+        if (goal == null) {
+            throw new BusinessException(ErrorCode.GOAL_NOT_FOUND);
+        }
+
+        String recordYm = YearMonth.now().format(YM_FORMATTER);
+        savingRecordMapper.upsertActualSaving(goal.getId(), recordYm, goal.getMonthlySaving(), request.getActualSaving());
+
+        SavingRecord record = savingRecordMapper.findByGoalIdAndRecordYm(goal.getId(), recordYm);
+        return toSavingCurrentResponse(record);
+    }
+
+    private GoalSavingCurrentResponse toSavingCurrentResponse(SavingRecord record) {
+        return GoalSavingCurrentResponse.builder()
+                .recordYm(record.getRecordYm())
+                .targetSaving(record.getTargetSaving())
+                .actualSaving(record.getActualSaving())
+                .recorded(true)
+                .differenceAmount(record.getActualSaving() - record.getTargetSaving())
                 .build();
     }
 

--- a/src/main/resources/mybatis/mapper/goal/SavingRecordMapper.xml
+++ b/src/main/resources/mybatis/mapper/goal/SavingRecordMapper.xml
@@ -25,4 +25,21 @@
          LIMIT #{limit}
     </select>
 
+    <select id="findByGoalIdAndRecordYm" resultMap="savingRecordMap">
+        SELECT id, goal_id, record_ym, target_saving, actual_saving,
+               is_modified, created_at, updated_at
+          FROM saving_record
+         WHERE goal_id = #{goalId}
+           AND record_ym = #{recordYm}
+    </select>
+
+    <!-- target_saving은 최초 입력에서만 고정하고 수정 시에는 건드리지 않는다(그 시점 monthly_saving 스냅샷 유지). -->
+    <insert id="upsertActualSaving">
+        INSERT INTO saving_record (goal_id, record_ym, target_saving, actual_saving, is_modified)
+        VALUES (#{goalId}, #{recordYm}, #{targetSaving}, #{actualSaving}, TRUE)
+        ON DUPLICATE KEY UPDATE
+            actual_saving = VALUES(actual_saving),
+            is_modified   = TRUE
+    </insert>
+
 </mapper>

--- a/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
@@ -85,6 +85,7 @@ class GoalDetailServiceImplTest {
                         null,
                         null,
                         null,
+                        null,
                         new BudgetCalculator(),
                         new LoanPlanCalculator(null, null, null, null) {
                             @Override
@@ -610,6 +611,16 @@ class GoalDetailServiceImplTest {
             return records.size() > limit
                     ? records.subList(0, limit)
                     : records;
+        }
+
+        @Override
+        public SavingRecord findByGoalIdAndRecordYm(Long goalId, String recordYm) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void upsertActualSaving(Long goalId, String recordYm, Long targetSaving, Long actualSaving) {
+            throw new UnsupportedOperationException();
         }
     }
 

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplMarketTrendTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplMarketTrendTest.java
@@ -85,6 +85,7 @@ class GoalServiceImplMarketTrendTest {
                 rentMedianService,
                 goalMapper,
                 goalHousingMapper,
+                null,
                 goalMarketTrendCacheStore,
                 null,
                 new BudgetCalculator(),

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplSummaryTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplSummaryTest.java
@@ -48,7 +48,8 @@ class GoalServiceImplSummaryTest {
     void setUp() {
         service = new GoalServiceImpl(
                 regionQueryService, assetConnectionService, assetSummaryService, rentMedianService,
-                goalMapper, goalHousingMapper, goalMarketTrendCacheStore, null, new BudgetCalculator(), null, null);
+                goalMapper, goalHousingMapper, null, goalMarketTrendCacheStore, null,
+                new BudgetCalculator(), null, null);
     }
 
     private Goal goal(long targetAmount, long monthlySaving) {

--- a/src/test/java/com/team/independence/goal/service/GoalServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalServiceImplTest.java
@@ -26,7 +26,7 @@ class GoalServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        service = new GoalServiceImpl(null, null, null, null, null, null, null, null, new BudgetCalculator(), null, null);
+        service = new GoalServiceImpl(null, null, null, null, null, null, null, null, null, new BudgetCalculator(), null, null);
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## #️⃣연관된 이슈

- #160 

## 📝작업 내용

기존 `saving_record` 테이블을 그대로 사용해 이번 달 실제 저축액 조회/입력 API를 추가했습니다.

### GET /api/v1/goals/savings/current                        
- 로그인 회원의 ACTIVE 목표 -> 현재 연월(YYYYMM) -> `saving_record` 조회 순서로 처리                                                  
- `saving_record` 행이 없으면 오류가 아니라 이번 달 미입력 상태로 정상 응답합니다.                                                  
- `targetSaving`은 현재 ACTIVE 목표의 `monthly_saving`을 그대로 노출

### PUT /api/v1/goals/savings/current
- Request: `{ "actualSaving": 650000 }` (0 이상만 허용, 0원도     
  유효한 기록으로 인정)                                             
- 해당 월 `saving_record`가 없으면 신규 INSERT —`target_saving`은 **저장 시점의 `goal.monthly_saving`을 복사해서 고정**하고, 이후 목표의 월 저축액이 바뀌어도 과거 월의`target_saving`은 그대로 유지됩니다.                                                        - 이미 있으면 `actual_saving`만 덮어쓰고 `target_saving`은 건드리지 않습니다.
- `is_modified`는 두 경우 모두 `TRUE`로 기록됩니다.               
- 내부적으로는 `uk_saving_goal_ym(goal_id, record_ym)` 유니크 키를 이용한 `INSERT ... ON DUPLICATE KEY UPDATE`로 처리해 조회 후 분기하는 방식보다 동시 요청에 안전합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?