### PR TITLE
chore: 목표 추천 30초 타임아웃 진단용 임시 계측 추가

### DIFF
--- a/src/main/java/com/team/independence/common/diagnostics/RecommendationProfiler.java
+++ b/src/main/java/com/team/independence/common/diagnostics/RecommendationProfiler.java
@@ -1,0 +1,47 @@
+package com.team.independence.common.diagnostics;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * 추천 30초 타임아웃 진단용 임시 계측기
+ */
+public final class RecommendationProfiler {
+
+    private static final AtomicLong mcCalls = new AtomicLong();
+    private static final AtomicLong mcNanos = new AtomicLong();
+    private static final AtomicLong pmDbQueries = new AtomicLong();
+    private static final AtomicLong pmDbNanos = new AtomicLong();
+    private static final AtomicLong pmCacheHits = new AtomicLong();
+
+    private RecommendationProfiler() {
+    }
+
+    public static void reset() {
+        mcCalls.set(0);
+        mcNanos.set(0);
+        pmDbQueries.set(0);
+        pmDbNanos.set(0);
+        pmCacheHits.set(0);
+    }
+
+    public static void recordMc(long nanos) {
+        mcCalls.incrementAndGet();
+        mcNanos.addAndGet(nanos);
+    }
+
+    public static void recordPmDb(long nanos) {
+        pmDbQueries.incrementAndGet();
+        pmDbNanos.addAndGet(nanos);
+    }
+
+    public static void recordPmHit() {
+        pmCacheHits.incrementAndGet();
+    }
+
+    public static String summary() {
+        return String.format(
+                "MC호출=%d회 MC누적=%dms | 가격모델DB쿼리=%d회 DB누적=%dms 캐시HIT=%d회",
+                mcCalls.get(), mcNanos.get() / 1_000_000,
+                pmDbQueries.get(), pmDbNanos.get() / 1_000_000, pmCacheHits.get());
+    }
+}

--- a/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/GoalRecommendationServiceImpl.java
@@ -3,6 +3,7 @@ package com.team.independence.goal.service;
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
 import com.team.independence.asset.service.AssetConnectionService;
 import com.team.independence.asset.service.AssetSummaryService;
+import com.team.independence.common.diagnostics.RecommendationProfiler;
 import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.goal.dto.GoalRecommendationRequest;
@@ -70,6 +71,8 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
      */
     @Override
     public GoalRecommendationResponse recommend(long memberId, GoalRecommendationRequest request) {
+        RecommendationProfiler.reset();
+        long startedAt = System.nanoTime();
         assetConnectionService.validateConnectedAccountExists(memberId);
 
         AssetNetWorthBreakdown netWorth = assetSummaryService.getNetWorthBreakdown(memberId);
@@ -126,6 +129,9 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
                 .build();
 
         recommendationStore.save(memberId, response);
+        log.info("[추천계측] 총 {}ms | 추천카드={}개 | {}",
+                (System.nanoTime() - startedAt) / 1_000_000, recommendations.size(),
+                RecommendationProfiler.summary());
         return response;
     }
 
