### PR TITLE
chore: estimateBatch 경로에 추천 계측 훅 추가

### DIFF
--- a/src/main/java/com/team/independence/property/service/PriceModelServiceImpl.java
+++ b/src/main/java/com/team/independence/property/service/PriceModelServiceImpl.java
@@ -115,7 +115,9 @@ public class PriceModelServiceImpl implements PriceModelService {
 
         // 1) 캐시 조회 — MGET 한 번으로 전체 조합을 확인하고, 미스만 다음 단계로 넘긴다.
         //    조합마다 GET을 돌리면 40개 키에 왕복 40회가 나가고 Realistic·HoldOut이 연달아 불러 80회가 된다.
-        result.putAll(priceModelStore.findAll(regionCode, keys));
+        Map<PriceModelKey, PriceModelResponse> cacheHits = priceModelStore.findAll(regionCode, keys);
+        cacheHits.forEach((k, v) -> RecommendationProfiler.recordPmHit());
+        result.putAll(cacheHits);
 
         List<PriceModelKey> misses = new ArrayList<>();
         for (PriceModelKey key : keys) {
@@ -145,8 +147,10 @@ public class PriceModelServiceImpl implements PriceModelService {
         }
         List<TypeDealPair> typePairs = new ArrayList<>(pairSet);
 
+        long t0 = System.nanoTime();
         List<PriceModelBatchRow> rows = rentTransactionMapper.findAmountsForPriceModelBatch(
                 regionCode, typePairs, startYm, endYm);
+        RecommendationProfiler.recordPmDb(System.nanoTime() - t0);
 
         // 3) 조합 키(ht|dt|areaMin|areaMax)별로 행을 재그룹핑한다. area는 SIZE_BUCKETS 하드코딩 경계와 정확히 일치.
         Map<PriceModelKey, List<MonthlyPricePoint>> perKey = new HashMap<>();


### PR DESCRIPTION
## #️⃣연관된 이슈

#165

## 📝작업 내용

`RecommendationProfiler`의 계측 훅이 단건 `estimate()`에만 있어, 추천 알고리즘(Realistic, HoldOut)이 실제로 타는 `estimateBatch()` 경로를 못 보는 사각지대를 보완합니다.

- **캐시 HIT 계측**: `findAll`(Redis MGET) 결과를 조합별로 `recordPmHit()` 카운트
- **배치 DB 계측**: `findAmountsForPriceModelBatch` 호출을 `System.nanoTime()`으로 감싸 `recordPmDb()`로 기록

### 왜 필요한가
직전 웜 측정에서 `가격모델DB쿼리=0회 / 캐시HIT=0회`로 찍혔지만, DEBUG SQL 로그를 보면 `findAmountsForPriceModelBatch`가 실제로 2회(각 9265행) 실행됐습니다. 프로파일러가 배치 경로를 못 봐서 생긴 착시입니다. 이 훅 없이 콜드를 측정하면 콜드 DB 비용도 0으로 찍혀 30초 인시던트(#163)의 실체를 못 잡습니다.

## 💬리뷰 요구사항(선택)

- `RecommendationProfiler`는 진단용 임시 계측기입니다. 콜드/웜 측정이 끝나면 훅과 함께 통째로 제거하는 후속 PR을 낼 예정입니다.