### PR TITLE
perf: 목표 추천(/api/v1/goals/recommendations) 병목 개선

### DIFF
--- a/sql/full_schema.sql
+++ b/sql/full_schema.sql
@@ -106,9 +106,18 @@ CREATE TABLE rent_transaction (
     -- (지역, 연월, 유형) 단위 재적재 시 DELETE 대상을 구간으로 좁힌다.
     -- 최좌측 프리픽스가 region_code라 fk_rent_region의 인덱스 요건도 함께 충족.
     KEY idx_rent_reload (region_code, deal_ym, housing_type),
-    KEY idx_rent_query  (region_code, housing_type, deal_type, deal_ym),
+    -- 앞 4개(region_code, housing_type, deal_type, deal_ym)가 탐색 키, 뒤 3개는 커버링용 페이로드.
+    -- median·PriceModel 계열 쿼리는 구간에 걸린 행을 전부 읽고 나서 area·deposit·monthly_rent로
+    -- 거르는데, 이 세 컬럼이 인덱스에 없으면 걸린 행 수만큼 클러스터드 인덱스 랜덤 룩업이 발생한다.
+    -- 인덱스에 실어 두면 Using index(커버링)로 끝나 테이블 접근이 사라진다.
+    KEY idx_rent_query  (region_code, housing_type, deal_type, deal_ym, area, deposit, monthly_rent),
     CONSTRAINT fk_rent_region FOREIGN KEY (region_code) REFERENCES region (code)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='실거래 전월세(4종 통합)';
+
+-- 기존 DB 마이그레이션용 (신규 생성 시에는 위 DDL에 이미 반영되어 있어 실행 불필요)
+-- ALTER TABLE rent_transaction
+--     DROP INDEX idx_rent_query,
+--     ADD  KEY   idx_rent_query (region_code, housing_type, deal_type, deal_ym, area, deposit, monthly_rent);
 
 -- 수집 이력
 -- 최초 수집/증분 수집을 코드에서 분기하지 않고, 조합별 성공 여부로 판단하기 위한 테이블.

--- a/src/main/java/com/team/independence/config/RootConfig.java
+++ b/src/main/java/com/team/independence/config/RootConfig.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import javax.sql.DataSource;
 
@@ -92,7 +93,9 @@ public class RootConfig {
         config.setJdbcUrl(dbUrl);
         config.setUsername(dbUsername);
         config.setPassword(dbPassword);
-        config.setMaximumPoolSize(10);
+        // 추천 요청 하나가 요청 스레드와 알고리즘 스레드에서 각각 커넥션을 잡는다.
+        // algorithmExecutor(core 8 / max 16)와 함께 봐야 하며, 10이면 동시 요청 서너 건에서 이미 고갈된다.
+        config.setMaximumPoolSize(20);
         config.setConnectionTimeout(5000);
         config.setConnectionInitSql("SET NAMES utf8mb4");
         return new HikariDataSource(config);
@@ -163,12 +166,27 @@ public class RootConfig {
         return executor;
     }
 
+    /**
+     * 목표 추천 알고리즘 병렬 실행용 풀.
+     *
+     * <p>ThreadPoolExecutor는 큐가 가득 차기 전에는 스레드를 core 이상으로 늘리지 않는다.
+     * core 3 / queue 20이면 큐에 20개가 쌓일 때까지 실질 병렬도가 3에 묶여, 요청 하나가
+     * 태스크 3개를 던지는 이 경로에서는 동시 요청 두 번째부터 바로 대기가 시작됐다.
+     * core를 실사용 병렬도에 맞추고 큐를 짧게 잡아 부하 시 max까지 늘어나도록 한다.
+     *
+     * <p>큐까지 넘치면 CallerRunsPolicy로 요청 스레드가 직접 실행한다. 무한정 쌓아 두고
+     * 전부 느려지는 것보다, 유입 속도를 처리 속도에 맞춰 자연스럽게 낮추는 편이 낫다.
+     * 풀 크기는 DataSource 커넥션 풀(20)과 함께 봐야 한다 — 알고리즘 스레드는 각자 커넥션을 잡는다.
+     */
     @Bean("algorithmExecutor")
     public Executor algorithmExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(3);
-        executor.setMaxPoolSize(6);
-        executor.setQueueCapacity(20);
+        executor.setCorePoolSize(8);
+        executor.setMaxPoolSize(16);
+        executor.setQueueCapacity(8);
+        executor.setKeepAliveSeconds(60);
+        executor.setAllowCoreThreadTimeOut(true);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         executor.setThreadNamePrefix("algo-rec-");
         executor.initialize();
         return executor;

--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
@@ -26,7 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 등록된 추천 알고리즘을 2-Phase로 실행해 결과를 모은다.
@@ -61,8 +60,15 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
     @Qualifier("algorithmExecutor")
     private final Executor algorithmExecutor;
 
+    /**
+     * {@code @Transactional}을 붙이지 않는다.
+     *
+     * <p>실제 DB 작업은 대부분 algorithmExecutor 스레드에서 일어나는데, 그 스레드들은 요청 스레드의
+     * 트랜잭션을 상속받지 못하고 각자 커넥션을 잡는다. 여기에 트랜잭션을 걸면 요청 스레드가
+     * join()으로 대기하는 내내 커넥션 하나를 쓰지도 않으면서 붙잡고 있게 되어, 동시 요청 수만큼
+     * 커넥션 풀이 먼저 마른다. 개별 조회는 각 서비스의 readOnly 트랜잭션이 이미 감싸고 있다.
+     */
     @Override
-    @Transactional(readOnly = true)
     public GoalRecommendationResponse recommend(long memberId, GoalRecommendationRequest request) {
         assetConnectionService.validateConnectedAccountExists(memberId);
 
@@ -117,8 +123,8 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
         return response;
     }
 
+    /** Redis만 읽으므로 트랜잭션이 필요 없다. 걸어 두면 쓰지 않을 커넥션을 잡는다. */
     @Override
-    @Transactional(readOnly = true)
     public GoalRecommendationResponse getSavedRecommendation(long memberId) {
         return recommendationStore.find(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GOAL_RECOMMENDATION_NOT_FOUND));

--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
@@ -89,6 +89,11 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
                                 () -> runSafely(a, memberId, request, ctx), algorithmExecutor))
                         .collect(Collectors.toList());
 
