### PR TITLE
feat: 온통청년 주거 정책 배치 동기화 및 조회 API 구현

### DIFF
--- a/src/main/java/com/team/independence/common/controller/BatchTriggerController.java
+++ b/src/main/java/com/team/independence/common/controller/BatchTriggerController.java
@@ -3,6 +3,7 @@ package com.team.independence.common.controller;
 import com.team.independence.common.response.ApiResponse;
 import com.team.independence.compare.service.GoalSnapshotBatchService;
 import com.team.independence.goal.service.GoalMarketTrendBatchService;
+import com.team.independence.policy.service.PolicySyncService;
 import com.team.independence.property.service.RentTransactionSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +31,7 @@ public class BatchTriggerController {
     private final RentTransactionSyncService rentTransactionSyncService;
     private final GoalSnapshotBatchService goalSnapshotBatchService;
     private final GoalMarketTrendBatchService goalMarketTrendBatchService;
+    private final PolicySyncService policySyncService;
 
     /** 전체 배치를 순서대로 실행한다. 초기 데이터 세팅 시 사용. */
     @PostMapping("/all")
@@ -77,5 +79,14 @@ public class BatchTriggerController {
         goalMarketTrendBatchService.refreshAll();
         log.info("[수동 배치] 목표 시세 변화 갱신 완료");
         return ApiResponse.ok("목표 시세 변화 갱신 완료.");
+    }
+
+    /** 온통청년 주거 정책 동기화만 실행한다. */
+    @PostMapping("/policy-sync")
+    public ApiResponse<String> syncPolicies() {
+        log.info("[수동 배치] 정책 동기화 시작");
+        policySyncService.syncAll();
+        log.info("[수동 배치] 정책 동기화 완료");
+        return ApiResponse.ok("온통청년 주거 정책 동기화 완료.");
     }
 }