@@ -200,8 +206,11 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
     private List<GoalRecommendationResponse.RecommendationItem> runSafely(
             RecommendationAlgorithm algorithm, long memberId,
             GoalRecommendationRequest request, MemberFinancialContext ctx) {
+        long t0 = System.nanoTime();
         try {
-            return algorithm.recommend(memberId, request, ctx);
+            List<GoalRecommendationResponse.RecommendationItem> result = algorithm.recommend(memberId, request, ctx);
+            log.info("[추천계측] {} {}ms", algorithm.getClass().getSimpleName(), (System.nanoTime() - t0) / 1_000_000);
+            return result;
         } catch (Exception e) {
             log.error("추천 알고리즘 실행 실패. algorithm={}, memberId={}",
                     algorithm.getClass().getSimpleName(), memberId, e);
@@ -212,8 +221,12 @@ public class GoalRecommendationServiceImpl implements GoalRecommendationService 
     private List<GoalRecommendationResponse.RecommendationItem> runHoldOutSafely(
             long memberId, GoalRecommendationRequest request, MemberFinancialContext ctx,
             GoalRecommendationResponse.RecommendationItem realisticItem) {
+        long t0 = System.nanoTime();
         try {
-            return holdOutAlgorithm.recommend(memberId, request, ctx, realisticItem);
+            List<GoalRecommendationResponse.RecommendationItem> result =
+                    holdOutAlgorithm.recommend(memberId, request, ctx, realisticItem);
+            log.info("[추천계측] HoldOutAlgorithm {}ms", (System.nanoTime() - t0) / 1_000_000);
+            return result;
         } catch (Exception e) {
             log.error("HoldOut 알고리즘 실행 실패. memberId={}", memberId, e);
             return List.of();

--- a/src/main/java/com/team/independence/goal/service/MonteCarloServiceImpl.java
+++ b/src/main/java/com/team/independence/goal/service/MonteCarloServiceImpl.java
@@ -3,6 +3,7 @@ package com.team.independence.goal.service;
 import com.team.independence.asset.dto.summary.AssetNetWorthBreakdown;
 import com.team.independence.asset.service.AssetConnectionService;
 import com.team.independence.asset.service.AssetSummaryService;
+import com.team.independence.common.diagnostics.RecommendationProfiler;
 import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.goal.domain.Goal;
@@ -107,10 +108,13 @@ public class MonteCarloServiceImpl implements MonteCarloService {
 
     @Override
     public MonteCarloEngine.Result simulate(PriceModelResponse priceModel, long initialPrice, long budgetAtT, int months) {
-        return MonteCarloEngine.simulate(
+        long t0 = System.nanoTime();
+        MonteCarloEngine.Result result = MonteCarloEngine.simulate(
                 priceModel.getAnnualDrift(), priceModel.getAnnualVol(),
                 initialPrice, budgetAtT,
                 months, MonteCarloEngine.DEFAULT_SIMULATIONS, MonteCarloEngine.DEFAULT_SEED);
+        RecommendationProfiler.recordMc(System.nanoTime() - t0);
+        return result;
     }
 
     private PriceModelRequest buildPriceModelRequest(GoalHousing housing) {

--- a/src/main/java/com/team/independence/property/service/PriceModelServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/PriceModelServiceImpl.java
@@ -1,5 +1,6 @@
 package com.team.independence.property.service;
 
+import com.team.independence.common.diagnostics.RecommendationProfiler;
 import com.team.independence.common.exception.BusinessException;
 import com.team.independence.common.exception.ErrorCode;
 import com.team.independence.property.dto.MonthlyPricePoint;
@@ -46,6 +47,7 @@ public class PriceModelServiceImpl implements PriceModelService {
     public PriceModelResponse estimate(PriceModelRequest request) {
         Optional<PriceModelResponse> cached = priceModelStore.find(request);
         if (cached.isPresent()) {
+            RecommendationProfiler.recordPmHit();
             return cached.get();
         }
 
@@ -59,6 +61,7 @@ public class PriceModelServiceImpl implements PriceModelService {
         String startYm = start.format(YM);
         String endYm = end.format(YM);
 
+        long t0 = System.nanoTime();
         List<MonthlyPricePoint> raw = rentTransactionMapper.findAmountsForPriceModel(
                 request.getRegionCode(),
                 request.getHousingType(),
@@ -67,6 +70,7 @@ public class PriceModelServiceImpl implements PriceModelService {
                 toSqm(request.getAreaMax()),
                 startYm,
                 endYm);
+        RecommendationProfiler.recordPmDb(System.nanoTime() - t0);
 
         // 월별 그룹핑 → 표본 부족 월 제외 → 평단가 중앙값 시계열
         List<Double> monthlyMedians = raw.stream()


### PR DESCRIPTION
## #️⃣연관된 이슈

Related to #163

## 📝작업 내용

목표 추천에서 서울 전체 최소 입력 요청이 30초 타임아웃 나는 원인을 수치로 확정하기 위한 임시 계측입니다. 로직은 바꾸지 않고 측정 훅만 추가했습니다.

배경: 배포 환경에서 같은 요청이 어느 순간 정상으로 뜸 → `priceModelStore`(Redis, TTL 12h) 캐시 워밍으로 추정. MC는 알고리즘 경로에서 캐시되지 않는데(매번 10k 재계산) 결과가 뒤집힘 → 30초 타임아웃 요인이 MC CPU가 아니라 콜드 상태의 가격모델 `estimate()`(3년치 DB fetch + Java 집계 × ~40조합)인지 확인하려는 것.

측정 항목(로그 태그 `[추천계측]`):
- 총 소요시간 / 알고리즘별 소요시간 (Realistic / HoldOut / Preference)
- MC 엔진 10k 호출 수, 누적 CPU 시간
- 가격모델 DB쿼리 수, 누적 DB 시간, 캐시 HIT 수

변경 파일(4개):
- `common/diagnostics/RecommendationProfiler.java` (신규): 정적 AtomicLong 카운터(단건 재현 전제). reset/summary + record 훅
- `goal/service/GoalRecommendationServiceImpl.java`: recommend() 시작 시 reset, 종료 시 총/알고리즘별 시간, summary 로그
- `goal/service/MonteCarloServiceImpl.java`: 엔진 호출이 있는 `simulate(PriceModelResponse,...)` 오버로드에 MC 타이밍
- `property/service/PriceModelServiceImpl.java`: estimate()의 캐시 HIT / DB쿼리 시간 계측

검증 방법: 배포 환경에서 (1) 웜 1건 → `가격모델DB쿼리≈0`, (2) `property:priceModel:*` flush 후 콜드 1건 → `가격모델DB쿼리≈40, DB누적 큼, 총>30000ms`. 두 로그의 DB누적, MC누적 차이로 #163 가설 채택/기각

## 💬리뷰 요구사항(선택)

- 임시 진단용 코드입니다. #163 측정이 끝나면 `RecommendationProfiler`와 호출부를 통째로 제거하는 후속 PR을 올릴 예정입니다.
- `RecommendationProfiler`를 `common/diagnostics`에 둔 이유: property 도메인의 `PriceModelServiceImpl`도 참조해야 하는데, goal 패키지에 두면 property→goal 레이어링 역방향 위반이라 공용 위치로 뺐습니다.
- 카운터가 JVM 정적 공유라 동시 요청 시 오염됩니다. 단건 진단 전제라 의도한 한계이며, 부하 테스트 용도가 아닙니다.