+        // 응답의 originalPreference에 들어갈 기준 시세도 알고리즘과 무관한 별도 조회다.
+        // 결과 조립 시점에 부르면 모든 알고리즘이 끝난 뒤 무거운 median 쿼리가 직렬로 하나 더 붙는다.
+        CompletableFuture<Long> baseMedianFuture = CompletableFuture.supplyAsync(
+                () -> resolveBaseMedianAmount(request), algorithmExecutor);
+
         // Phase 2: Realistic 완료 후 HoldOut 실행
         CompletableFuture<List<GoalRecommendationResponse.RecommendationItem>> holdOutFuture =
                 realisticFuture.thenApplyAsync(realisticItems -> {
@@ -101,6 +106,7 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
         List<CompletableFuture<?>> allFutures = new ArrayList<>();
         allFutures.add(realisticFuture);
         allFutures.add(holdOutFuture);
+        allFutures.add(baseMedianFuture);
         allFutures.addAll(otherFutures);
         CompletableFuture.allOf(allFutures.toArray(new CompletableFuture[0])).join();
 
@@ -115,7 +121,7 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
         }
 
         GoalRecommendationResponse response = GoalRecommendationResponse.builder()
-                .originalPreference(buildOriginalPreference(request, monthlySaving))
+                .originalPreference(buildOriginalPreference(request, monthlySaving, baseMedianFuture.join()))
                 .recommendations(recommendations)
                 .build();
 
@@ -131,7 +137,7 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
     }
 
     private GoalRecommendationResponse.OriginalPreference buildOriginalPreference(
-            GoalRecommendationRequest request, long monthlySaving) {
+            GoalRecommendationRequest request, long monthlySaving, Long baseMedianAmount) {
 
         String regionCode = request.getRegionCode();
         String regionName = regionCode.length() == 2
@@ -150,7 +156,7 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
                         .depositMax(request.getDepositMax())
                         .monthlyRentMin(request.getMonthlyRentMin())
                         .monthlyRentMax(request.getMonthlyRentMax())
-                        .marketMedianAmount(resolveBaseMedianAmount(request))
+                        .marketMedianAmount(baseMedianAmount)
                         .build();
 
         return GoalRecommendationResponse.OriginalPreference.builder()

--- a/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithm.java
@@ -169,7 +169,9 @@ public class PreferenceAlgorithm implements RecommendationAlgorithm {
         // 목표 시점을 입력하지 않았으면 고정할 시점이 없어 조건 없는(null) 카드를 낸다.
         GoalRecommendationResponse.RecommendationItem dateFixedCard;
         if (request.getTargetDate() != null) {
-            LoanPlans dateFixedPlans = loanPlanCalculator.calculate(memberId, projectedDeposit, targetDate, ctx.currentEffectiveSaving());
+            LoanPlans dateFixedPlans = loanPlanCalculator.calculate(
+                    memberId, projectedDeposit, targetDate,
+                    netWorth, ctx.loanSchedules(), ctx.currentEffectiveSaving());
             GoalRecommendationResponse.LoanXPlan dateFixedLoanX =
                     RecommendationAlgorithm.withMonthlyRentAdded(dateFixedPlans.getLoanX(), monthlyRent);
             GoalRecommendationResponse.LoanOPlan dateFixedLoanO =

--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -538,7 +538,8 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         // 화면에 나가는 목표 금액은 환산값이 아니라 실제로 모아야 하는 보증금이다.
         // loanO 달성 가능 여부 판정은 "지금 시점" 스냅샷이면 충분하므로 currentEffectiveSaving을 쓴다.
         LoanPlans plans = loanPlanCalculator.calculate(
-                memberId, chosen.deposit(), targetDate, search.currentEffectiveSaving);
+                memberId, chosen.deposit(), targetDate,
+                search.netWorth, search.loanSchedules, search.currentEffectiveSaving);
 
         // 날짜 고정 카드라 대출은 시점을 앞당기는 게 아니라 필요 저축액을 낮춘다 → 단축 개월은 0
         // monthlySaving은 보증금을 모으는 동안의 저축액이라 월세가 빠져 있다. 월세 후보면 더해서 보여준다.

--- a/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
+++ b/src/main/java/com/team/independence/goal/service/algorithm/RealisticAlgorithm.java
@@ -160,8 +160,12 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
 
         AssetNetWorthBreakdown netWorth = ctx.netWorth();
 
+        // 목표 시점의 예산은 후보와 무관하게 같으므로 조합 평가 루프 밖에서 한 번만 계산한다.
+        long budgetAtT = budgetCalculator.calculate(
+                netWorth, ctx.rawMonthlySaving(), ctx.loanSchedules(), desiredMonths);
+
         Search search = new Search(memberId, netWorth, ctx.rawMonthlySaving(), ctx.loanSchedules(),
-                ctx.currentEffectiveSaving(), desiredMonths);
+                ctx.currentEffectiveSaving(), desiredMonths, budgetAtT);
 
         // 1단계: 시군구 확정
         String regionCode = selectRegion(request, search);
@@ -477,10 +481,8 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
                 new PriceModelKey(housingType, dealType, areaMin, areaMax));
         if (priceModel != null) {
             try {
-                long budgetAtT = budgetCalculator.calculate(
-                        search.netWorth, search.rawMonthlySaving, search.loanSchedules, search.desiredMonths);
                 MonteCarloEngine.Result mc = monteCarloService.simulate(
-                        priceModel, deposit, budgetAtT, (int) search.desiredMonths);
+                        priceModel, deposit, search.budgetAtT, (int) search.desiredMonths);
                 projectedDeposit = mc.priceP50();
             } catch (RuntimeException e) {
                 log.debug("MC 실패, 현재 시세 폴백. regionCode={}, housingType={}, dealType={}",
@@ -597,17 +599,26 @@ public class RealisticAlgorithm implements RecommendationAlgorithm {
         /** "지금 시점" 스냅샷 순저축액. loanO 달성 가능 여부(capacity) 판정 등 현재 스냅샷이 필요한 곳에서만 쓴다. */
         private final long currentEffectiveSaving;
         private final long desiredMonths;
+        /**
+         * 목표 시점(desiredMonths)의 예상 예산. 후보와 무관하게 고정된 값이라 여기서 한 번만 계산한다.
+         *
+         * <p>후보마다 다시 구하면 개월 수만큼 도는 예산 누적 루프가 조합 수(최대 40)만큼 반복된다.
+         * HoldOut도 같은 이유로 루프 밖에서 한 번만 계산한다.
+         */
+        private final long budgetAtT;
         /** 조합 키 → 평가 결과. 표본이 없어 후보가 되지 못한 조합도 담아 재조회를 막는다. */
         private final Map<String, Optional<Candidate>> evaluated = new HashMap<>();
 
         private Search(long memberId, AssetNetWorthBreakdown netWorth, long rawMonthlySaving,
-                       List<LoanSchedule> loanSchedules, long currentEffectiveSaving, long desiredMonths) {
+                       List<LoanSchedule> loanSchedules, long currentEffectiveSaving, long desiredMonths,
+                       long budgetAtT) {
             this.memberId = memberId;
             this.netWorth = netWorth;
             this.rawMonthlySaving = rawMonthlySaving;
             this.loanSchedules = loanSchedules;
             this.currentEffectiveSaving = currentEffectiveSaving;
             this.desiredMonths = desiredMonths;
+            this.budgetAtT = budgetAtT;
         }
     }
 

--- a/src/main/java/com/team/independence/goal/service/calculator/BudgetCalculator.java
+++ b/src/main/java/com/team/independence/goal/service/calculator/BudgetCalculator.java
@@ -1,6 +1,8 @@
 package com.team.independence.goal.service.calculator;
 
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +22,15 @@ public class BudgetCalculator {
 
     private static final double ANNUAL_INTEREST_RATE = 0.05;
     private static final long   MAX_FORECAST_MONTHS  = 1200;
+
+    /**
+     * 월 복리 이율. 상수식이라 호출마다 다시 구할 이유가 없다.
+     *
+     * <p>도달 개월 수 탐색은 최대 1200번 반복하고 그 안에서 다시 이율을 쓴다.
+     * 매번 {@code Math.pow}를 부르면 같은 값을 수천 번 계산한다.
+     */
+    private static final double MONTHLY_INTEREST_RATE =
+            Math.pow(1 + ANNUAL_INTEREST_RATE, 1.0 / 12) - 1;
 
     /**
      * n개월 후 예상 총 예산을 계산한다.
@@ -72,15 +83,11 @@ public class BudgetCalculator {
      */
     public long calculate(AssetNetWorthBreakdown netWorth, long rawSaving,
                           List<LoanSchedule> loanSchedules, long months) {
-        double r = monthlyInterestRate();
+        double r = MONTHLY_INTEREST_RATE;
+        ActiveLoanPayments active = new ActiveLoanPayments(loanSchedules);
         long cumulativeSavings = 0L;
         for (long m = 1; m <= months; m++) {
-            final long month = m;
-            long activePayment = loanSchedules.stream()
-                    .filter(l -> l.remainingMonths() >= month)
-                    .mapToLong(LoanSchedule::monthlyPayment)
-                    .sum();
-            long effectiveThisMonth = Math.max(0, rawSaving - activePayment);
+            long effectiveThisMonth = Math.max(0, rawSaving - active.at(m));
             cumulativeSavings = Math.round(cumulativeSavings * (1 + r)) + effectiveThisMonth;
         }
         return calculateGrownAmount(netWorth.getInterestBearingAssets(), months)
@@ -100,15 +107,11 @@ public class BudgetCalculator {
 
         if (growingAssets + fixedAssets >= targetAmount) return 0L;
 
-        double r = monthlyInterestRate();
+        double r = MONTHLY_INTEREST_RATE;
+        ActiveLoanPayments active = new ActiveLoanPayments(loanSchedules);
         long cumulativeSavings = 0L;
         for (long m = 1; m <= MAX_FORECAST_MONTHS; m++) {
-            final long month = m;
-            long activePayment = loanSchedules.stream()
-                    .filter(l -> l.remainingMonths() >= month)
-                    .mapToLong(LoanSchedule::monthlyPayment)
-                    .sum();
-            long effectiveThisMonth = Math.max(0, rawSaving - activePayment);
+            long effectiveThisMonth = Math.max(0, rawSaving - active.at(m));
             cumulativeSavings = Math.round(cumulativeSavings * (1 + r)) + effectiveThisMonth;
 
             long budget = calculateGrownAmount(growingAssets, m) + fixedAssets + cumulativeSavings;
@@ -131,7 +134,49 @@ public class BudgetCalculator {
     }
 
     private double monthlyInterestRate() {
-        return Math.pow(1 + ANNUAL_INTEREST_RATE, 1.0 / 12) - 1;
+        return MONTHLY_INTEREST_RATE;
+    }
+
+    /**
+     * 개월 수가 커질수록 만기된 대출이 빠지는 월 원리금 합계를 순차적으로 내준다.
+     *
+     * <p>{@code m}개월차에 아직 상환 중인 대출은 {@code remainingMonths >= m}인 것들이다.
+     * 매달 전체 스케줄을 스트림으로 다시 훑으면 도달 시점 탐색(최대 1200개월)에서만
+     * 스트림 파이프라인이 1200번 만들어진다. 잔여 기간 오름차순으로 한 번 정렬해 두면
+     * 만기가 지난 대출을 커서로 하나씩 빼면서 O(대출수 log 대출수 + 개월수)로 끝난다.
+     *
+     * <p>월을 1부터 단조 증가로만 조회한다고 가정한다(두 루프 모두 m=1부터 1씩 증가).
+     */
+    private static final class ActiveLoanPayments {
+
+        private final long[] remainingMonths;
+        private final long[] payments;
+        private int expiredCount;
+        private long activeSum;
+
+        private ActiveLoanPayments(List<LoanSchedule> loanSchedules) {
+            List<LoanSchedule> sorted = new ArrayList<>(loanSchedules);
+            sorted.sort(Comparator.comparingLong(LoanSchedule::remainingMonths));
+
+            remainingMonths = new long[sorted.size()];
+            payments = new long[sorted.size()];
+            long sum = 0L;
+            for (int i = 0; i < sorted.size(); i++) {
+                remainingMonths[i] = sorted.get(i).remainingMonths();
+                payments[i] = sorted.get(i).monthlyPayment();
+                sum += payments[i];
+            }
+            this.activeSum = sum;
+        }
+
+        /** {@code month}개월차에 아직 상환 중인 대출의 월 원리금 합계 */
+        private long at(long month) {
+            while (expiredCount < remainingMonths.length && remainingMonths[expiredCount] < month) {
+                activeSum -= payments[expiredCount];
+                expiredCount++;
+            }
+            return activeSum;
+        }
     }
 
     private long calculateGrownAmount(long principal, long months) {

--- a/src/main/java/com/team/independence/goal/service/calculator/LoanPlanCalculator.java
+++ b/src/main/java/com/team/independence/goal/service/calculator/LoanPlanCalculator.java
@@ -2,7 +2,6 @@ package com.team.independence.goal.service.calculator;
 
 import com.team.independence.asset.dto.account.LoanAccountDetailItem;
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
-import com.team.independence.asset.service.AssetSummaryService;
 import com.team.independence.asset.service.LoanAccountService;
 import com.team.independence.goal.dto.GoalRecommendationResponse;
 import com.team.independence.goal.dto.LoanPlans;
@@ -40,7 +39,6 @@ public class LoanPlanCalculator {
 
     private final MemberService       memberService;
     private final LoanAccountService  loanAccountService;
-    private final AssetSummaryService assetSummaryService;
     private final BudgetCalculator    budgetCalculator;
 
     /**
@@ -50,13 +48,18 @@ public class LoanPlanCalculator {
      * 대출 한도가 목표 금액을 초과하는 경우 대출액은 목표 금액으로 캡되며,
      * 자력 부담과 월 저축액은 0이 된다.
      *
+     * @param netWorth        호출자가 상위에서 한 번만 조회해 넘기는 순자산 구성.
+     *                        여기서 다시 조회하면 알고리즘마다 같은 4개 쿼리가 반복된다.
+     * @param loanSchedules   호출자가 상위에서 한 번만 조회해 넘기는 기존 대출 스케줄.
+     *                        DSR 여유분 계산의 기존 상환액 합계를 여기서 구한다.
      * @param effectiveSaving 호출자가 넘기는 월 순저축액(기존 대출 상환액 등을 이미 차감한 값).
      *                        loanO 달성 가능 여부(capacity) 판정에 쓴다. 서버 캐시가 아니라 이 값을 기준으로
      *                        삼아, 추천 요청이 넘긴 저축액과 예산 계산이 어긋나지 않게 한다.
      */
-    public LoanPlans calculate(long memberId, long requiredAmount, YearMonth targetDate, long effectiveSaving) {
+    public LoanPlans calculate(long memberId, long requiredAmount, YearMonth targetDate,
+                               AssetNetWorthBreakdown netWorth, List<LoanSchedule> loanSchedules,
+                               long effectiveSaving) {
         long months = ChronoUnit.MONTHS.between(YearMonth.now(), targetDate);
-        AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
 
         long loanXSaving = calcMonthlySavingNeeded(netWorth, requiredAmount, months);
         GoalRecommendationResponse.LoanXPlan loanX = GoalRecommendationResponse.LoanXPlan.builder()
@@ -65,7 +68,7 @@ public class LoanPlanCalculator {
                 .monthlySaving(loanXSaving)
                 .build();
 
-        long existingPayment = calcTotalExistingMonthlyPayment(memberId);
+        long existingPayment = totalMonthlyPayment(loanSchedules);
         long loanAmount = Math.min(calcMaxLoanAmount(memberId, existingPayment), requiredAmount);
         if (loanAmount <= 0) {
             return LoanPlans.builder().loanX(loanX).loanO(null).build();
@@ -118,7 +121,7 @@ public class LoanPlanCalculator {
                 .monthlySaving(rawMonthlySaving)
                 .build();
 
-        long existingPayment = calcTotalExistingMonthlyPayment(memberId);
+        long existingPayment = totalMonthlyPayment(loanSchedules);
         long loanAmount = Math.min(calcMaxLoanAmount(memberId, existingPayment), requiredAmount);
         if (loanAmount <= 0) {
             return LoanPlans.builder().loanX(loanX).loanO(null).build();
@@ -173,6 +176,18 @@ public class LoanPlanCalculator {
 
 
     /**
+     * 이미 확보해 둔 대출 스케줄에서 월 원리금 합계를 구한다.
+     *
+     * <p>{@link #getLoanSchedules(long)}가 상환 부담 없는 대출(잔액 0·만기 도래·end_date 없음)을
+     * 이미 걸러 내므로, 스케줄 합계는 {@link #calcTotalExistingMonthlyPayment(long)}과 같은 값이다.
+     * {@code MemberFinancialContext.currentEffectiveSaving()}도 같은 방식으로 합산한다.
+     * 상위에서 한 번 조회한 스케줄을 재사용해 계좌 조회 쿼리 반복을 없앤다.
+     */
+    private long totalMonthlyPayment(List<LoanSchedule> loanSchedules) {
+        return loanSchedules.stream().mapToLong(LoanSchedule::monthlyPayment).sum();
+    }
+
+    /**
      * 기존 대출 계좌 전체의 월 원리금 합계를 반환한다.
      *
      * <p>end_date가 없거나 이미 만기된 대출은 상환 부담 없음으로 처리한다.
@@ -196,7 +211,7 @@ public class LoanPlanCalculator {
     }
 
     private long calcMaxLoanAmount(long memberId, long existingMonthlyPayment) {
-        Long monthlyIncome = memberService.getMember(memberId).monthlyIncome();
+        Long monthlyIncome = memberService.getMonthlyIncome(memberId);
         if (monthlyIncome == null || monthlyIncome <= 0) return 0L;
 
         double r = ASSUMED_LOAN_ANNUAL_RATE / 12.0;

--- a/src/main/java/com/team/independence/member/mapper/MemberMapper.java
+++ b/src/main/java/com/team/independence/member/mapper/MemberMapper.java
@@ -17,6 +17,15 @@ public interface MemberMapper {
     /** PK로 회원 조회 */
     Optional<Member> findById(Long id);
 
+    /**
+     * 월소득만 필요한 곳을 위한 경량 조회. id·monthly_income만 채워진 Member를 반환한다.
+     *
+     * <p>DSR 한도 계산은 monthly_income 하나만 쓰는데 {@code getMember()}를 부르면
+     * 회원 전체 컬럼에 약관 동의 목록까지 조인 없이 한 번 더 조회된다.
+     * 회원 존재 여부와 소득 null을 구분해야 해서 스칼라가 아니라 Member로 받는다.
+     */
+    Optional<Member> findIncomeById(Long id);
+
     /** 카카오 고유 ID로 회원 조회 */
     Optional<Member> findByKakaoId(String kakaoId);
 

--- a/src/main/java/com/team/independence/member/service/MemberService.java
+++ b/src/main/java/com/team/independence/member/service/MemberService.java
@@ -15,6 +15,16 @@ public interface MemberService {
 
     MemberProfileResponse getMember(Long id);
 
+    /**
+     * 월소득만 조회한다. 등록하지 않았으면 null.
+     *
+     * <p>DSR 한도 계산처럼 소득 한 필드만 필요한 호출부용이다.
+     * {@link #getMember(Long)}은 약관 동의 목록까지 함께 읽어 쿼리가 2개 나간다.
+     *
+     * @throws com.team.independence.common.exception.BusinessException 회원이 없으면 MEMBER_NOT_FOUND
+     */
+    Long getMonthlyIncome(Long id);
+
     /** kakaoId로 memberId 조회. 존재하지 않으면 Optional.empty() */
     Optional<Long> findMemberIdByKakaoId(String kakaoId);
 

--- a/src/main/java/com/team/independence/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/team/independence/member/service/MemberServiceImpl.java
@@ -35,6 +35,14 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional(readOnly = true)
+    public Long getMonthlyIncome(Long id) {
+        return memberMapper.findIncomeById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND))
+                .getMonthlyIncome();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public Optional<Long> findMemberIdByKakaoId(String kakaoId) {
         return memberMapper.findByKakaoId(kakaoId).map(Member::getId);
     }

--- a/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
+++ b/src/main/java/com/team/independence/property/mapper/RentTransactionMapper.java
@@ -28,10 +28,14 @@ public interface RentTransactionMapper {
      * SQL 윈도우 함수로 분위값을 계산해 1행으로 반환한다.
      * 조건에 맞는 거래가 없으면 sampleCount=null 인 결과 1행을 반환한다.
      *
+     * @param regionCodes 집계 대상 시군구 코드 목록. 시도 요청이면 그 시도에 속한 시군구 전체가 들어온다.
+     *                    {@code LIKE '11%'}가 아니라 {@code IN}이어야 region_code 뒤의
+     *                    housing_type·deal_type·deal_ym까지 인덱스 키로 쓸 수 있다.
      * @param areaMinSqm 요청의 평수를 ㎡로 환산한 하한 (버림)
      * @param areaMaxSqm 요청의 평수를 ㎡로 환산한 상한 (버림)
      */
     MedianAggResult findAggregatedMedian(@Param("request") RentMedianRequest request,
+                                         @Param("regionCodes") List<String> regionCodes,
                                          @Param("areaMinSqm") long areaMinSqm,
                                          @Param("areaMaxSqm") long areaMaxSqm,
                                          @Param("startYm") String startYm,
@@ -42,8 +46,10 @@ public interface RentTransactionMapper {
      * (housing_type, deal_type) IN 절이 idx_rent_query 서브레인지를 조합별로 그대로 태우므로
      * 처리 행 수는 페어별 개별 쿼리 합과 동일하고, 왕복·파서·옵티마이저 오버헤드만 사라진다.
      * 결과 최대 8 × 5 = 40행.
+     *
+     * @param regionCodes 집계 대상 시군구 코드 목록. 시도 요청이면 그 시도에 속한 시군구 전체가 들어온다.
      */
-    List<BulkMedianResult> findBulkMedianBatch(@Param("regionCode") String regionCode,
+    List<BulkMedianResult> findBulkMedianBatch(@Param("regionCodes") List<String> regionCodes,
                                                @Param("typePairs") List<TypeDealPair> typePairs,
                                                @Param("startYm") String startYm,
                                                @Param("endYm") String endYm);

--- a/src/main/java/com/team/independence/property/service/PriceModelServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/PriceModelServiceImpl.java
@@ -109,14 +109,13 @@ public class PriceModelServiceImpl implements PriceModelService {
             return result;
         }
 
-        // 1) 캐시 조회 — 히트분은 즉시 결과에 담고, 미스만 다음 단계로 넘긴다.
+        // 1) 캐시 조회 — MGET 한 번으로 전체 조합을 확인하고, 미스만 다음 단계로 넘긴다.
+        //    조합마다 GET을 돌리면 40개 키에 왕복 40회가 나가고 Realistic·HoldOut이 연달아 불러 80회가 된다.
+        result.putAll(priceModelStore.findAll(regionCode, keys));
+
         List<PriceModelKey> misses = new ArrayList<>();
         for (PriceModelKey key : keys) {
-            PriceModelRequest req = toRequest(regionCode, key);
-            Optional<PriceModelResponse> cached = priceModelStore.find(req);
-            if (cached.isPresent()) {
-                result.put(key, cached.get());
-            } else {
+            if (!result.containsKey(key)) {
                 misses.add(key);
             }
         }
@@ -157,7 +156,8 @@ public class PriceModelServiceImpl implements PriceModelService {
                     row.getDealYm(), row.getDeposit(), row.getArea()));
         }
 
-        // 4) 조합별로 PriceModel.estimate → 캐시 저장 → 결과 맵에 담기.
+        // 4) 조합별로 PriceModel.estimate → 결과 맵에 담기.
+        Map<PriceModelKey, PriceModelResponse> computed = new HashMap<>();
         for (PriceModelKey miss : misses) {
             List<MonthlyPricePoint> raw = perKey.get(miss);
             PriceModelResponse response = buildPriceModel(regionCode, regionName, miss, raw, startYm, endYm);
@@ -165,9 +165,12 @@ public class PriceModelServiceImpl implements PriceModelService {
                 // 표본 부족은 배치에서는 예외를 던지지 않고 스킵한다. 호출자는 null을 폴백 신호로 쓴다.
                 continue;
             }
-            priceModelStore.save(toRequest(regionCode, miss), response);
-            result.put(miss, response);
+            computed.put(miss, response);
         }
+
+        // 5) 새로 계산한 조합만 파이프라인 한 번으로 캐싱한다.
+        priceModelStore.saveAll(regionCode, computed);
+        result.putAll(computed);
         return result;
     }
 
@@ -216,16 +219,6 @@ public class PriceModelServiceImpl implements PriceModelService {
                 .startYm(startYm)
                 .endYm(endYm)
                 .build();
-    }
-
-    private PriceModelRequest toRequest(String regionCode, PriceModelKey key) {
-        PriceModelRequest req = new PriceModelRequest();
-        req.setRegionCode(regionCode);
-        req.setHousingType(key.housingType());
-        req.setDealType(key.dealType());
-        req.setAreaMin(key.areaMin());
-        req.setAreaMax(key.areaMax());
-        return req;
     }
 
     /** 한 달치 거래 목록에서 평당 보증금(원/평)의 중앙값을 반환 */

--- a/src/main/java/com/team/independence/property/service/PriceModelStore.java
+++ b/src/main/java/com/team/independence/property/service/PriceModelStore.java
@@ -2,13 +2,22 @@ package com.team.independence.property.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.independence.property.dto.PriceModelKey;
 import com.team.independence.property.dto.PriceModelRequest;
 import com.team.independence.property.dto.PriceModelResponse;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
 
 /**
@@ -42,6 +51,43 @@ public class PriceModelStore {
         }
     }
 
+    /**
+     * 같은 지역의 여러 조합을 MGET 한 번으로 조회한다. 히트한 조합만 담긴 맵을 반환한다.
+     *
+     * <p>조합마다 {@link #find}를 부르면 40개 키에 왕복 40회가 나가고, Realistic·HoldOut이
+     * 연달아 부르므로 요청 하나에 80회가 된다. 키 순서와 결과 순서가 대응하는 MGET으로 한 번에 받는다.
+     */
+    public Map<PriceModelKey, PriceModelResponse> findAll(String regionCode, Collection<PriceModelKey> keys) {
+        Map<PriceModelKey, PriceModelResponse> hits = new HashMap<>();
+        if (keys.isEmpty()) {
+            return hits;
+        }
+
+        List<PriceModelKey> ordered = new ArrayList<>(keys);
+        List<String> redisKeys = new ArrayList<>(ordered.size());
+        for (PriceModelKey key : ordered) {
+            redisKeys.add(key(regionCode, key));
+        }
+
+        List<String> values = redisTemplate.opsForValue().multiGet(redisKeys);
+        if (values == null) {
+            return hits;
+        }
+
+        for (int i = 0; i < ordered.size() && i < values.size(); i++) {
+            String json = values.get(i);
+            if (json == null) {
+                continue;
+            }
+            try {
+                hits.put(ordered.get(i), objectMapper.readValue(json, PriceModelResponse.class));
+            } catch (JsonProcessingException e) {
+                log.warn("[PriceModel 캐시] 역직렬화 실패, 미스로 처리: key={}", redisKeys.get(i), e);
+            }
+        }
+        return hits;
+    }
+
     public void save(PriceModelRequest request, PriceModelResponse response) {
         try {
             String json = objectMapper.writeValueAsString(response);
@@ -51,8 +97,50 @@ public class PriceModelStore {
         }
     }
 
+    /**
+     * 같은 지역의 여러 조합을 파이프라인 한 번으로 저장한다.
+     *
+     * <p>배치 미스가 40개면 개별 저장은 SET 왕복 40회다. 콜드 캐시 응답에 그대로 얹히므로 묶는다.
+     */
+    public void saveAll(String regionCode, Map<PriceModelKey, PriceModelResponse> models) {
+        if (models.isEmpty()) {
+            return;
+        }
+
+        Map<String, String> serialized = new HashMap<>();
+        for (Map.Entry<PriceModelKey, PriceModelResponse> entry : models.entrySet()) {
+            String redisKey = key(regionCode, entry.getKey());
+            try {
+                serialized.put(redisKey, objectMapper.writeValueAsString(entry.getValue()));
+            } catch (JsonProcessingException e) {
+                log.warn("[PriceModel 캐시] 직렬화 실패, 캐싱 건너뜀: key={}", redisKey, e);
+            }
+        }
+        if (serialized.isEmpty()) {
+            return;
+        }
+
+        // TTL을 키마다 걸어야 해서 MSET을 못 쓴다. SETEX를 파이프라인으로 묶어 왕복만 1회로 만든다.
+        redisTemplate.executePipelined(new SessionCallback<Object>() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public <K, V> Object execute(RedisOperations<K, V> operations) {
+                ValueOperations<String, String> ops =
+                        ((RedisOperations<String, String>) operations).opsForValue();
+                serialized.forEach((k, v) -> ops.set(k, v, TTL));
+                return null;
+            }
+        });
+    }
+
     private String key(PriceModelRequest r) {
         return KEY_PREFIX + r.getRegionCode() + ":" + r.getHousingType()
                 + ":" + r.getDealType() + ":" + r.getAreaMin() + ":" + r.getAreaMax();
+    }
+
+    /** 배치용 키. {@link #key(PriceModelRequest)}와 같은 형식이어야 단건·배치 캐시가 서로를 재사용한다. */
+    private String key(String regionCode, PriceModelKey k) {
+        return KEY_PREFIX + regionCode + ":" + k.housingType()
+                + ":" + k.dealType() + ":" + k.areaMin() + ":" + k.areaMax();
     }
 }

--- a/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/RentMedianServiceImpl.java
@@ -53,6 +53,7 @@ public class RentMedianServiceImpl implements RentMedianService {
 
         MedianAggResult agg = rentTransactionMapper.findAggregatedMedian(
                 request,
+                resolveRegionCodes(request.getRegionCode()),
                 toSqm(request.getAreaMin()),
                 toSqm(request.getAreaMax()),
                 startYm,
@@ -95,7 +96,7 @@ public class RentMedianServiceImpl implements RentMedianService {
             }
         }
         List<BulkMedianResult> rows = rentTransactionMapper.findBulkMedianBatch(
-                regionCode, typePairs, startYm, endYm);
+                resolveRegionCodes(regionCode), typePairs, startYm, endYm);
 
         Map<String, RentMedianResponse> result = new HashMap<>();
         for (BulkMedianResult r : rows) {
@@ -151,6 +152,26 @@ public class RentMedianServiceImpl implements RentMedianService {
             return regionMapper.findSidoNameByPrefix(regionCode);
         }
         return regionMapper.findFullNameByCode(regionCode);
+    }
+
+    /**
+     * 집계 대상 시군구 코드 목록을 만든다. 시군구 코드면 그 자신 하나, 시도 코드면 소속 시군구 전체.
+     *
+     * <p>시도 요청을 {@code region_code LIKE '11%'}로 처리하면 region_code가 범위 조건이 되어
+     * idx_rent_query의 뒤쪽 컬럼(housing_type·deal_type·deal_ym)을 인덱스 키로 쓸 수 없다.
+     * 결과적으로 그 시도의 모든 유형·모든 월을 훑고 나서야 필터가 걸린다.
+     * 코드 목록을 풀어 {@code IN}으로 넘기면 코드마다 등치 조건이 되어 조합별 서브레인지 스캔이 된다.
+     * 집계 대상 행 자체는 동일하므로 결과값은 바뀌지 않는다.
+     */
+    private List<String> resolveRegionCodes(String regionCode) {
+        if (regionCode != null && regionCode.length() == SIDO_CODE_LENGTH) {
+            List<String> sigunguCodes = regionMapper.findCodesBySidoPrefix(regionCode);
+            if (sigunguCodes.isEmpty()) {
+                throw new BusinessException(ErrorCode.REGION_NOT_FOUND);
+            }
+            return sigunguCodes;
+        }
+        return List.of(regionCode);
     }
 
     private long toSqm(int pyeong) {

--- a/src/main/resources/mybatis/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mybatis/mapper/member/MemberMapper.xml
@@ -30,6 +30,13 @@
          WHERE id = #{id}
     </select>
 
+    <!-- DSR 한도 계산용. monthly_income만 쓰지만 회원 존재 여부를 구분해야 해 id를 함께 읽는다. -->
+    <select id="findIncomeById" parameterType="long" resultMap="memberMap">
+        SELECT id, monthly_income
+          FROM member
+         WHERE id = #{id}
+    </select>
+
     <select id="findByKakaoId" parameterType="string" resultMap="memberMap">
         SELECT id, kakao_id, nickname, birth_date,
                income_bracket, income_bracket_updated_at,

--- a/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
+++ b/src/main/resources/mybatis/mapper/property/RentTransactionMapper.xml
@@ -77,7 +77,10 @@
     </select>
 
     <!-- MySQL 8.0 윈도우 함수로 분위값을 DB에서 직접 계산해 1행으로 반환한다.
-         deposit = 0 이상치 제외. 조건에 맞는 데이터가 없으면 sampleCount=null인 1행이 반환된다. -->
+         deposit = 0 이상치 제외. 조건에 맞는 데이터가 없으면 sampleCount=null인 1행이 반환된다.
+         시도 요청이어도 LIKE가 아니라 IN(시군구 목록)으로 받는다. LIKE는 region_code가 범위 조건이
+         되어 뒤따르는 housing_type·deal_type·deal_ym을 인덱스 키로 못 쓰고 시도 전체를 훑지만,
+         IN은 코드별 등치 조건이라 조합마다 idx_rent_query 서브레인지 스캔으로 좁혀진다. -->
     <select id="findAggregatedMedian" resultType="com.team.independence.property.dto.MedianAggResult">
         SELECT
             MAX(CASE WHEN dep_rn  = CEIL(0.25 * total) THEN deposit      END) AS deposit_q1,
@@ -93,14 +96,10 @@
                    ROW_NUMBER() OVER (ORDER BY monthly_rent) AS rent_rn,
                    COUNT(*)     OVER ()                      AS total
               FROM rent_transaction
-            <choose>
-                <when test="request.regionCode.length() == 2">
-             WHERE region_code LIKE CONCAT(#{request.regionCode}, '%')
-                </when>
-                <otherwise>
-             WHERE region_code = #{request.regionCode}
-                </otherwise>
-            </choose>
+             WHERE region_code IN
+                   <foreach collection="regionCodes" item="code" open="(" separator="," close=")">
+                       #{code}
+                   </foreach>
                AND housing_type = #{request.housingType}
                AND deal_type    = #{request.dealType}
                AND deal_ym      BETWEEN #{startYm} AND #{endYm}
@@ -213,14 +212,10 @@
                         END
                 ) AS total
               FROM rent_transaction
-            <choose>
-                <when test="regionCode.length() == 2">
-             WHERE region_code LIKE CONCAT(#{regionCode}, '%')
-                </when>
-                <otherwise>
-             WHERE region_code = #{regionCode}
-                </otherwise>
-            </choose>
+             WHERE region_code IN
+                   <foreach collection="regionCodes" item="code" open="(" separator="," close=")">
+                       #{code}
+                   </foreach>
                AND (housing_type, deal_type) IN
                    <foreach collection="typePairs" item="p" open="(" separator="," close=")">
                        (#{p.housingType}, #{p.dealType})

--- a/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/GoalDetailServiceImplTest.java
@@ -86,7 +86,7 @@ class GoalDetailServiceImplTest {
                         null,
                         null,
                         new BudgetCalculator(),
-                        new LoanPlanCalculator(null, null, null, null) {
+                        new LoanPlanCalculator(null, null, null) {
                             @Override
                             public long calcTotalExistingMonthlyPayment(long memberId) {
                                 return 0L;

--- a/src/test/java/com/team/independence/goal/service/LoanPlanCalculatorImplTest.java
+++ b/src/test/java/com/team/independence/goal/service/LoanPlanCalculatorImplTest.java
@@ -8,12 +8,10 @@ import static org.mockito.Mockito.when;
 
 import com.team.independence.asset.dto.account.LoanAccountDetailItem;
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
-import com.team.independence.asset.service.AssetSummaryService;
 import com.team.independence.asset.service.LoanAccountService;
 import com.team.independence.goal.dto.LoanPlans;
 import com.team.independence.goal.service.calculator.BudgetCalculator;
 import com.team.independence.goal.service.calculator.LoanPlanCalculator;
-import com.team.independence.member.dto.MemberProfileResponse;
 import com.team.independence.member.service.MemberService;
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -30,7 +28,6 @@ class LoanPlanCalculatorTest {
 
     @Mock MemberService      memberService;
     @Mock LoanAccountService loanAccountService;
-    @Mock AssetSummaryService assetSummaryService;
 
     private LoanPlanCalculator calculator;
 
@@ -45,7 +42,6 @@ class LoanPlanCalculatorTest {
         calculator = new LoanPlanCalculator(
                 memberService,
                 loanAccountService,
-                assetSummaryService,
                 new BudgetCalculator()
         );
     }
@@ -57,7 +53,7 @@ class LoanPlanCalculatorTest {
     @Test
     @DisplayName("소득이 null이면 대출 한도는 0")
     void 소득_null이면_대출한도_0() {
-        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(null));
+        when(memberService.getMonthlyIncome(MEMBER_ID)).thenReturn(null);
 
         assertEquals(0L, calculator.calcMaxLoanAmount(MEMBER_ID));
     }
@@ -65,7 +61,7 @@ class LoanPlanCalculatorTest {
     @Test
     @DisplayName("소득이 0이면 대출 한도는 0")
     void 소득_0이면_대출한도_0() {
-        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(0L));
+        when(memberService.getMonthlyIncome(MEMBER_ID)).thenReturn(0L);
 
         assertEquals(0L, calculator.calcMaxLoanAmount(MEMBER_ID));
     }
@@ -73,7 +69,7 @@ class LoanPlanCalculatorTest {
     @Test
     @DisplayName("기존 대출이 없으면 월소득 × 40% 전부를 신규 대출 상환에 쓸 수 있다")
     void 기존대출_없으면_DSR_전체_여유() {
-        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(MONTHLY_INCOME));
+        when(memberService.getMonthlyIncome(MEMBER_ID)).thenReturn(MONTHLY_INCOME);
         when(loanAccountService.getLoanAccounts(MEMBER_ID)).thenReturn(List.of());
 
         long maxLoan = calculator.calcMaxLoanAmount(MEMBER_ID);
@@ -87,7 +83,7 @@ class LoanPlanCalculatorTest {
     @Test
     @DisplayName("기존 대출이 DSR 한도를 꽉 채우면 신규 대출 한도는 0")
     void 기존대출_DSR_초과시_신규한도_0() {
-        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(MONTHLY_INCOME));
+        when(memberService.getMonthlyIncome(MEMBER_ID)).thenReturn(MONTHLY_INCOME);
 
         // 기존 대출: 잔액 5억, 잔여 30년 → 월 상환액이 DSR 40%(160만)를 이미 초과
         LoanAccountDetailItem heavyLoan = loanItem(500_000_000L, LocalDate.now().plusYears(30));
@@ -99,7 +95,7 @@ class LoanPlanCalculatorTest {
     @Test
     @DisplayName("기존 대출이 있으면 한도가 줄어든다")
     void 기존대출_있으면_한도_감소() {
-        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(MONTHLY_INCOME));
+        when(memberService.getMonthlyIncome(MEMBER_ID)).thenReturn(MONTHLY_INCOME);
 
         long maxWithout = maxLoanWithNoExistingDebt();
 
@@ -114,7 +110,7 @@ class LoanPlanCalculatorTest {
     @Test
     @DisplayName("만기가 지난 대출은 DSR 부담에서 제외된다")
     void 만기_지난_대출은_DSR_무시() {
-        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(MONTHLY_INCOME));
+        when(memberService.getMonthlyIncome(MEMBER_ID)).thenReturn(MONTHLY_INCOME);
 
         // 이미 만기된 대출
         LoanAccountDetailItem expiredLoan = loanItem(100_000_000L, LocalDate.now().minusDays(1));
@@ -135,10 +131,10 @@ class LoanPlanCalculatorTest {
     @Test
     @DisplayName("소득이 없으면 loanO가 null이다")
     void 소득없으면_loanO_null() {
-        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(null));
-        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(0L, 0L));
+        when(memberService.getMonthlyIncome(MEMBER_ID)).thenReturn(null);
+        AssetNetWorthBreakdown netWorth = netWorth(0L, 0L);
 
-        LoanPlans plans = calculator.calculate(MEMBER_ID, 200_000_000L, YearMonth.now().plusMonths(36), 5_000_000L);
+        LoanPlans plans = calculator.calculate(MEMBER_ID, 200_000_000L, YearMonth.now().plusMonths(36), netWorth, List.of(), 5_000_000L);
 
         assertNotNull(plans.getLoanX());
         assertNull(plans.getLoanO(), "대출 한도 0이면 loanO는 null이어야 한다");
@@ -148,12 +144,11 @@ class LoanPlanCalculatorTest {
     @DisplayName("대출이 목표금액 이상이면 loanO의 월 저축액은 0")
     void 대출이_목표초과시_loanO_저축_0() {
         // 대출 한도 > 목표 금액 → selfFunded = 0
-        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(10_000_000L)); // 고소득
-        when(loanAccountService.getLoanAccounts(MEMBER_ID)).thenReturn(List.of());
-        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(0L, 0L));
+        when(memberService.getMonthlyIncome(MEMBER_ID)).thenReturn(10_000_000L); // 고소득
+        AssetNetWorthBreakdown netWorth = netWorth(0L, 0L);
 
         long requiredAmount = 50_000_000L; // 5천만 (대출 한도보다 훨씬 작음)
-        LoanPlans plans = calculator.calculate(MEMBER_ID, requiredAmount, YearMonth.now().plusMonths(24), 5_000_000L);
+        LoanPlans plans = calculator.calculate(MEMBER_ID, requiredAmount, YearMonth.now().plusMonths(24), netWorth, List.of(), 5_000_000L);
 
         assertNotNull(plans.getLoanO());
         assertEquals(0L, plans.getLoanO().getMonthlySaving(), "대출으로 전액 충당되면 월 저축 0이어야 한다");
@@ -164,12 +159,11 @@ class LoanPlanCalculatorTest {
     @Test
     @DisplayName("loanO의 월 저축액은 loanX보다 작다")
     void loanO_월저축이_loanX보다_작다() {
-        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(MONTHLY_INCOME));
-        when(loanAccountService.getLoanAccounts(MEMBER_ID)).thenReturn(List.of());
-        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(10_000_000L, 5_000_000L));
+        when(memberService.getMonthlyIncome(MEMBER_ID)).thenReturn(MONTHLY_INCOME);
+        AssetNetWorthBreakdown netWorth = netWorth(10_000_000L, 5_000_000L);
 
         // 현재 자산으로는 부족하고 저축이 필요한 규모
-        LoanPlans plans = calculator.calculate(MEMBER_ID, 200_000_000L, YearMonth.now().plusMonths(48), 5_000_000L);
+        LoanPlans plans = calculator.calculate(MEMBER_ID, 200_000_000L, YearMonth.now().plusMonths(48), netWorth, List.of(), 5_000_000L);
 
         assertNotNull(plans.getLoanO());
         assertTrue(plans.getLoanO().getMonthlySaving() < plans.getLoanX().getMonthlySaving(),
@@ -179,12 +173,12 @@ class LoanPlanCalculatorTest {
     @Test
     @DisplayName("loanX의 목표금액과 targetDate는 입력값 그대로다")
     void loanX_필드_검증() {
-        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(null));
-        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(0L, 0L));
+        when(memberService.getMonthlyIncome(MEMBER_ID)).thenReturn(null);
+        AssetNetWorthBreakdown netWorth = netWorth(0L, 0L);
 
         long requiredAmount = 150_000_000L;
         YearMonth targetDate = YearMonth.now().plusMonths(30);
-        LoanPlans plans = calculator.calculate(MEMBER_ID, requiredAmount, targetDate, 5_000_000L);
+        LoanPlans plans = calculator.calculate(MEMBER_ID, requiredAmount, targetDate, netWorth, List.of(), 5_000_000L);
 
         assertEquals(requiredAmount, plans.getLoanX().getTargetAmount());
         assertEquals(targetDate, plans.getLoanX().getTargetDate());
@@ -193,11 +187,11 @@ class LoanPlanCalculatorTest {
     @Test
     @DisplayName("이미 자산이 목표금액 이상이면 월 저축액은 0")
     void 자산이_목표초과시_저축_0() {
-        when(memberService.getMember(MEMBER_ID)).thenReturn(profile(null));
+        when(memberService.getMonthlyIncome(MEMBER_ID)).thenReturn(null);
         // 현재 자산 2억 > 목표 1억
-        when(assetSummaryService.getNetWorthBreakdown(MEMBER_ID)).thenReturn(netWorth(200_000_000L, 0L));
+        AssetNetWorthBreakdown netWorth = netWorth(200_000_000L, 0L);
 
-        LoanPlans plans = calculator.calculate(MEMBER_ID, 100_000_000L, YearMonth.now().plusMonths(24), 5_000_000L);
+        LoanPlans plans = calculator.calculate(MEMBER_ID, 100_000_000L, YearMonth.now().plusMonths(24), netWorth, List.of(), 5_000_000L);
 
         assertEquals(0L, plans.getLoanX().getMonthlySaving(), "자산이 이미 충분하면 저축 0이어야 한다");
     }
@@ -205,10 +199,6 @@ class LoanPlanCalculatorTest {
     // -----------------------------------------------------------------------
     // 헬퍼
     // -----------------------------------------------------------------------
-
-    private MemberProfileResponse profile(Long monthlyIncome) {
-        return new MemberProfileResponse(MEMBER_ID, "테스터", null, monthlyIncome, null, false, false);
-    }
 
     private AssetNetWorthBreakdown netWorth(long interestBearing, long flat) {
         return AssetNetWorthBreakdown.builder()

--- a/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/PreferenceAlgorithmTest.java
@@ -77,7 +77,7 @@ class PreferenceAlgorithmTest {
                 .build();
         ctx = new MemberFinancialContext(defaultNetWorth, 10_000_000L, List.of());
 
-        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), anyLong()))
+        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), any(), any(), anyLong()))
                 .thenReturn(LoanPlans.builder().build());
         when(loanPlanCalculator.calculateSavingFixed(anyLong(), anyLong(), any(), anyLong(), any()))
                 .thenReturn(LoanPlans.builder().build());
@@ -180,7 +180,7 @@ class PreferenceAlgorithmTest {
                         .loanX(GoalRecommendationResponse.LoanXPlan.builder()
                                 .targetAmount(1000 * 만).monthlySaving(1_000_000L).build())
                         .build());
-        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), anyLong()))
+        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), any(), any(), anyLong()))
                 .thenReturn(LoanPlans.builder()
                         .loanX(GoalRecommendationResponse.LoanXPlan.builder()
                                 .targetAmount(1000 * 만).monthlySaving(500_000L).build())
@@ -259,7 +259,7 @@ class PreferenceAlgorithmTest {
         assertThat(result).hasSize(2);
         assertThat(result.get(1).getType()).isEqualTo(AlgorithmType.PREFERENCE_DATE_FIXED);
         assertThat(result.get(1).getCondition()).isNotNull();
-        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(2 * 억), any(), anyLong());
+        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(2 * 억), any(), any(), any(), anyLong());
     }
 
     // ===== 헬퍼 =====

--- a/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
+++ b/src/test/java/com/team/independence/goal/service/algorithm/RealisticAlgorithmTest.java
@@ -172,7 +172,7 @@ class RealisticAlgorithmTest {
                     return result;
                 });
 
-        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), anyLong()))
+        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), any(), any(), anyLong()))
                 .thenReturn(LoanPlans.builder().build());
     }
 
@@ -191,7 +191,7 @@ class RealisticAlgorithmTest {
         assertThat(item.getCondition().getAreaMin()).isEqualTo(15);
         assertThat(item.getCondition().getAreaMax()).isEqualTo(19);
         // 화면에 나가는 목표 금액은 실제 보증금이다.
-        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(2 * 억), any(), anyLong());
+        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(2 * 억), any(), any(), any(), anyLong());
     }
 
     @Test
@@ -243,7 +243,7 @@ class RealisticAlgorithmTest {
         assertThat(item.getCondition().getDealType()).isEqualTo(DealType.WOLSE);
         assertThat(item.getCondition().getMonthlyRent()).isEqualTo(40 * 만);
         // 환산값(1.06억)이 아니라 실제로 모아야 하는 보증금(1,000만)을 넘긴다.
-        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(1000 * 만), any(), anyLong());
+        verify(loanPlanCalculator).calculate(eq(MEMBER_ID), eq(1000 * 만), any(), any(), any(), anyLong());
     }
 
     @Test
@@ -251,7 +251,7 @@ class RealisticAlgorithmTest {
     void addsMonthlyRentToLoanXAndLoanOWhenWolseChosen() {
         put("11110", HousingType.APT, DealType.WOLSE, 15, 1000 * 만, 40 * 만);
 
-        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), anyLong()))
+        when(loanPlanCalculator.calculate(anyLong(), anyLong(), any(), any(), any(), anyLong()))
                 .thenReturn(LoanPlans.builder()
                         .loanX(GoalRecommendationResponse.LoanXPlan.builder()
                                 .targetAmount(1000 * 만).monthlySaving(1_000_000L).build())

--- a/src/test/java/com/team/independence/property/service/RentMedianIntegrationTest.java
+++ b/src/test/java/com/team/independence/property/service/RentMedianIntegrationTest.java
@@ -9,6 +9,7 @@ import com.team.independence.property.dto.MedianAggResult;
 import com.team.independence.property.dto.RentMedianRequest;
 import com.team.independence.property.dto.RentMedianResponse;
 import com.team.independence.property.mapper.RentTransactionMapper;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -69,6 +70,7 @@ class RentMedianIntegrationTest {
     void 전세_금액_조회() {
         MedianAggResult agg = rentTransactionMapper.findAggregatedMedian(
                 request(DealType.JEONSE, null, null),
+                List.of(REGION_CODE),
                 AREA_MIN_SQM, AREA_MAX_SQM, DEAL_YM, DEAL_YM);
 
         System.out.println("전세 조회 건수: " + agg.getSampleCount());
@@ -86,6 +88,7 @@ class RentMedianIntegrationTest {
     void 월세_금액_조회() {
         MedianAggResult agg = rentTransactionMapper.findAggregatedMedian(
                 request(DealType.WOLSE, MONTHLY_RENT_MIN, MONTHLY_RENT_MAX),
+                List.of(REGION_CODE),
                 AREA_MIN_SQM, AREA_MAX_SQM, DEAL_YM, DEAL_YM);
 
         System.out.println("월세 조회 건수: " + agg.getSampleCount());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #158

## 📝작업 내용

`/api/v1/goals/recommendations` 호출 경로(컨트롤러 → `GoalRecommendationServiceImpl` → Realistic/HoldOut/Preference 알고리즘 → property/asset 레이어 → SQL)의 병목 지점을 분석하고, DB 인덱스·중복 쿼리·캐시 왕복·루프 내 재계산·스레드풀/커넥션풀·트랜잭션 범위 8건을 커밋 단위로 개선했습니다.

### 1. `rent_transaction` 조회 인덱스를 커버링 인덱스로 확장 (`8f18c02`)
`idx_rent_query`에 `area, deposit, monthly_rent`를 추가했습니다. median·PriceModel 계열 쿼리가 구간 필터 후 매번 타던 테이블 랜덤 룩업을 인덱스만으로 처리합니다.
- ⚠️ 기존 DB에는 자동 반영되지 않습니다 — `sql/full_schema.sql` 하단의 `ALTER TABLE ... DROP INDEX / ADD KEY`를 운영/스테이징에 별도 실행해야 합니다.

### 2. 시도 단위 조회를 LIKE 프리픽스 → 시군구 IN 목록으로 전환 (`312c522`)
`findAggregatedMedian`, `findBulkMedianBatch`가 시도(2자리) 코드를 `region_code LIKE '11%'`로 처리해 뒤따르는 인덱스 컬럼을 못 타던 문제를 `findMediansByRegionCodes`와 동일한 IN 방식으로 통일했습니다.

### 3. 추천 경로의 회원·자산·대출 중복 조회 제거 (`f597cdb`)
- `LoanPlanCalculator.calculate()`가 상위에서 이미 조회한 `netWorth`를 내부에서 재조회하던 것을 제거했습니다.
- 기존 대출 월 상환액 합계를 계좌 재조회 대신 이미 확보한 `loanSchedules`에서 합산하도록 바꿨습니다.
- `MemberService.getMonthlyIncome()`을 신설했습니다 — DSR 한도 계산이 월소득 한 필드 때문에 회원 전체+약관 조인을 불러오던 것을 개선했습니다.

### 4. PriceModel 배치 캐시를 MGET·파이프라인 한 번으로 묶음 (`a5ce66f`)
`estimateBatch()`의 개별 `GET`/`SET` 루프(40회)를 `PriceModelStore.findAll()`(MGET)·`saveAll()`(파이프라인)로 교체했습니다. Realistic+HoldOut 합산 Redis 왕복이 80회 → 2회로 줄었습니다.

### 5. RealisticAlgorithm 예산 계산을 조합 평가 루프 밖으로 이동 (`ca0a83e`)
후보와 무관한 `budgetAtT`가 `lookUp()` 안에서 후보마다(최대 40회) 재계산되던 것을 `Search` 생성 시 1회로 이동했습니다.

### 6. BudgetCalculator 월별 루프의 스트림 재순회·이율 재계산 제거 (`aa7db00`)
매달 전체 대출 스케줄을 스트림으로 재순회하던 것을 잔여 기간 정렬 후 커서로 만기 대출을 제거하는 `ActiveLoanPayments`로 교체했습니다(`monthsToReach`는 최대 1200회 반복). 월 복리 이율도 상수화했습니다.
- 무작위 입력 500건으로 기존 구현과 결과가 완전히 일치함을 확인한 뒤 검증용 테스트는 정리했습니다.

### 7. 병렬 실행 풀·커넥션 풀 설정과 트랜잭션 범위 조정 (`950bdd9`)
- `algorithmExecutor`: core 3/queue 20 → core 8/max 16/queue 8 + `CallerRunsPolicy`
- Hikari `maximumPoolSize`: 10 → 20
- `recommend()`/`getSavedRecommendation()`의 불필요한 `@Transactional(readOnly = true)`를 제거했습니다 (요청 스레드가 알고리즘 스레드 대기 중 안 쓰는 커넥션을 붙잡던 문제).

### 8. originalPreference 기준 시세 조회를 Phase 1 병렬 구간으로 이동 (`37b0387`)
모든 알고리즘 완료 후 직렬로 붙던 `resolveBaseMedianAmount()` 호출을 병렬 구간으로 이동했습니다.

## 💬리뷰 요구사항(선택)

- ①번(인덱스) 마이그레이션은 코드 병합과 별개로 운영/스테이징 DB에 직접 적용해야 합니다.
- ⑦번의 Hikari `maximumPoolSize` 20이 MySQL `max_connections` 및 배치 프로필과 충돌하지 않는지 확인 부탁드립니다.