--- a/src/main/java/com/team/independence/common/exception/ErrorCode.java
+++ b/src/main/java/com/team/independence/common/exception/ErrorCode.java
@@ -61,6 +61,7 @@ public enum ErrorCode {
 
     // ===== 정책 POLICY_xxx =====
     POLICY_NOT_FOUND("POLICY_001", "정책을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    POLICY_SYNC_FAILED("POLICY_002", "정책 동기화에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
     // ===== 매물 PROPERTY_xxx =====
     REGION_NOT_FOUND("PROPERTY_001", "존재하지 않는 지역 코드입니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/team/independence/config/WebConfig.java
+++ b/src/main/java/com/team/independence/config/WebConfig.java
@@ -54,7 +54,9 @@ public class WebConfig implements WebMvcConfigurer {
                         "/api/v1/oauth/**",
                         "/api/v1/auth/refresh",
                         "/api/v1/members/health",
-                        "/api/v1/admin/batch/**"
+                        "/api/v1/admin/batch/**",
+                        "/api/v1/policies",
+                        "/api/v1/policies/**"
                 );
     }
 

--- a/src/main/java/com/team/independence/external/ontong/OntongPolicyClient.java
+++ b/src/main/java/com/team/independence/external/ontong/OntongPolicyClient.java
@@ -1,0 +1,9 @@
+package com.team.independence.external.ontong;
+
+import com.team.independence.external.ontong.dto.OntongPolicyItem;
+import java.util.List;
+
+public interface OntongPolicyClient {
+
+    List<OntongPolicyItem> fetchHousingPolicies();
+}

--- a/src/main/java/com/team/independence/external/ontong/OntongPolicyMockClient.java
+++ b/src/main/java/com/team/independence/external/ontong/OntongPolicyMockClient.java
@@ -1,0 +1,60 @@
+package com.team.independence.external.ontong;
+
+import com.team.independence.external.ontong.dto.OntongPolicyItem;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("local")
+public class OntongPolicyMockClient implements OntongPolicyClient {
+
+    @Override
+    public List<OntongPolicyItem> fetchHousingPolicies() {
+        log.info("[온통청년] Mock 클라이언트 사용 (local 프로필)");
+
+        OntongPolicyItem item1 = new OntongPolicyItem();
+        setField(item1, "plcyNo", "20240101000000000001");
+        setField(item1, "plcyNm", "[Mock] 청년 전세자금 대출");
+        setField(item1, "plcyExplnCn", "청년을 위한 전세자금 대출 지원 정책입니다.");
+        setField(item1, "lclsfNm", "주거");
+        setField(item1, "mclsfNm", "금융지원");
+        setField(item1, "plcySprtCn", "전세자금 최대 2억 원 저금리 대출");
+        setField(item1, "sprvsnInstCdNm", "국토교통부");
+        setField(item1, "aplyPrdSeCd", "0057001");
+        setField(item1, "sprtTrgtMinAge", "19");
+        setField(item1, "sprtTrgtMaxAge", "34");
+        setField(item1, "sprtTrgtAgeLmtYn", "Y");
+        setField(item1, "aplyUrlAddr", "https://apply.lh.or.kr/");
+        setField(item1, "aplyYmd", "");
+
+        OntongPolicyItem item2 = new OntongPolicyItem();
+        setField(item2, "plcyNo", "20240101000000000002");
+        setField(item2, "plcyNm", "[Mock] 청년 월세 지원");
+        setField(item2, "plcyExplnCn", "청년 월세 부담 완화를 위한 월세 보조금 지원입니다.");
+        setField(item2, "lclsfNm", "주거");
+        setField(item2, "mclsfNm", "주거비지원");
+        setField(item2, "plcySprtCn", "월 최대 20만 원, 최장 12개월 지원");
+        setField(item2, "sprvsnInstCdNm", "국토교통부");
+        setField(item2, "aplyPrdSeCd", "0057002");
+        setField(item2, "bizPrdBgngYmd", "20240101");
+        setField(item2, "bizPrdEndYmd", "20241231");
+        setField(item2, "sprtTrgtMinAge", "19");
+        setField(item2, "sprtTrgtMaxAge", "39");
+        setField(item2, "sprtTrgtAgeLmtYn", "Y");
+        setField(item2, "aplyYmd", "20240101 ~ 20241231");
+
+        return List.of(item1, item2);
+    }
+
+    private void setField(OntongPolicyItem item, String field, String value) {
+        try {
+            var f = OntongPolicyItem.class.getDeclaredField(field);
+            f.setAccessible(true);
+            f.set(item, value);
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/src/main/java/com/team/independence/external/ontong/OntongPolicyRealClient.java
+++ b/src/main/java/com/team/independence/external/ontong/OntongPolicyRealClient.java
@@ -1,0 +1,79 @@
+package com.team.independence.external.ontong;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.independence.external.ontong.dto.OntongApiResponse;
+import com.team.independence.external.ontong.dto.OntongPolicyItem;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+@Profile("!local")
+@RequiredArgsConstructor
+public class OntongPolicyRealClient implements OntongPolicyClient {
+
+    private static final String HOUSING_CATEGORY = "주거";
+
+    private final OntongProperties properties;
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public List<OntongPolicyItem> fetchHousingPolicies() {
+        List<OntongPolicyItem> all = new ArrayList<>();
+        int pageNum = 1;
+
+        do {
+            String url = UriComponentsBuilder
+                    .fromHttpUrl(properties.getBaseUrl() + "/getPlcy")
+                    .queryParam("apiKeyNm", properties.getApiKey())
+                    .queryParam("rtnType", "json")
+                    .queryParam("lclsfNm", HOUSING_CATEGORY)
+                    .queryParam("pageNum", pageNum)
+                    .queryParam("pageSize", properties.getPageSize())
+                    .build(false)
+                    .toUriString();
+
+            String raw = restTemplate.getForObject(url, String.class);
+            OntongApiResponse response = parse(raw);
+
+            if (response.getResultCode() != 200 || response.getResult() == null) {
+                throw new RuntimeException("[온통청년] API 오류. resultCode=" + response.getResultCode()
+                        + " message=" + response.getResultMessage());
+            }
+
+            List<OntongPolicyItem> items = response.getResult().getYouthPolicyList();
+            if (items == null || items.isEmpty()) {
+                break;
+            }
+
+            all.addAll(items);
+            int totCount = response.getResult().getPagging().getTotCount();
+            log.debug("[온통청년] 페이지={} 수집={}/{}", pageNum, all.size(), totCount);
+
+            if (all.size() >= totCount) {
+                break;
+            }
+            pageNum++;
+
+        } while (true);
+
+        log.info("[온통청년] 주거 정책 수집 완료: {}건", all.size());
+        return all;
+    }
+
+    private OntongApiResponse parse(String raw) {
+        try {
+            return objectMapper.readValue(raw, OntongApiResponse.class);
+        } catch (Exception e) {
+            throw new RuntimeException("[온통청년] 응답 파싱 실패: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/team/independence/external/ontong/OntongProperties.java
+++ b/src/main/java/com/team/independence/external/ontong/OntongProperties.java
@@ -1,0 +1,19 @@
+package com.team.independence.external.ontong;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class OntongProperties {
+
+    @Value("${youth.api.base-url}")
+    private String baseUrl;
+
+    @Value("${youth.api.key}")
+    private String apiKey;
+
+    @Value("${youth.api.page-size:100}")
+    private int pageSize;
+}

--- a/src/main/java/com/team/independence/external/ontong/dto/OntongApiResponse.java
+++ b/src/main/java/com/team/independence/external/ontong/dto/OntongApiResponse.java
@@ -1,0 +1,33 @@
+package com.team.independence.external.ontong.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OntongApiResponse {
+
+    private int resultCode;
+    private String resultMessage;
+    private OntongResult result;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class OntongResult {
+        private OntongPaging pagging;
+        private List<OntongPolicyItem> youthPolicyList;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class OntongPaging {
+        private int totCount;
+        private int pageNum;
+        private int pageSize;
+    }
+}

--- a/src/main/java/com/team/independence/external/ontong/dto/OntongPolicyItem.java
+++ b/src/main/java/com/team/independence/external/ontong/dto/OntongPolicyItem.java
@@ -1,0 +1,45 @@
+package com.team.independence.external.ontong.dto;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 온통청년 API youthPolicyList 단건 항목
+ * 필드명은 API 원본 그대로 유지
+ * extras는 매핑되지 않은 나머지 필드를 전부 흡수해 extra 컬럼에 직렬화
+ */
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = false)
+public class OntongPolicyItem {
+
+    private String plcyNo;
+    private String plcyNm;
+    private String plcyExplnCn;
+    private String lclsfNm;
+    private String mclsfNm;
+    private String plcyPvsnMthdCd;
+    private String plcySprtCn;
+    private String sprvsnInstCdNm;
+    private String addAplyQlfcCndCn;
+    private String aplyPrdSeCd;
+    private String bizPrdBgngYmd;
+    private String bizPrdEndYmd;
+    private String aplyYmd;
+    private String aplyUrlAddr;
+    private String refUrlAddr1;
+    private String sprtTrgtMinAge;
+    private String sprtTrgtMaxAge;
+    private String sprtTrgtAgeLmtYn;
+
+    private final Map<String, Object> extras = new LinkedHashMap<>();
+
+    @JsonAnySetter
+    public void setExtra(String key, Object value) {
+        extras.put(key, value);
+    }
+}

--- a/src/main/java/com/team/independence/policy/controller/PolicyController.java
+++ b/src/main/java/com/team/independence/policy/controller/PolicyController.java
@@ -1,0 +1,42 @@
+package com.team.independence.policy.controller;
+
+import com.team.independence.common.response.ApiResponse;
+import com.team.independence.policy.dto.PolicyDetailResponse;
+import com.team.independence.policy.dto.PolicyListRequest;
+import com.team.independence.policy.dto.PolicySummaryResponse;
+import com.team.independence.policy.service.PolicyService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/policies")
+@RequiredArgsConstructor
+public class PolicyController {
+
+    private final PolicyService policyService;
+
+    @GetMapping
+    public ApiResponse<Map<String, Object>> getList(@ModelAttribute PolicyListRequest request) {
+        List<PolicySummaryResponse> policies = policyService.getList(request);
+        long totalCount = policyService.countList(request);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("policies", policies);
+        body.put("totalCount", totalCount);
+        body.put("page", request.getPage());
+        body.put("size", request.getSize());
+        return ApiResponse.ok(body);
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<PolicyDetailResponse> getDetail(@PathVariable Long id) {
+        return ApiResponse.ok(policyService.getDetail(id));
+    }
+}

--- a/src/main/java/com/team/independence/policy/domain/Policy.java
+++ b/src/main/java/com/team/independence/policy/domain/Policy.java
@@ -1,0 +1,63 @@
+package com.team.independence.policy.domain;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class Policy {
+
+    private Long id;
+    private String sourceApi;
+    private String policyApiId;
+    private String largeCategory;
+    private String mediumCategory;
+    private String providingMethod;
+    private String policyName;
+    private String policySummary;
+    private String targetDescription;
+    private String benefitDescription;
+    private String providingOrgName;
+    private String applyPeriodType;
+    private LocalDate applyStartDate;
+    private LocalDate applyEndDate;
+    private String applyUrl;
+    private Integer minAge;
+    private Integer maxAge;
+    private String extra;
+    private boolean isActive;
+    private String applicableGoalTypes;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Policy(String sourceApi, String policyApiId, String largeCategory, String mediumCategory,
+                  String providingMethod, String policyName, String policySummary,
+                  String targetDescription, String benefitDescription, String providingOrgName,
+                  String applyPeriodType, LocalDate applyStartDate, LocalDate applyEndDate,
+                  String applyUrl, Integer minAge, Integer maxAge, String extra,
+                  boolean isActive, String applicableGoalTypes) {
+        this.sourceApi = sourceApi;
+        this.policyApiId = policyApiId;
+        this.largeCategory = largeCategory;
+        this.mediumCategory = mediumCategory;
+        this.providingMethod = providingMethod;
+        this.policyName = policyName;
+        this.policySummary = policySummary;
+        this.targetDescription = targetDescription;
+        this.benefitDescription = benefitDescription;
+        this.providingOrgName = providingOrgName;
+        this.applyPeriodType = applyPeriodType;
+        this.applyStartDate = applyStartDate;
+        this.applyEndDate = applyEndDate;
+        this.applyUrl = applyUrl;
+        this.minAge = minAge;
+        this.maxAge = maxAge;
+        this.extra = extra;
+        this.isActive = isActive;
+        this.applicableGoalTypes = applicableGoalTypes;
+    }
+}

--- a/src/main/java/com/team/independence/policy/domain/PolicyApplyPeriodType.java
+++ b/src/main/java/com/team/independence/policy/domain/PolicyApplyPeriodType.java
@@ -1,0 +1,18 @@
+package com.team.independence.policy.domain;
+
+public enum PolicyApplyPeriodType {
+
+    ONGOING,  // 상시 (aplyPrdSeCd=0057001)
+    SPECIFIC,  // 특정기간 (aplyPrdSeCd=0057002)
+    CLOSED;  // 마감 (aplyPrdSeCd=0057003)
+
+    public static PolicyApplyPeriodType fromCode(String code) {
+        if (code == null) return ONGOING;
+        switch (code.trim()) {
+            case "0057001": return ONGOING;
+            case "0057002": return SPECIFIC;
+            case "0057003": return CLOSED;
+            default: return ONGOING;
+        }
+    }
+}

--- a/src/main/java/com/team/independence/policy/dto/PolicyDetailResponse.java
+++ b/src/main/java/com/team/independence/policy/dto/PolicyDetailResponse.java
@@ -1,0 +1,45 @@
+package com.team.independence.policy.dto;
+
+import com.team.independence.policy.domain.Policy;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PolicyDetailResponse {
+
+    private Long id;
+    private String policyName;
+    private String policySummary;
+    private String largeCategory;
+    private String mediumCategory;
+    private String providingOrgName;
+    private String applyPeriodType;
+    private LocalDate applyStartDate;
+    private LocalDate applyEndDate;
+    private Integer minAge;
+    private Integer maxAge;
+    private String applyUrl;
+    private String targetDescription;
+    private String benefitDescription;
+
+    public static PolicyDetailResponse from(Policy policy) {
+        return PolicyDetailResponse.builder()
+                .id(policy.getId())
+                .policyName(policy.getPolicyName())
+                .policySummary(policy.getPolicySummary())
+                .largeCategory(policy.getLargeCategory())
+                .mediumCategory(policy.getMediumCategory())
+                .providingOrgName(policy.getProvidingOrgName())
+                .applyPeriodType(policy.getApplyPeriodType())
+                .applyStartDate(policy.getApplyStartDate())
+                .applyEndDate(policy.getApplyEndDate())
+                .minAge(policy.getMinAge())
+                .maxAge(policy.getMaxAge())
+                .applyUrl(policy.getApplyUrl())
+                .targetDescription(policy.getTargetDescription())
+                .benefitDescription(policy.getBenefitDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/team/independence/policy/dto/PolicyListRequest.java
+++ b/src/main/java/com/team/independence/policy/dto/PolicyListRequest.java
@@ -1,0 +1,19 @@
+package com.team.independence.policy.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PolicyListRequest {
+
+    private String keyword;
+    private Integer age;
+    private String lclsfNm;
+    private int page = 1;
+    private int size = 20;
+
+    public int getOffset() {
+        return (page - 1) * size;
+    }
+}

--- a/src/main/java/com/team/independence/policy/dto/PolicySummaryResponse.java
+++ b/src/main/java/com/team/independence/policy/dto/PolicySummaryResponse.java
@@ -1,0 +1,41 @@
+package com.team.independence.policy.dto;
+
+import com.team.independence.policy.domain.Policy;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PolicySummaryResponse {
+
+    private Long id;
+    private String policyName;
+    private String policySummary;
+    private String largeCategory;
+    private String mediumCategory;
+    private String providingOrgName;
+    private String applyPeriodType;
+    private LocalDate applyStartDate;
+    private LocalDate applyEndDate;
+    private Integer minAge;
+    private Integer maxAge;
+    private String applyUrl;
+
+    public static PolicySummaryResponse from(Policy policy) {
+        return PolicySummaryResponse.builder()
+                .id(policy.getId())
+                .policyName(policy.getPolicyName())
+                .policySummary(policy.getPolicySummary())
+                .largeCategory(policy.getLargeCategory())
+                .mediumCategory(policy.getMediumCategory())
+                .providingOrgName(policy.getProvidingOrgName())
+                .applyPeriodType(policy.getApplyPeriodType())
+                .applyStartDate(policy.getApplyStartDate())
+                .applyEndDate(policy.getApplyEndDate())
+                .minAge(policy.getMinAge())
+                .maxAge(policy.getMaxAge())
+                .applyUrl(policy.getApplyUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/team/independence/policy/mapper/PolicyMapper.java
+++ b/src/main/java/com/team/independence/policy/mapper/PolicyMapper.java
@@ -1,0 +1,22 @@
+package com.team.independence.policy.mapper;
+
+import com.team.independence.policy.domain.Policy;
+import com.team.independence.policy.dto.PolicyListRequest;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface PolicyMapper {
+
+    void upsertBatch(@Param("list") List<Policy> policies);
+
+    void deactivateExcept(@Param("sourceApi") String sourceApi,
+                          @Param("ids") List<String> policyApiIds);
+
+    List<Policy> findList(@Param("req") PolicyListRequest req);
+
+    long countList(@Param("req") PolicyListRequest req);
+
+    Policy findById(@Param("id") Long id);
+}

--- a/src/main/java/com/team/independence/policy/service/PolicyService.java
+++ b/src/main/java/com/team/independence/policy/service/PolicyService.java
@@ -1,0 +1,15 @@
+package com.team.independence.policy.service;
+
+import com.team.independence.policy.dto.PolicyDetailResponse;
+import com.team.independence.policy.dto.PolicyListRequest;
+import com.team.independence.policy.dto.PolicySummaryResponse;
+import java.util.List;
+
+public interface PolicyService {
+
+    List<PolicySummaryResponse> getList(PolicyListRequest request);
+
+    long countList(PolicyListRequest request);
+
+    PolicyDetailResponse getDetail(Long id);
+}

--- a/src/main/java/com/team/independence/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/team/independence/policy/service/PolicyServiceImpl.java
@@ -1,0 +1,45 @@
+package com.team.independence.policy.service;
+
+import com.team.independence.common.exception.BusinessException;
+import com.team.independence.common.exception.ErrorCode;
+import com.team.independence.policy.domain.Policy;
+import com.team.independence.policy.dto.PolicyDetailResponse;
+import com.team.independence.policy.dto.PolicyListRequest;
+import com.team.independence.policy.dto.PolicySummaryResponse;
+import com.team.independence.policy.mapper.PolicyMapper;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PolicyServiceImpl implements PolicyService {
+
+    private final PolicyMapper policyMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<PolicySummaryResponse> getList(PolicyListRequest request) {
+        return policyMapper.findList(request).stream()
+                .map(PolicySummaryResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public long countList(PolicyListRequest request) {
+        return policyMapper.countList(request);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PolicyDetailResponse getDetail(Long id) {
+        Policy policy = policyMapper.findById(id);
+        if (policy == null) {
+            throw new BusinessException(ErrorCode.POLICY_NOT_FOUND);
+        }
+        return PolicyDetailResponse.from(policy);
+    }
+}

--- a/src/main/java/com/team/independence/policy/service/PolicySyncService.java
+++ b/src/main/java/com/team/independence/policy/service/PolicySyncService.java
@@ -1,0 +1,6 @@
+package com.team.independence.policy.service;
+
+public interface PolicySyncService {
+
+    void syncAll();
+}

--- a/src/main/java/com/team/independence/policy/service/PolicySyncServiceImpl.java
+++ b/src/main/java/com/team/independence/policy/service/PolicySyncServiceImpl.java
@@ -1,0 +1,143 @@
+package com.team.independence.policy.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team.independence.external.ontong.OntongPolicyClient;
+import com.team.independence.external.ontong.dto.OntongPolicyItem;
+import com.team.independence.external.slack.SlackNotifier;
+import com.team.independence.policy.domain.Policy;
+import com.team.independence.policy.domain.PolicyApplyPeriodType;
+import com.team.independence.policy.mapper.PolicyMapper;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PolicySyncServiceImpl implements PolicySyncService {
+
+    private static final String SOURCE_API = "YOUTH";
+    private static final String APPLICABLE_GOAL_TYPES = "HOUSING";
+    private static final int BATCH_SIZE = 100;
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final OntongPolicyClient ontongPolicyClient;
+    private final PolicyMapper policyMapper;
+    private final SlackNotifier slackNotifier;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    @Transactional
+    public void syncAll() {
+        log.info("[정책배치] 온통청년 주거 정책 동기화 시작");
+        try {
+            List<OntongPolicyItem> items = ontongPolicyClient.fetchHousingPolicies();
+
+            List<Policy> policies = items.stream()
+                    .map(this::toPolicy)
+                    .collect(Collectors.toList());
+
+            // 100건씩 배치 upsert
+            for (int i = 0; i < policies.size(); i += BATCH_SIZE) {
+                List<Policy> batch = policies.subList(i, Math.min(i + BATCH_SIZE, policies.size()));
+                policyMapper.upsertBatch(batch);
+            }
+
+            // 이번 배치에 없는 정책 비활성화
+            List<String> currentIds = items.stream()
+                    .map(OntongPolicyItem::getPlcyNo)
+                    .collect(Collectors.toList());
+            if (!currentIds.isEmpty()) {
+                policyMapper.deactivateExcept(SOURCE_API, currentIds);
+            }
+
+            log.info("[정책배치] 온통청년 주거 정책 동기화 완료: {}건 upsert", policies.size());
+
+        } catch (Exception e) {
+            log.error("[정책배치] 동기화 실패", e);
+            slackNotifier.sendBatchFailureSummary("policy-sync", e.getMessage());
+            throw new RuntimeException("[정책배치] 동기화 실패: " + e.getMessage(), e);
+        }
+    }
+
+    private Policy toPolicy(OntongPolicyItem item) {
+        String applyUrl = resolveUrl(item.getAplyUrlAddr(), item.getRefUrlAddr1());
+        LocalDate startDate = parseDateFromAplyYmd(item.getAplyYmd(), true);
+        LocalDate endDate   = parseDateFromAplyYmd(item.getAplyYmd(), false);
+        if (startDate == null) startDate = parseDate(item.getBizPrdBgngYmd());
+        if (endDate   == null) endDate   = parseDate(item.getBizPrdEndYmd());
+
+        Integer minAge = parseAge(item.getSprtTrgtAgeLmtYn(), item.getSprtTrgtMinAge());
+        Integer maxAge = parseAge(item.getSprtTrgtAgeLmtYn(), item.getSprtTrgtMaxAge());
+
+        return Policy.builder()
+                .sourceApi(SOURCE_API)
+                .policyApiId(item.getPlcyNo())
+                .largeCategory(item.getLclsfNm())
+                .mediumCategory(item.getMclsfNm())
+                .providingMethod(item.getPlcyPvsnMthdCd())
+                .policyName(item.getPlcyNm())
+                .policySummary(item.getPlcyExplnCn())
+                .targetDescription(item.getAddAplyQlfcCndCn())
+                .benefitDescription(item.getPlcySprtCn())
+                .providingOrgName(item.getSprvsnInstCdNm())
+                .applyPeriodType(PolicyApplyPeriodType.fromCode(item.getAplyPrdSeCd()).name())
+                .applyStartDate(startDate)
+                .applyEndDate(endDate)
+                .applyUrl(applyUrl)
+                .minAge(minAge)
+                .maxAge(maxAge)
+                .extra(toJson(item))
+                .isActive(true)
+                .applicableGoalTypes(APPLICABLE_GOAL_TYPES)
+                .build();
+    }
+
+    /** aplyYmd 형식: "YYYYMMDD ~ YYYYMMDD" */
+    private LocalDate parseDateFromAplyYmd(String aplyYmd, boolean isStart) {
+        if (aplyYmd == null || aplyYmd.trim().isEmpty()) return null;
+        String[] parts = aplyYmd.split("~");
+        if (parts.length < 2) return null;
+        String raw = isStart ? parts[0].trim() : parts[1].trim();
+        return parseDate(raw);
+    }
+
+    private LocalDate parseDate(String raw) {
+        if (raw == null || raw.trim().isEmpty()) return null;
+        try {
+            return LocalDate.parse(raw.trim(), DATE_FMT);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String resolveUrl(String primary, String fallback) {
+        if (primary != null && !primary.trim().isEmpty()) return primary.trim();
+        if (fallback != null && !fallback.trim().isEmpty()) return fallback.trim();
+        return null;
+    }
+
+    private Integer parseAge(String ageLmtYn, String ageValue) {
+        if (!"Y".equals(ageLmtYn)) return null;
+        if (ageValue == null || ageValue.trim().isEmpty()) return null;
+        try {
+            return Integer.parseInt(ageValue.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private String toJson(OntongPolicyItem item) {
+        try {
+            return objectMapper.writeValueAsString(item);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/team/independence/scheduler/PolicySyncScheduler.java
+++ b/src/main/java/com/team/independence/scheduler/PolicySyncScheduler.java
@@ -1,0 +1,29 @@
+package com.team.independence.scheduler;
+
+import com.team.independence.policy.service.PolicySyncService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PolicySyncScheduler implements InitializingBean {
+
+    private final PolicySyncService policySyncService;
+
+    @Override
+    public void afterPropertiesSet() {
+        log.info("[배치] 정책 동기화 스케줄러 등록됨 (batch 프로필 활성)");
+    }
+
+    /** 매일 새벽 3시 온통청년 주거 정책 동기화 */
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    public void syncPolicies() {
+        log.info("[배치] 온통청년 정책 동기화 시작");
+        policySyncService.syncAll();
+        log.info("[배치] 온통청년 정책 동기화 완료");
+    }
+}

--- a/src/main/resources/config/app.properties
+++ b/src/main/resources/config/app.properties
@@ -18,5 +18,10 @@ kakao.client.id=${KAKAO_REST_API_KEY:local-dev-client-id}
 kakao.client.secret=${KAKAO_CLIENT_SECRET:}
 kakao.redirect.uri=${KAKAO_REDIRECT_URI:http://localhost:5173/callback}
 
+# 온통청년 정책 API
+youth.api.base-url=https://www.youthcenter.go.kr/go/ythip
+youth.api.key=${POLICY_API_KEY:}
+youth.api.page-size=100
+
 # Slack (배치 실패 알림)
 slack.webhook.url=${SLACK_WEBHOOK_URL:}

--- a/src/main/resources/mybatis/mapper/policy/PolicyMapper.xml
+++ b/src/main/resources/mybatis/mapper/policy/PolicyMapper.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.team.independence.policy.mapper.PolicyMapper">
+
+    <resultMap id="policyResultMap" type="com.team.independence.policy.domain.Policy">
+        <id     property="id"                 column="id"/>
+        <result property="sourceApi"          column="source_api"/>
+        <result property="policyApiId"        column="policy_api_id"/>
+        <result property="largeCategory"      column="large_category"/>
+        <result property="mediumCategory"     column="medium_category"/>
+        <result property="providingMethod"    column="providing_method"/>
+        <result property="policyName"         column="policy_name"/>
+        <result property="policySummary"      column="policy_summary"/>
+        <result property="targetDescription"  column="target_description"/>
+        <result property="benefitDescription" column="benefit_description"/>
+        <result property="providingOrgName"   column="providing_org_name"/>
+        <result property="applyPeriodType"    column="apply_period_type"/>
+        <result property="applyStartDate"     column="apply_start_date"/>
+        <result property="applyEndDate"       column="apply_end_date"/>
+        <result property="applyUrl"           column="apply_url"/>
+        <result property="minAge"             column="min_age"/>
+        <result property="maxAge"             column="max_age"/>
+        <result property="extra"              column="extra"/>
+        <result property="isActive"           column="is_active"/>
+        <result property="applicableGoalTypes" column="applicable_goal_types"/>
+        <result property="createdAt"          column="created_at"/>
+        <result property="updatedAt"          column="updated_at"/>
+    </resultMap>
+
+    <insert id="upsertBatch" parameterType="list">
+        INSERT INTO policies (
+            source_api, policy_api_id, large_category, medium_category,
+            providing_method, policy_name, policy_summary, target_description,
+            benefit_description, providing_org_name, apply_period_type,
+            apply_start_date, apply_end_date, apply_url,
+            min_age, max_age, extra, is_active, applicable_goal_types
+        ) VALUES
+        <foreach collection="list" item="p" separator=",">
+            (
+                #{p.sourceApi}, #{p.policyApiId}, #{p.largeCategory}, #{p.mediumCategory},
+                #{p.providingMethod}, #{p.policyName}, #{p.policySummary}, #{p.targetDescription},
+                #{p.benefitDescription}, #{p.providingOrgName}, #{p.applyPeriodType},
+                #{p.applyStartDate}, #{p.applyEndDate}, #{p.applyUrl},
+                #{p.minAge}, #{p.maxAge}, #{p.extra}, TRUE, #{p.applicableGoalTypes}
+            )
+        </foreach>
+        ON DUPLICATE KEY UPDATE
+            large_category      = VALUES(large_category),
+            medium_category     = VALUES(medium_category),
+            providing_method    = VALUES(providing_method),
+            policy_name         = VALUES(policy_name),
+            policy_summary      = VALUES(policy_summary),
+            target_description  = VALUES(target_description),
+            benefit_description = VALUES(benefit_description),
+            providing_org_name  = VALUES(providing_org_name),
+            apply_period_type   = VALUES(apply_period_type),
+            apply_start_date    = VALUES(apply_start_date),
+            apply_end_date      = VALUES(apply_end_date),
+            apply_url           = VALUES(apply_url),
+            min_age             = VALUES(min_age),
+            max_age             = VALUES(max_age),
+            extra               = VALUES(extra),
+            is_active           = TRUE,
+            updated_at          = NOW()
+    </insert>
+
+    <update id="deactivateExcept">
+        UPDATE policies
+        SET is_active = FALSE
+        WHERE source_api = #{sourceApi}
+        AND policy_api_id NOT IN
+        <foreach collection="ids" item="id" open="(" separator="," close=")">
+            #{id}
+        </foreach>
+    </update>
+
+    <select id="findList" resultMap="policyResultMap">
+        SELECT *
+        FROM policies
+        WHERE is_active = TRUE
+        <if test="req.keyword != null and req.keyword != ''">
+            AND (policy_name LIKE CONCAT('%', #{req.keyword}, '%')
+              OR policy_summary LIKE CONCAT('%', #{req.keyword}, '%'))
+        </if>
+        <if test="req.lclsfNm != null and req.lclsfNm != ''">
+            AND large_category = #{req.lclsfNm}
+        </if>
+        <if test="req.age != null">
+            AND (min_age IS NULL OR min_age &lt;= #{req.age})
+            AND (max_age IS NULL OR max_age &gt;= #{req.age})
+        </if>
+        ORDER BY updated_at DESC
+        LIMIT #{req.size} OFFSET #{req.offset}
+    </select>
+
+    <select id="countList" resultType="long">
+        SELECT COUNT(*)
+        FROM policies
+        WHERE is_active = TRUE
+        <if test="req.keyword != null and req.keyword != ''">
+            AND (policy_name LIKE CONCAT('%', #{req.keyword}, '%')
+              OR policy_summary LIKE CONCAT('%', #{req.keyword}, '%'))
+        </if>
+        <if test="req.lclsfNm != null and req.lclsfNm != ''">
+            AND large_category = #{req.lclsfNm}
+        </if>
+        <if test="req.age != null">
+            AND (min_age IS NULL OR min_age &lt;= #{req.age})
+            AND (max_age IS NULL OR max_age &gt;= #{req.age})
+        </if>
+    </select>
+
+    <select id="findById" resultMap="policyResultMap">
+        SELECT *
+        FROM policies
+        WHERE id = #{id}
+    </select>
+
+</mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈

#171

## 📝작업 내용

온통청년 Open API를 통해 주거 정책을 매일 자동 수집하고, 목록/상세 조회 API를 제공합니다.

**외부 API 클라이언트** (`external/ontong`)
- 온통청년 정책 API 전 페이지 수집, 로컬/실서버 프로필 분리
- `@JsonAnySetter`로 DTO 미매핑 필드를 `extras` Map에 흡수 → `extra` 컬럼에 원본 필드 전체 보존

**policy 도메인 + DB 계층**
- `Policy` 도메인, `PolicyApplyPeriodType` enum
- `PolicyMapper` upsert / deactivate / 조회, MyBatis XML (`ON DUPLICATE KEY UPDATE`, 동적 필터 WHERE)

**배치 동기화**
- `PolicySyncServiceImpl`: 100건 단위 upsert → 미반환 정책 비활성화
- `PolicySyncScheduler`: 매일 03시 자동 실행 (batch 프로필)
- `POST /api/v1/admin/batch/policy-sync` 수동 트리거 추가

**조회 API**
- `GET /api/v1/policies`: 키워드, 나이, 대분류 필터 + 페이징, 인증 불필요 공개 API
- `GET /api/v1/policies/{id}`: 상세 조회

### 스크린샷
#### 정책 목록 반환
<img width="1238" height="789" alt="스크린샷 2026-09-07 오후 1 57 24" src="https://github.com/user-attachments/assets/a63f95cd-37fc-4883-b6c1-2c84222ce22b" />

#### 정책 상세 조회
<img width="1239" height="527" alt="스크린샷 2026-09-07 오후 2 14 10" src="https://github.com/user-attachments/assets/d10f13b3-02ad-44c0-915a-06a54c915fe4" />


## 💬리뷰 요구사항(선택)
`extra` 컬럼에 원본 API 필드 전체를 JSON으로 저장하는 방식이 AI 추천 확장 대비로 적절한지 의견 주시면 좋겠습니다.